### PR TITLE
fix too much socket fds for apache http connection

### DIFF
--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
@@ -25,13 +25,13 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.BasicHttpClientConnectionManager;
-import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.socket.ConnectionSocketFactory;
 import org.apache.hc.client5.http.socket.PlainConnectionSocketFactory;
 import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
 import org.apache.hc.client5.http.ssl.SSLConnectionSocketFactory;
 import org.apache.hc.core5.http.Header;
 import org.apache.hc.core5.http.HttpRequest;
+import org.apache.hc.core5.http.HttpResponse;
 import org.apache.hc.core5.http.config.Registry;
 import org.apache.hc.core5.http.config.RegistryBuilder;
 import org.apache.hc.core5.http.io.SocketConfig;
@@ -84,6 +84,10 @@ public class ApacheHttpConnectionImpl extends ClickHouseHttpConnection {
             r.register("https", SSLSocketFactory.create(c));
         }
         return HttpClientBuilder.create().setConnectionManager(new HttpConnectionManager(r.build(), c))
+                // disable keep alive for it may cause too many socket fd.
+                .setKeepAliveStrategy((HttpResponse response, HttpContext context) -> null)
+                .setConnectionReuseStrategy((HttpRequest request, HttpResponse response, HttpContext context)
+                        -> Boolean.parseBoolean(null))
                 .disableContentCompression().build();
     }
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
I found apache http connection created to many socket fds(ESTABLISHED and TIMED_WAIT) and it will cause connection timeout error. The following is some tests.

1.apache http connection(before)
```
netstat -na | grep 8123 | grep ESTABLISHED | wc -l && netstat -na | grep 8123 | wc -l
     626
   26523
netstat -na | grep 8123 | grep ESTABLISHED | wc -l && netstat -na | grep 8123 | wc -l

     671
   12215
```

2.apache http connection(after)
```
netstat -na | grep 8123 | grep ESTABLISHED | wc -l && netstat -na | grep 8123 | wc -l
      16
      19
netstat -na | grep 8123 | grep ESTABLISHED | wc -l && netstat -na | grep 8123 | wc -l
      22
```

3.http url connection
```
netstat -na | grep 8123 | grep ESTABLISHED | wc -l && netstat -na | grep 8123 | wc -l
      24
     146
netstat -na | grep 8123 | grep ESTABLISHED | wc -l && netstat -na | grep 8123 | wc -l
      24
     157
```

PS: the performance testing results have shown a slight decrease
```
Benchmark                                   (client)  (connection)  (statement)   (type)   Mode  Cnt     Score     Error  Units
Query.selectInt8  clickhouse-apache-http-client-jdbc         reuse       normal  default  thrpt   20  1861.249 ± 219.318  ops/s
Query.selectInt8  clickhouse-apache-http-client-jdbc         reuse     prepared  default  thrpt   20  1868.108 ± 199.007  ops/s
```
## Change log
1. disable keep alive
