### PR TITLE
make apache http client reusable

### DIFF
--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
@@ -204,7 +204,7 @@ public class ApacheHttpConnectionImpl extends ClickHouseHttpConnection {
 
     @Override
     protected boolean isReusable() {
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
@zhicwu Sorry, there is something wrong with my local commits in #1336 and lose `reusable` change. The benchmark in #1336 runs with `reusable` = true.

This Pr simple make apache http client reusable.
