### PR TITLE
Limit timezone testing to JDBC driver

### DIFF
--- a/.github/workflows/timezone.yml
+++ b/.github/workflows/timezone.yml
@@ -54,9 +54,16 @@ jobs:
           key: ${{ runner.os }}-build-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-build-
-      - name: Test using Maven
+      - name: Install dependencies
         run: |
           mvn --batch-mode --update-snapshots \
+            --projects clickhouse-client -DskipTests \
+            --also-make install
+      - name: Test JDBC driver
+        run: |
+          mvn --batch-mode --update-snapshots \
+            --projects clickhouse-jdbc \
             -DclickhouseTimezone=${{ matrix.serverTz }} \
             -DclickhouseVersion=21.8 \
-            -Duser.timezone=${{ matrix.clientTz }} verify
+            -Duser.timezone=${{ matrix.clientTz }} \
+            --also-make clean verify


### PR DESCRIPTION
This will cut build time in half.