### PR TITLE
refactor data processors and response classes to ensure input stream remain intact before first read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 ## 0.5.0
+### Breaking Changes
+* refactor data processors and response classes to ensure input stream remain intact before first read:
+  - move ClickHouseSimpleRecord to com.clickhouse.data
+  - stop reading input stream when instantiating ClickHouseDataProcessor
+  - remove createRecord() method in ClickHouseDataProcessor along with some duplicated code
+
 ### New Features
 * disable SQL rewrite for DELETE statement in ClickHouse 23.3+
 

--- a/clickhouse-cli-client/src/main/java/com/clickhouse/client/cli/ClickHouseCommandLineResponse.java
+++ b/clickhouse-cli-client/src/main/java/com/clickhouse/client/cli/ClickHouseCommandLineResponse.java
@@ -16,7 +16,7 @@ public class ClickHouseCommandLineResponse extends ClickHouseStreamResponse {
         super(config, cli.getInputStream(), null, null, ClickHouseResponseSummary.EMPTY);
         this.cli = cli;
 
-        if (this.input.available() < 1) {
+        if (processor.getInputStream().available() < 1) {
             IOException exp = cli.getError();
             if (exp != null) {
                 throw exp;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseSimpleResponse.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseSimpleResponse.java
@@ -9,8 +9,8 @@ import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseInputStream;
 import com.clickhouse.data.ClickHouseRecord;
 import com.clickhouse.data.ClickHouseRecordTransformer;
+import com.clickhouse.data.ClickHouseSimpleRecord;
 import com.clickhouse.data.ClickHouseValue;
-import com.clickhouse.data.format.ClickHouseSimpleRecord;
 
 /**
  * A simple response built on top of two lists: columns and records.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseSimpleRecord.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseSimpleRecord.java
@@ -1,12 +1,7 @@
-package com.clickhouse.data.format;
+package com.clickhouse.data;
 
 import java.util.Collections;
 import java.util.List;
-
-import com.clickhouse.data.ClickHouseColumn;
-import com.clickhouse.data.ClickHouseRecord;
-import com.clickhouse.data.ClickHouseUtils;
-import com.clickhouse.data.ClickHouseValue;
 
 /**
  * Default implementation of {@link com.clickhouse.data.ClickHouseRecord},

--- a/clickhouse-data/src/main/java/com/clickhouse/data/format/ClickHouseRowBinaryProcessor.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/format/ClickHouseRowBinaryProcessor.java
@@ -11,7 +11,6 @@ import java.util.Map.Entry;
 
 import com.clickhouse.config.ClickHouseRenameMethod;
 import com.clickhouse.data.ClickHouseAggregateFunction;
-import com.clickhouse.data.ClickHouseArraySequence;
 import com.clickhouse.data.ClickHouseChecker;
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseDataConfig;
@@ -247,35 +246,16 @@ public class ClickHouseRowBinaryProcessor extends ClickHouseDataProcessor {
     }
 
     @Override
-    protected ClickHouseRecord createRecord() {
-        return new ClickHouseSimpleRecord(getColumns(), templates);
-    }
-
-    @Override
     protected void readAndFill(ClickHouseRecord r) throws IOException {
         ClickHouseInputStream in = input;
-        ClickHouseDeserializer[] tbl = deserializers;
+        ClickHouseDeserializer[] tbl = serde.deserializers;
 
-        for (int i = readPosition, len = columns.length; i < len; i++) {
+        for (int i = readPosition, len = serde.columns.length; i < len; i++) {
             tbl[i].deserialize(r.getValue(i), in);
             readPosition = i;
         }
 
         readPosition = 0;
-    }
-
-    @Override
-    protected void readAndFill(ClickHouseValue value) throws IOException {
-        int pos = readPosition;
-        ClickHouseValue v = deserializers[pos].deserialize(value, input);
-        if (v != value) {
-            templates[pos] = v;
-        }
-        if (++pos >= columns.length) {
-            readPosition = 0;
-        } else {
-            readPosition = pos;
-        }
     }
 
     @Override

--- a/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseSimpleRecordTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseSimpleRecordTest.java
@@ -1,10 +1,8 @@
-package com.clickhouse.data.format;
+package com.clickhouse.data;
 
 import java.util.Arrays;
 import java.util.Collections;
 
-import com.clickhouse.data.ClickHouseColumn;
-import com.clickhouse.data.ClickHouseValue;
 import com.clickhouse.data.value.ClickHouseLongValue;
 import com.clickhouse.data.value.ClickHouseStringValue;
 


### PR DESCRIPTION
## Summary
refactor data processors and response classes to ensure input stream remain intact before first read

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
