### PR TITLE
change default databaseTerm to catalog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 ## 0.5.0
+### Breaking Changes
+* ClickHouseByteBuffer can no longer be extended
+* rename ClickHouseByteUtils methods by removing LE suffix
+* change default databaseTerm from schema to catalog
+
+### New Features
+* use VarHandle in JDK 9+ to read/write numbers
+
 ### Bug Fixes
 * Java client threw confusing error when query is invalid.
 

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/JdbcConfig.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/JdbcConfig.java
@@ -48,7 +48,7 @@ public class JdbcConfig {
     private static final String DEFAULT_AUTO_COMMIT = BOOLEAN_TRUE;
     private static final String DEFAULT_CREATE_DATABASE = BOOLEAN_FALSE;
     private static final String DEFAULT_CONTINUE_BATCH = BOOLEAN_FALSE;
-    private static final String DEFAULT_DATABASE_TERM = TERM_SCHEMA;
+    private static final String DEFAULT_DATABASE_TERM = TERM_CATALOG;
     private static final String DEFAULT_DIALECT = "";
     private static final String DEFAULT_EXTERNAL_DATABASE = BOOLEAN_TRUE;
     private static final String DEFAULT_FETCH_SIZE = "0";

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseConnectionTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseConnectionTest.java
@@ -156,6 +156,7 @@ public class ClickHouseConnectionTest extends JdbcIntegrationTest {
     public void testNonExistDatabase() throws SQLException {
         String database = UUID.randomUUID().toString();
         Properties props = new Properties();
+        props.setProperty(JdbcConfig.PROP_DATABASE_TERM, JdbcConfig.TERM_SCHEMA);
         props.setProperty(ClickHouseClientOption.DATABASE.getKey(), database);
         SQLException exp = null;
         try (ClickHouseConnection conn = newConnection(props)) {


### PR DESCRIPTION
## Summary
Change default databaseTerm to catalog.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
