### PR TITLE
More intuitive client info

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java
@@ -437,10 +437,7 @@ public enum ClickHouseClientOption implements ClickHouseOption {
         }
         CLIENT_OS_INFO = new StringBuilder().append(getSystemConfig("os.name", "O/S")).append('/')
                 .append(getSystemConfig("os.version", UNKNOWN)).toString();
-        String javaVersion = System.getProperty("java.vendor.version");
-        if (javaVersion == null || javaVersion.isEmpty() || javaVersion.indexOf(' ') >= 0) {
-            javaVersion = getSystemConfig("java.vm.version", getSystemConfig("java.version", UNKNOWN));
-        }
+        String javaVersion = getSystemConfig("java.version", UNKNOWN);
         CLIENT_JVM_INFO = new StringBuilder().append(getSystemConfig("java.vm.name", "Java")).append('/')
                 .append(javaVersion).toString();
         CLIENT_USER = getSystemConfig("user.name", UNKNOWN);

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseConfigTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseConfigTest.java
@@ -78,8 +78,7 @@ public class ClickHouseConfigTest {
         Assert.assertEquals(config.getClientOsInfo(),
                 System.getProperty("os.name") + "/" + System.getProperty("os.version"));
         Assert.assertEquals(config.getClientJvmInfo(),
-                System.getProperty("java.vm.name") + "/" + System.getProperty("java.vendor.version",
-                        System.getProperty("java.vm.version", System.getProperty("java.version", "unknown"))));
+                System.getProperty("java.vm.name") + "/" + System.getProperty("java.version", "unknown"));
         Assert.assertEquals(config.getClientUser(), System.getProperty("user.name"));
         Assert.assertEquals(config.getClientHost(), InetAddress.getLocalHost().getHostName());
 

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseConfigTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseConfigTest.java
@@ -85,8 +85,7 @@ public class ClickHouseConfigTest {
         Assert.assertEquals(ClickHouseClientOption.buildUserAgent(null, null),
                 "ClickHouse-JavaClient/unknown (" + System.getProperty("os.name") + "/"
                         + System.getProperty("os.version") + "; " + System.getProperty("java.vm.name") + "/"
-                        + System.getProperty("java.vendor.version",
-                                System.getProperty("java.vm.version", System.getProperty("java.version", "unknown")))
+                        + System.getProperty("java.version", "unknown")
                         + "; rv:unknown)");
         Assert.assertEquals(ClickHouseClientOption.buildUserAgent(null, null),
                 ClickHouseClientOption.buildUserAgent("", null));


### PR DESCRIPTION
## Summary
Now when getting JVM version info we use property in this order ` java.vendor.version`, `java.vm.version`,  `java.version`.

And Oracal JDK 1.8 we get 
```
Java HotSpot(TM) 64-Bit Server VM/25.221-b11
```

Maybe `1.8` is more intuitive.

## Change log

when getting JVM version info use `java.version`.
