### PR TITLE
switch to CongoCC

### DIFF
--- a/.github/workflows/third_party_libs.yml
+++ b/.github/workflows/third_party_libs.yml
@@ -6,7 +6,7 @@ on:
       version:
         description: "Release version"
         required: true
-        default: "1.8.0"
+        default: "1.9.0"
 
 jobs:
   release:

--- a/third-party-libraries/org.congocc/pom.xml
+++ b/third-party-libraries/org.congocc/pom.xml
@@ -7,16 +7,16 @@
         <version>${revision}</version>
     </parent>
 
-    <artifactId>com.javacc</artifactId>
+    <artifactId>org.congocc</artifactId>
     <packaging>jar</packaging>
 
     <name>${project.artifactId}</name>
-    <description>Repackaged JavaCC for generating SQL parser</description>
-    <url>https://github.com/ClickHouse/clickhouse-java/tree/main/third-party-libraries/com.javacc</url>
+    <description>Repackaged CongoCC Parser Generator for generating SQL parser</description>
+    <url>https://github.com/ClickHouse/clickhouse-java/tree/main/third-party-libraries/org.congocc</url>
 
     <properties>
-        <javacc.dir>javacc21-master</javacc.dir>
-        <javacc.src.zip>https://github.com/javacc21/javacc21/archive/refs/heads/master.zip</javacc.src.zip>
+        <congocc.dir>congo-parser-generator-main</congocc.dir>
+        <congocc.src.zip>https://github.com/congo-cc/congo-parser-generator/archive/refs/heads/main.zip</congocc.src.zip>
     </properties>
 
     <build>
@@ -26,12 +26,12 @@
                 <artifactId>maven-antrun-plugin</artifactId>
                 <executions>
                     <execution>
-                        <id>get-javacc</id>
+                        <id>get-congocc</id>
                         <phase>clean</phase>
                         <configuration>
                             <target>
-                                <get src="${javacc.src.zip}" dest="${project.build.directory}/javacc.zip" />
-                                <unzip src="${project.build.directory}/javacc.zip" dest="${project.build.directory}" />
+                                <get src="${congocc.src.zip}" dest="${project.build.directory}/congocc.zip" />
+                                <unzip src="${project.build.directory}/congocc.zip" dest="${project.build.directory}" />
                             </target>
                         </configuration>
                         <goals>
@@ -39,14 +39,14 @@
                         </goals>
                     </execution>
                     <execution>
-                        <id>build-javacc</id>
+                        <id>build-congocc</id>
                         <phase>initialize</phase>
                         <configuration>
                             <target>
-                                <ant antfile="${project.build.directory}/${javacc.dir}/build.xml" dir="${project.build.directory}/${javacc.dir}">
+                                <ant antfile="${project.build.directory}/${congocc.dir}/build.xml" dir="${project.build.directory}/${congocc.dir}">
                                     <target name="full-jar" />
                                 </ant>
-                                <unzip src="${project.build.directory}/${javacc.dir}/javacc-full.jar" dest="${project.build.directory}/classes" />
+                                <unzip src="${project.build.directory}/${congocc.dir}/congocc-full.jar" dest="${project.build.directory}/classes" />
                             </target>
                         </configuration>
                         <goals>
@@ -63,7 +63,7 @@
                         <manifestFile>${project.build.directory}/classes/META-INF/MANIFEST.MF</manifestFile>
                     </archive>
                     <excludes>
-                        <exclude>com/javacc/DummyClass.class</exclude>
+                        <exclude>org/congocc/DummyClass.class</exclude>
                     </excludes>
                 </configuration>
             </plugin>

--- a/third-party-libraries/org.congocc/src/main/java/org/congocc/DummyClass.java
+++ b/third-party-libraries/org.congocc/src/main/java/org/congocc/DummyClass.java
@@ -1,4 +1,4 @@
-package com.javacc;
+package org.congocc;
 
 /**
  * Dummy class for generating sources and javadoc jars.

--- a/third-party-libraries/pom.xml
+++ b/third-party-libraries/pom.xml
@@ -37,9 +37,9 @@
     </developers>
 
     <modules>
-        <module>com.javacc</module>
         <module>io.grpc</module>
         <module>org.apache.commons.compress</module>
+        <module>org.congocc</module>
         <module>org.roaringbitmap</module>
     </modules>
 
@@ -72,27 +72,27 @@
     </distributionManagement>
 
     <properties>
-        <revision>1.8.0</revision>
+        <revision>1.9.0</revision>
         <project.current.year>2023</project.current.year>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <annotations-api.version>6.0.53</annotations-api.version>
-        <compress.version>1.22</compress.version>
-        <grpc.version>1.53.0</grpc.version>
+        <compress.version>1.23.0</compress.version>
+        <grpc.version>1.54.0</grpc.version>
         <gson.version>2.10.1</gson.version>
         <opencensus.version>0.31.1</opencensus.version>
         <roaring-bitmap.version>0.9.39</roaring-bitmap.version>
 
         <antrun-plugin.version>3.1.0</antrun-plugin.version>
-        <compiler-plugin.version>3.10.1</compiler-plugin.version>
-        <deploy-plugin.version>3.0.0</deploy-plugin.version>
-        <flatten-plugin.version>1.2.7</flatten-plugin.version>
+        <compiler-plugin.version>3.11.0</compiler-plugin.version>
+        <deploy-plugin.version>3.1.1</deploy-plugin.version>
+        <flatten-plugin.version>1.4.1</flatten-plugin.version>
         <gpg-plugin.version>3.0.1</gpg-plugin.version>
-        <jar-plugin.version>3.2.2</jar-plugin.version>
-        <javadoc-plugin.version>3.4.0</javadoc-plugin.version>
-        <moditect-plugin.version>1.0.0.RC2</moditect-plugin.version>
-        <shade-plugin.version>3.3.0</shade-plugin.version>
+        <jar-plugin.version>3.3.0</jar-plugin.version>
+        <javadoc-plugin.version>3.5.0</javadoc-plugin.version>
+        <moditect-plugin.version>1.0.0.RC3</moditect-plugin.version>
+        <shade-plugin.version>3.4.1</shade-plugin.version>
         <source-plugin.version>3.2.1</source-plugin.version>
         <staging-plugin.version>1.6.13</staging-plugin.version>
     </properties>


### PR DESCRIPTION
## Summary
Change JavaCC21 to CongoCC.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
