### PR TITLE
bump dependencies and upgrade to 23.3 for regression

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -27,6 +27,9 @@ on:
         description: "Pull request#"
         required: false
 
+env:
+  PREFERRED_LTS_VERSION: "23.3"
+
 jobs:
   static:
     runs-on: ubuntu-latest
@@ -47,7 +50,7 @@ jobs:
           git fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 \
             origin pull/${{ github.event.inputs.pr }}/head:the-pr && git checkout the-pr
         if: github.event.inputs.pr != ''
-      - name: Install JDK 8 and Maven
+      - name: Install JDK and Maven
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"
@@ -87,12 +90,13 @@ jobs:
       - name: Build and install
         run: |
           find . -type f -name "simplelogger.*" -exec rm -fv '{}' \;
-          mvn -q --batch-mode --projects '!clickhouse-benchmark' -DclickhouseVersion=22.8 -DskipTests install
+          mvn -q --batch-mode --projects '!clickhouse-benchmark' -DclickhouseVersion=$PREFERRED_LTS_VERSION \
+            -DskipTests install
       - name: Analyze
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          mvn --batch-mode --projects '!clickhouse-benchmark' -DclickhouseVersion=22.8 \
+          mvn --batch-mode --projects '!clickhouse-benchmark' -DclickhouseVersion=$PREFERRED_LTS_VERSION \
             -Panalysis verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
         continue-on-error: true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.number || github.sha }}
   cancel-in-progress: true
 
+env:
+  PREFERRED_LTS_VERSION: "23.3"
+
 jobs:
   compile:
     runs-on: ubuntu-latest
@@ -134,7 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile
     timeout-minutes: 10
