### PR TITLE
Fix potential endless loop when batch update failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 * incorrect nested array value. [#1221](https://github.com/ClickHouse/clickhouse-java/issues/1221)
+* potential endless loop when handling batch update error. [#1233](https://github.com/ClickHouse/clickhouse-java/issues/1233)
 
 ## 0.4.0, 2023-01-19
 ### Breaking changes

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/SqlExceptionUtils.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/SqlExceptionUtils.java
@@ -102,8 +102,6 @@ public final class SqlExceptionUtils {
                     0, updateCounts, null);
         } else if (e instanceof BatchUpdateException) {
             return (BatchUpdateException) e;
-        } else if (e instanceof ClickHouseException) {
-            return batchUpdateError(e, updateCounts);
         } else if (e instanceof SQLException) {
             SQLException sqlExp = (SQLException) e;
             return new BatchUpdateException(sqlExp.getMessage(), sqlExp.getSQLState(), sqlExp.getErrorCode(),


### PR DESCRIPTION
## Summary
Fix potential endless loop when batch update failed

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
