### PR TITLE
Remove unsupported setting

### DIFF
--- a/clickhouse-client/src/test/resources/containers/clickhouse-server/config.d/ports.xml
+++ b/clickhouse-client/src/test/resources/containers/clickhouse-server/config.d/ports.xml
@@ -82,7 +82,6 @@
     </macros>
 
     <zookeeper>
-        <zookeeper_load_balancing>random</zookeeper_load_balancing>
         <node>
             <host>localhost</host>
             <port>9181</port>


### PR DESCRIPTION
## Summary
Remove unsupported setting.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