-    name: CLI client + CH 22.8
+    name: CLI client + CH ${{ env.PREFERRED_LTS_VERSION }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v3
@@ -159,7 +162,7 @@ jobs:
             && clickhouse client --version
       - name: Test CLI client
         run: |
-          mvn --also-make --batch-mode --projects clickhouse-cli-client -DclickhouseVersion=22.8 -Dj8 -DskipUTs verify
+          mvn --also-make --batch-mode --projects clickhouse-cli-client -DclickhouseVersion=$PREFERRED_LTS_VERSION -Dj8 -DskipUTs verify
       - name: Upload test results
         uses: actions/upload-artifact@v2
         if: failure()
@@ -388,7 +391,7 @@ jobs:
         run: mvn --also-make --batch-mode --projects clickhouse-cli-client,clickhouse-grpc-client,clickhouse-http-client -Dj8 -DskipTests install
       - name: Test JDBC and R2DBC drivers
         run: |
-          mvn --batch-mode --projects clickhouse-jdbc,clickhouse-r2dbc -DclickhouseVersion=22.8 \
+          mvn --batch-mode --projects clickhouse-jdbc,clickhouse-r2dbc -DclickhouseVersion=$PREFERRED_LTS_VERSION \
             -DclickhouseTimezone=${{ matrix.serverTz }} -Duser.timezone=${{ matrix.clientTz }} \
             -Dj8 -DskipUTs verify
       - name: Upload test results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,7 +137,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: compile
     timeout-minutes: 10
-    name: CLI client + CH ${{ env.PREFERRED_LTS_VERSION }}
+    name: CLI client + CH LTS
     steps:
       - name: Check out repository
         uses: actions/checkout@v3

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -30,7 +30,7 @@ jobs:
           git fetch --no-tags --prune --progress --no-recurse-submodules --depth=1 \
             origin pull/${{ github.event.inputs.pr }}/merge:merged-pr && git checkout merged-pr
         if: github.event.inputs.pr != ''
-      - name: Install JDK 8 and Maven
+      - name: Install JDK and Maven
         uses: actions/setup-java@v3
         with:
           distribution: "temurin"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Check out Git repository
         uses: actions/checkout@v3
-      - name: Install JDK 8 and Maven
+      - name: Install JDK and Maven
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ To create a native binary of JDBC driver for evaluation and testing:
 
 ## Testing
 
-By default, [docker](https://docs.docker.com/engine/install/) is required to run integration test. Docker image(defaults to `clickhouse/clickhouse-server`) will be pulled from Internet, and containers will be created automatically by [testcontainers](https://www.testcontainers.org/) before testing. To test against specific version of ClickHouse, you can pass parameter like `-DclickhouseVersion=22.8` to Maven.
+By default, [docker](https://docs.docker.com/engine/install/) is required to run integration test. Docker image(defaults to `clickhouse/clickhouse-server`) will be pulled from Internet, and containers will be created automatically by [testcontainers](https://www.testcontainers.org/) before testing. To test against specific version of ClickHouse, you can pass parameter like `-DclickhouseVersion=23.3` to Maven.
 
 In the case you don't want to use docker and/or prefer to test against an existing server, please follow instructions below:
 

--- a/pom.xml
+++ b/pom.xml
@@ -92,27 +92,26 @@
         <annotations-api.version>6.0.53</annotations-api.version>
         <apache.httpclient.version>5.2.1</apache.httpclient.version>
         <arrow.version>11.0.0</arrow.version>
+        <asm.version>9.5</asm.version>
         <avro.version>1.11.1</avro.version>
         <brotli.version>0.1.2</brotli.version>
         <brotli4j.version>1.11.0</brotli4j.version>
-        <byte-buddy.version>1.14.0</byte-buddy.version>
         <caffeine.version>3.1.6</caffeine.version>
         <compress.version>1.23.0</compress.version>
         <dnsjava.version>3.5.2</dnsjava.version>
         <fastutil.version>8.5.12</fastutil.version>
-        <grpc.version>1.54.0</grpc.version>
+        <grpc.version>1.54.1</grpc.version>
         <gson.version>2.10.1</gson.version>
-        <janino.version>3.1.9</janino.version>
         <jctools.version>4.0.1</jctools.version>
         <opencensus.version>0.31.1</opencensus.version>
-        <protobuf.version>3.22.0</protobuf.version>
+        <protobuf.version>3.22.3</protobuf.version>
         <lz4.version>1.8.0</lz4.version>
         <msgpack.version>0.9.3</msgpack.version>
-        <roaring-bitmap.version>0.9.39</roaring-bitmap.version>
+        <roaring-bitmap.version>0.9.40</roaring-bitmap.version>
         <slf4j.version>2.0.7</slf4j.version>
         <snappy.version>1.1.9.1</snappy.version>
         <xz.version>1.9</xz.version>
-        <zstd-jni.version>1.5.5-1</zstd-jni.version>
+        <zstd-jni.version>1.5.5-2</zstd-jni.version>
         <testcontainers.version>1.18.0</testcontainers.version>
         <!-- stay 7.5 for JDK 8 support -->
         <testng.version>7.5</testng.version>
@@ -121,7 +120,7 @@
         <mysql-driver.version>8.0.33</mysql-driver.version>
         <postgresql-driver.version>42.6.0</postgresql-driver.version>
 
-        <repackaged.version>1.9.0</repackaged.version>
+        <repackaged.version>1.9.1</repackaged.version>
         <shade.base>${project.groupId}.client.internal</shade.base>
 
         <antrun-plugin.version>3.1.0</antrun-plugin.version>
@@ -319,11 +318,6 @@
                 <version>${brotli.version}</version>
             </dependency>
             <dependency>
-                <groupId>org.codehaus.janino</groupId>
-                <artifactId>janino</artifactId>
-                <version>${janino.version}</version>
-            </dependency>
-            <dependency>
                 <groupId>org.jctools</groupId>
                 <artifactId>jctools-core</artifactId>
                 <version>${jctools.version}</version>
@@ -342,6 +336,11 @@
                 <groupId>org.msgpack</groupId>
                 <artifactId>msgpack-core</artifactId>
                 <version>${msgpack.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.ow2.asm</groupId>
+                <artifactId>asm</artifactId>
+                <version>${asm.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.roaringbitmap</groupId>


### PR DESCRIPTION
## Summary
Bump dependencies and upgrade to 23.3 for regression.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
