### PR TITLE
Fix build failure of congocc

### DIFF
--- a/third-party-libraries/org.congocc/pom.xml
+++ b/third-party-libraries/org.congocc/pom.xml
@@ -44,9 +44,9 @@
                         <configuration>
                             <target>
                                 <ant antfile="${project.build.directory}/${congocc.dir}/build.xml" dir="${project.build.directory}/${congocc.dir}">
-                                    <target name="full-jar" />
+                                    <target name="jar" />
                                 </ant>
-                                <unzip src="${project.build.directory}/${congocc.dir}/congocc-full.jar" dest="${project.build.directory}/classes" />
+                                <unzip src="${project.build.directory}/${congocc.dir}/congocc.jar" dest="${project.build.directory}/classes" />
                             </target>
                         </configuration>
                         <goals>


### PR DESCRIPTION
## Summary
Fix build failure of congocc caused by congo-cc/congo-parser-generator#37.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
