### PR TITLE
Bump dependencies and rollback flatten plugin to 1.2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-## 0.4.3
+## 0.4.4, 2023-04-17
+### Bug Fixes
+* flatten plugin 1.4.1 generated non-sense dependencies.
+
+## 0.4.3, 2023-04-17
 ### Bug Fixes
 * unable to convert empty string to default value when using text-based data format.
 * r2dbc driver does not support most client options. [#1299](https://github.com/ClickHouse/clickhouse-java/issues/1299)

--- a/pom.xml
+++ b/pom.xml
@@ -96,11 +96,11 @@
         <brotli.version>0.1.2</brotli.version>
         <brotli4j.version>1.11.0</brotli4j.version>
         <byte-buddy.version>1.14.0</byte-buddy.version>
-        <caffeine.version>3.1.4</caffeine.version>
+        <caffeine.version>3.1.6</caffeine.version>
         <compress.version>1.23.0</compress.version>
         <dnsjava.version>3.5.2</dnsjava.version>
-        <fastutil.version>8.5.11</fastutil.version>
-        <grpc.version>1.53.0</grpc.version>
+        <fastutil.version>8.5.12</fastutil.version>
+        <grpc.version>1.54.0</grpc.version>
         <gson.version>2.10.1</gson.version>
         <janino.version>3.1.9</janino.version>
         <jctools.version>4.0.1</jctools.version>
@@ -109,17 +109,17 @@
         <lz4.version>1.8.0</lz4.version>
         <msgpack.version>0.9.3</msgpack.version>
         <roaring-bitmap.version>0.9.39</roaring-bitmap.version>
-        <slf4j.version>2.0.6</slf4j.version>
+        <slf4j.version>2.0.7</slf4j.version>
         <snappy.version>1.1.9.1</snappy.version>
         <xz.version>1.9</xz.version>
-        <zstd-jni.version>1.5.4-2</zstd-jni.version>
-        <testcontainers.version>1.17.6</testcontainers.version>
+        <zstd-jni.version>1.5.5-1</zstd-jni.version>
+        <testcontainers.version>1.18.0</testcontainers.version>
         <!-- stay 7.5 for JDK 8 support -->
         <testng.version>7.5</testng.version>
 
-        <mariadb-driver.version>3.1.2</mariadb-driver.version>
+        <mariadb-driver.version>3.1.3</mariadb-driver.version>
         <mysql-driver.version>8.0.32</mysql-driver.version>
-        <postgresql-driver.version>42.5.4</postgresql-driver.version>
+        <postgresql-driver.version>42.6.0</postgresql-driver.version>
 
         <repackaged.version>1.9.0</repackaged.version>
         <shade.base>${project.groupId}.client.internal</shade.base>
@@ -132,7 +132,7 @@
         <enforcer-plugin.version>3.2.1</enforcer-plugin.version>
         <exec-plugin.version>3.1.0</exec-plugin.version>
         <failsafe-plugin.version>3.0.0-M9</failsafe-plugin.version>
-        <flatten-plugin.version>1.4.1</flatten-plugin.version>
+        <flatten-plugin.version>1.2.7</flatten-plugin.version>
         <git-plugin.version>4.9.9</git-plugin.version>
         <gpg-plugin.version>3.0.1</gpg-plugin.version>
         <helper-plugin.version>3.3.0</helper-plugin.version>


### PR DESCRIPTION
## Summary
Bump dependencies and rollback flatten plugin to 1.2.7.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
