### PR TITLE
Repsect node-specific credentials

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * error while converting Nested values to Java maps.
 * incorrect algorithm extracted from PEM. [#1274](https://github.com/ClickHouse/clickhouse-java/issues/1274)
 * transaction failure introduced 0.4.0.
+* respect node-specific credentials. [#1114](https://github.com/ClickHouse/clickhouse-java/issues/1114)
 
 ## 0.4.1, 2023-02-19
 ### Breaking Changes


### PR DESCRIPTION
## Summary
Repsect node-specific credentials.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
