### PR TITLE
fixes issue with shiftOrResize when a mark occurs before and a reset …

### DIFF
--- a/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/response/StreamSplitter.java
+++ b/clickhouse-jdbc/src/main/java/ru/yandex/clickhouse/response/StreamSplitter.java
@@ -22,7 +22,7 @@ public class StreamSplitter {
     // position until which the values from buf already passed out through next()
     private int posNext;
 
-    private int markedRead;
+    private boolean marked;
     private int markedNext;
 
     private boolean readOnce;
@@ -98,11 +98,11 @@ public class StreamSplitter {
     }
 
 
-    // if we have read till the end of buffer, we have to create a new buffer 
-    // and move data by posNext (already send data position)
-    // if there is no sent data and buffer is still full - expand the buffer
+	  // if we have read till the end of buffer, and there is no mark, we have to create a new buffer
+	  // and move data by posNext (already send data position)
+	  // if there is no sent data and buffer is still full, or there is a mark, expand the buffer
     private void shiftOrResize() {
-        if (posNext > 0) {
+        if (!marked && posNext > 0) {
             byte[] oldBuf = buf;
             buf = new byte[buf.length];
             System.arraycopy(oldBuf, posNext, buf, 0, oldBuf.length - posNext);
@@ -152,12 +152,12 @@ public class StreamSplitter {
     }
 
     public void mark() {
-        markedRead = posRead;
+	      marked = true;
         markedNext = posNext;
     }
 
     public void reset() {
-        posRead = markedRead;
+	      marked = false;
         posNext = markedNext;
     }
 }


### PR DESCRIPTION
In `ru.yandex.clickhouse.response.StreamSplitter` if `mark()` is called (eg from `ru.yandex.clickhouse.response.ClickHouseResultSet#onTheSeparatorRow`) and then `shiftOrResize()` occurs, then `reset()` leaves the stream in an invalid result.

`posNext` and `posRead` are reset but `buf` still contain the next chunk of data.

In such a case `ru.yandex.clickhouse.response.ClickHouseResultSet#getTotals` fails if the data of the total line are split across two chunks of data.

I know this class should be removed but, while waiting for a new stable version, this issue cause unavoidable error. (and, as far as I know, there is no equivalent feature in the new jdbc driver)