### PR TITLE
Only throw BatchUpdateException for statements for read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
 * transaction failure introduced 0.4.0.
 * respect node-specific credentials. [#1114](https://github.com/ClickHouse/clickhouse-java/issues/1114)
 * USE statement does nothing. [#1160](https://github.com/ClickHouse/clickhouse-java/issues/1160)
+* executeBatch does not support on cluster anymore. [#1261](https://github.com/ClickHouse/clickhouse-java/issues/1261)
 
 ## 0.4.1, 2023-02-19
 ### Breaking Changes

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseStatementImpl.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseStatementImpl.java
@@ -772,7 +772,7 @@ public class ClickHouseStatementImpl extends JdbcWrapper
             int i = 0;
             for (ClickHouseSqlStatement s : batchStmts) {
                 try (ClickHouseResponse r = executeStatement(s, null, null, null); ResultSet rs = updateResult(s, r)) {
-                    if (rs != null) {
+                    if (rs != null && s.isQuery()) {
                         throw SqlExceptionUtils.queryInBatchError(results);
                     }
                     results[i] = currentUpdateCount <= 0L ? 0L : currentUpdateCount;

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/SqlBasedPreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/SqlBasedPreparedStatement.java
@@ -161,7 +161,7 @@ public class SqlBasedPreparedStatement extends AbstractPreparedStatement impleme
             long rows = 0L;
             try {
                 r = executeStatement(builder.toString(), reparse);
-                if (updateResult(parsedStmt, r) != null && asBatch) {
+                if (updateResult(parsedStmt, r) != null && asBatch && parsedStmt.isQuery()) {
                     throw SqlExceptionUtils.queryInBatchError(results);
                 }
                 rows = r.getSummary().getWrittenRows();
@@ -208,7 +208,7 @@ public class SqlBasedPreparedStatement extends AbstractPreparedStatement impleme
                     preparedQuery.apply(builder, params);
                     try {
                         r = executeStatement(builder.toString(), reparse);
-                        if (updateResult(parsedStmt, r) != null && asBatch) {
+                        if (updateResult(parsedStmt, r) != null && asBatch && parsedStmt.isQuery()) {
                             throw SqlExceptionUtils.queryInBatchError(results);
                         }
                         int count = getUpdateCount();

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/TableBasedPreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/TableBasedPreparedStatement.java
@@ -101,7 +101,7 @@ public class TableBasedPreparedStatement extends AbstractPreparedStatement imple
             for (List<ClickHouseExternalTable> list : batch) {
                 try (ClickHouseResponse r = executeStatement(sql, null, list, null);
                         ResultSet rs = updateResult(parsedStmt, r)) {
-                    if (asBatch && rs != null) {
+                    if (asBatch && rs != null && parsedStmt.isQuery()) {
                         throw SqlExceptionUtils.queryInBatchError(results);
                     }
                     long rows = getLargeUpdateCount();

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
@@ -695,6 +695,24 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
     }
 
     @Test(groups = "integration")
+    public void testBatchDdl() throws SQLException {
+        Properties props = new Properties();
+        try (ClickHouseConnection conn = newConnection(props)) {
+            try (PreparedStatement stmt = conn.prepareStatement(
+                    "drop table if exists test_batch_dll_on_cluster on cluster test_shard_localhost")) {
+                stmt.addBatch();
+                stmt.addBatch();
+                Assert.assertEquals(stmt.executeBatch(), new int[] { 0, 0 });
+            }
+
+            try (PreparedStatement stmt = conn.prepareStatement("select 1")) {
+                stmt.addBatch();
+                Assert.assertThrows(BatchUpdateException.class, () -> stmt.executeBatch());
+            }
+        }
+    }
+
+    @Test(groups = "integration")
     public void testBatchInsert() throws SQLException {
         try (ClickHouseConnection conn = newConnection(new Properties());
                 ClickHouseStatement s = conn.createStatement();

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
@@ -698,6 +698,9 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
     public void testBatchDdl() throws SQLException {
         Properties props = new Properties();
         try (ClickHouseConnection conn = newConnection(props)) {
+            if (!conn.getServerVersion().check("[22.8,)")) {
+                throw new SkipException("Skip due to error 'unknown key zookeeper_load_balancing'");
+            }
             try (PreparedStatement stmt = conn.prepareStatement(
                     "drop table if exists test_batch_dll_on_cluster on cluster test_shard_localhost")) {
                 stmt.addBatch();

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseStatementTest.java
@@ -69,6 +69,22 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
     }
 
     @Test(groups = "integration")
+    public void testBatchUpdate() throws SQLException {
+        Properties props = new Properties();
+        try (ClickHouseConnection conn = newConnection(props); ClickHouseStatement stmt = conn.createStatement()) {
+            stmt.addBatch("drop table if exists test_batch_dll_on_cluster on cluster test_shard_localhost");
+            stmt.addBatch(
+                    "create table if not exists test_batch_dll_on_cluster on cluster test_shard_localhost(a Int64) Engine=MergeTree order by a;"
+                            + "drop table if exists test_batch_dll_on_cluster on cluster test_shard_localhost;");
+            Assert.assertEquals(stmt.executeBatch(), new int[] { 0, 0, 0 });
+
+            stmt.addBatch("drop table if exists test_batch_queries");
+            stmt.addBatch("select 1");
+            Assert.assertThrows(BatchUpdateException.class, () -> stmt.executeBatch());
+        }
+    }
+
+    @Test(groups = "integration")
     public void testBitmap64() throws SQLException {
         Properties props = new Properties();
         String sql = "select k,\n"

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseStatementTest.java
@@ -72,6 +72,10 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
     public void testBatchUpdate() throws SQLException {
         Properties props = new Properties();
         try (ClickHouseConnection conn = newConnection(props); ClickHouseStatement stmt = conn.createStatement()) {
+            if (!conn.getServerVersion().check("[22.8,)")) {
+                throw new SkipException("Skip due to error 'unknown key zookeeper_load_balancing'");
+            }
+
             stmt.addBatch("drop table if exists test_batch_dll_on_cluster on cluster test_shard_localhost");
             stmt.addBatch(
                     "create table if not exists test_batch_dll_on_cluster on cluster test_shard_localhost(a Int64) Engine=MergeTree order by a;"


### PR DESCRIPTION
## Summary
Only throw BatchUpdateException for statements for read.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
