### PR TITLE
Disable SQL rewrite for DELETE statement in ClickHouse 23.3+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,15 @@
+## 0.5.0
+### New Features
+* disable SQL rewrite for DELETE statement in ClickHouse 23.3+
+
 ## 0.4.4, 2023-04-17
 ### Bug Fixes
 * flatten plugin 1.4.1 generated non-sense dependencies.
 
 ## 0.4.3, 2023-04-17
+### New Features
+* replace JavaCC21 with CongoCC
+
 ### Bug Fixes
 * unable to convert empty string to default value when using text-based data format.
 * r2dbc driver does not support most client options. [#1299](https://github.com/ClickHouse/clickhouse-java/issues/1299)

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/internal/ClickHouseConnectionImplTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/internal/ClickHouseConnectionImplTest.java
@@ -206,8 +206,8 @@ public class ClickHouseConnectionImplTest extends JdbcIntegrationTest {
         try (ClickHouseConnection conn = newConnection(props)) {
             ClickHouseSqlStatement[] stmts = conn.parse(sql, conn.getConfig(), null);
             Assert.assertEquals(stmts.length, 1);
-            Assert.assertEquals(stmts[0].getSQL(),
-                    "ALTER TABLE `table` DELETE where column=1 SETTINGS mutations_sync=1");
+            Assert.assertEquals(stmts[0].getSQL(), conn.getServerVersion().check("[23.3,)") ? sql
+                    : "ALTER TABLE `table` DELETE where column=1 SETTINGS mutations_sync=1");
             if (conn.getServerVersion().check("[22.8,)")) {
                 supportsLightWeightDelete = true;
             }
@@ -221,8 +221,8 @@ public class ClickHouseConnectionImplTest extends JdbcIntegrationTest {
         try (ClickHouseConnection conn = newConnection(props)) {
             ClickHouseSqlStatement[] stmts = conn.parse(sql, conn.getConfig(), null);
             Assert.assertEquals(stmts.length, 1);
-            Assert.assertEquals(stmts[0].getSQL(),
-                    "ALTER TABLE `table` DELETE where column=1 SETTINGS mutations_sync=1");
+            Assert.assertEquals(stmts[0].getSQL(), conn.getServerVersion().check("[23.3,)") ? sql
+                    : "ALTER TABLE `table` DELETE where column=1 SETTINGS mutations_sync=1");
 
             stmts = conn.parse(sql, conn.getConfig(), conn.unwrap(ClickHouseRequest.class).getSettings());
             Assert.assertEquals(stmts.length, 1);


### PR DESCRIPTION
## Summary
Disable SQL rewrite for DELETE statement in ClickHouse 23.3+

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
