### PR TITLE
Add dynamic query

### DIFF
--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/parser/ClickHouseSqlStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/parser/ClickHouseSqlStatement.java
@@ -41,19 +41,20 @@ public class ClickHouseSqlStatement {
     private final Map<String, Integer> positions;
     private final Map<String, String> settings;
     private final Set<String> tempTables;
+    private final Map<String, String> expressions;
 
     public ClickHouseSqlStatement(String sql) {
-        this(sql, StatementType.UNKNOWN, null, null, null, null, null, null, null, null, null, null, null, null);
+        this(sql, StatementType.UNKNOWN, null, null, null, null, null, null, null, null, null, null, null, null, null);
     }
 
     public ClickHouseSqlStatement(String sql, StatementType stmtType) {
-        this(sql, stmtType, null, null, null, null, null, null, null, null, null, null, null, null);
+        this(sql, stmtType, null, null, null, null, null, null, null, null, null, null, null, null, null);
     }
 
     public ClickHouseSqlStatement(String sql, StatementType stmtType, String cluster, String database, String table,
             String input, String compressAlgorithm, String compressLevel, String format, String file,
             List<Integer> parameters, Map<String, Integer> positions, Map<String, String> settings,
-            Set<String> tempTables) {
+            Set<String> tempTables, Map<String, String> expressions) {
         this.sql = sql;
         this.stmtType = stmtType;
 
@@ -108,6 +109,14 @@ public class ClickHouseSqlStatement {
             this.tempTables = Collections.unmodifiableSet(s);
         } else {
             this.tempTables = Collections.emptySet();
+        }
+
+        if (expressions != null && !expressions.isEmpty()) {
+            Map<String, String> m = new LinkedHashMap<>();
+            m.putAll(expressions);
+            this.expressions = Collections.unmodifiableMap(m);
+        } else {
+            this.expressions = Collections.emptyMap();
         }
     }
 
@@ -270,6 +279,10 @@ public class ClickHouseSqlStatement {
         return !this.tempTables.isEmpty();
     }
 
+    public boolean hasDynamicExpression() {
+        return !this.expressions.isEmpty();
+    }
+
     public List<Integer> getParameters() {
         return this.parameters;
     }
@@ -305,6 +318,10 @@ public class ClickHouseSqlStatement {
         return this.tempTables;
     }
 
+    public Map<String, String> getDynamicExpressions() {
+        return this.expressions;
+    }
+
     @Override
     public String toString() {
         StringBuilder sb = new StringBuilder();
@@ -314,8 +331,8 @@ public class ClickHouseSqlStatement {
                 .append(", compressAlgorithm=").append(compressAlgorithm).append(", compressLevel=")
                 .append(compressLevel).append(", format=").append(format).append(", outfile=").append(file)
                 .append(", parameters=").append(parameters).append(", positions=").append(positions)
-                .append(", settings=").append(settings).append(", tempTables=").append(settings).append("\nSQL:\n")
-                .append(sql);
+                .append(", settings=").append(settings).append(", tempTables=").append(settings)
+                .append(", expressions=").append(expressions).append("\nSQL:\n").append(sql);
 
         return sb.toString();
     }
@@ -339,6 +356,7 @@ public class ClickHouseSqlStatement {
         result = prime * result + positions.hashCode();
         result = prime * result + settings.hashCode();
         result = prime * result + tempTables.hashCode();
+        result = prime * result + expressions.hashCode();
         return result;
     }
 
@@ -359,6 +377,6 @@ public class ClickHouseSqlStatement {
                 && Objects.equals(compressLevel, other.compressLevel) && Objects.equals(format, other.format)
                 && Objects.equals(file, other.file) && parameters.equals(other.parameters)
                 && positions.equals(other.positions) && settings.equals(other.settings)
-                && tempTables.equals(other.tempTables);
+                && tempTables.equals(other.tempTables) && expressions.equals(other.expressions);
     }
 }

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/parser/ParseHandler.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/parser/ParseHandler.java
@@ -46,12 +46,13 @@ public abstract class ParseHandler {
      * @param positions         keyword positions
      * @param settings          settings
      * @param tempTables        temporary tables
+     * @param expressions       dynamic expressions
      * @return sql statement, or null means no change
      */
     public ClickHouseSqlStatement handleStatement(String sql, StatementType stmtType, String cluster, String database,
             String table, String input, String compressAlgorithm, String compressLevel, String format, String file,
             List<Integer> parameters, Map<String, Integer> positions, Map<String, String> settings,
-            Set<String> tempTables) {
+            Set<String> tempTables, Map<String, String> expressions) {
         return null;
     }
 }

--- a/clickhouse-jdbc/src/main/javacc/ClickHouseSqlParser.jj
+++ b/clickhouse-jdbc/src/main/javacc/ClickHouseSqlParser.jj
@@ -150,6 +150,7 @@ TOKEN_MGR_DECLS: {
     final Map<String, Integer> positions = new HashMap<>();
     final Map<String, String> settings = new LinkedHashMap<>();
     final Set<String> tempTables = new LinkedHashSet<>();
+    final Map<String, String> expressions = new LinkedHashMap<>();
 
     public void CommonTokenAction(Token t) {
         if (t.kind != ClickHouseSqlParserConstants.SEMICOLON) {
@@ -229,6 +230,7 @@ TOKEN_MGR_DECLS: {
         positions.clear();
         settings.clear();
         tempTables.clear();
+        expressions.clear();
     }
 
     ClickHouseSqlStatement build(ParseHandler handler) {
@@ -236,12 +238,12 @@ TOKEN_MGR_DECLS: {
         ClickHouseSqlStatement s = null;
         if (handler != null) {
             s = handler.handleStatement(
-                sqlStmt, stmtType, cluster, database, table, input, compressAlgorithm, compressLevel, format, file, parameters, positions, settings, tempTables);
+                sqlStmt, stmtType, cluster, database, table, input, compressAlgorithm, compressLevel, format, file, parameters, positions, settings, tempTables, expressions);
         }
 
         if (s == null) {
             s = new ClickHouseSqlStatement(
-                sqlStmt, stmtType, cluster, database, table, input, compressAlgorithm, compressLevel, format, file, parameters, positions, settings, tempTables);
+                sqlStmt, stmtType, cluster, database, table, input, compressAlgorithm, compressLevel, format, file, parameters, positions, settings, tempTables, expressions);
         }
         
         // reset variables
@@ -290,10 +292,17 @@ SKIP: {
         | "\u2000" | "\u200a" | "\u200b" | "\u200c" | "\u200d" 
         | "\u2028" | "\u2029" | "\u202f" | "\u205f" | "\u2060" | "\u3000" | "\ufeff">
     { append(image); }
-    | <JDBC_LITERAL: ("{d" | "{t" | "{ts" | "{tt") (~["}"])* "}"> {
+    | <JDBC_LITERAL: ("{d" | "{e" | "{t" | "{ts" | "{tt") (~["}"])* "}"> {
         int startIndex = image.indexOf("\'");
         int endIndex = image.lastIndexOf("\'");
-        if (startIndex < 0 || endIndex < 0 || endIndex <= startIndex) {
+        if (image.charAt(1) == 'e' && Character.isWhitespace(image.charAt(2))) { // dynamic expression
+            String expression = image.substring(3, image.lastIndexOf("}")).trim();
+            if (!expression.isEmpty()) {
+                String placeholder = java.util.UUID.randomUUID().toString();
+                builder.append(placeholder);
+                expressions.put(placeholder, expression);
+            }
+        } else if (startIndex < 0 || endIndex < 0 || endIndex <= startIndex) {
             // skip invalid content
         } else if (image.charAt(1) == 'd') { // date
             builder.append("date")

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/JdbcParseHandlerTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/JdbcParseHandlerTest.java
@@ -115,9 +115,9 @@ public class JdbcParseHandlerTest {
                         put("DELETE", 0);
                         put("FROM", 8);
                     }
-                }, null, null),
+                }, null, null, null),
                 new ClickHouseSqlStatement("TRUNCATE TABLE  `a\\`' a` . tbl", StatementType.DELETE,
-                        null, "a\\`' a", "tbl", null, null, null, null, null, null, null, null, null));
+                        null, "a\\`' a", "tbl", null, null, null, null, null, null, null, null, null, null));
         Assert.assertEquals(JdbcParseHandler.INSTANCE.handleStatement("delete from  `table\\`'1`",
                 StatementType.DELETE,
                 null, null, "table1", null, null, null, null, null, null, new HashMap<String, Integer>() {
@@ -125,9 +125,9 @@ public class JdbcParseHandlerTest {
                         put("DELETE", 0);
                         put("FROM", 7);
                     }
-                }, null, null),
+                }, null, null, null),
                 new ClickHouseSqlStatement("TRUNCATE TABLE  `table\\`'1`", StatementType.DELETE, null,
-                        null, "table1", null, null, null, null, null, null, null, null, null),
+                        null, "table1", null, null, null, null, null, null, null, null, null, null),
                 null);
     }
 
@@ -140,22 +140,22 @@ public class JdbcParseHandlerTest {
         Assert.assertEquals(
                 JdbcParseHandler.INSTANCE.handleStatement("delete from  `a\\`' a` . tbl where a = b",
                         StatementType.DELETE, null, "a\\`' a", "tbl", null, null, null, null, null, null, positions,
-                        null, null),
+                        null, null, null),
                 new ClickHouseSqlStatement(
                         "ALTER TABLE `a\\`' a`.`tbl` DELETE where a = b SETTINGS mutations_sync=1",
                         StatementType.DELETE, null, "a\\`' a", "tbl", null, null, null, null, null, null, null, null,
-                        null));
+                        null, null));
         positions.put("DELETE", 0);
         positions.put("FROM", 8);
         positions.put("WHERE", 26);
         Assert.assertEquals(
                 JdbcParseHandler.INSTANCE.handleStatement("delete  from  `table\\`'1` where 1",
                         StatementType.DELETE, null, null, "table\\`'1", null, null, null, null, null, null, positions,
-                        null, null),
+                        null, null, null),
                 new ClickHouseSqlStatement(
                         "ALTER TABLE `table\\`'1` DELETE where 1 SETTINGS mutations_sync=1",
                         StatementType.DELETE, null, null, "table\\`'1", null, null, null, null, null,
-                        null, null, null, null));
+                        null, null, null, null, null));
     }
 
     @Test(groups = "unit")
@@ -171,9 +171,9 @@ public class JdbcParseHandlerTest {
         Map<String, String> settings = Collections.singletonMap("a", "1");
         Assert.assertEquals(
                 JdbcParseHandler.INSTANCE.handleStatement(sql1, StatementType.DELETE, null, null, "tbl",
-                        null, null, null, null, null, null, positions, settings, null),
+                        null, null, null, null, null, null, positions, settings, null, null),
                 new ClickHouseSqlStatement("TRUNCATE TABLE tbl settings a=1", StatementType.DELETE,
-                        null, null, "tbl", null, null, null, null, null, null, null, settings, null));
+                        null, null, "tbl", null, null, null, null, null, null, null, settings, null, null));
 
         String sql2 = "delete from tbl where a != 1 and b != 2 settings a=1,b='a'";
         positions = new HashMap<String, Integer>() {
@@ -192,11 +192,11 @@ public class JdbcParseHandlerTest {
         };
         Assert.assertEquals(
                 JdbcParseHandler.INSTANCE.handleStatement(sql2, StatementType.DELETE, null, null, "tbl",
-                        null, null, null, null, null, null, positions, settings, null),
+                        null, null, null, null, null, null, positions, settings, null, null),
                 new ClickHouseSqlStatement(
                         "ALTER TABLE `tbl` DELETE where a != 1 and b != 2 SETTINGS mutations_sync=1, a=1,b='a'",
                         StatementType.DELETE, null, null, "tbl", null, null, null, null, null, null, null,
-                        settings, null));
+                        settings, null, null));
 
         String sql3 = "delete from tbl where a != 1 and b != 2 settings a=1,mutations_sync=2,b='a'";
         positions = new HashMap<String, Integer>() {
@@ -216,11 +216,11 @@ public class JdbcParseHandlerTest {
         };
         Assert.assertEquals(
                 JdbcParseHandler.INSTANCE.handleStatement(sql3, StatementType.DELETE, null, null, "tbl",
-                        null, null, null, null, null, null, positions, settings, null),
+                        null, null, null, null, null, null, positions, settings, null, null),
                 new ClickHouseSqlStatement(
                         "ALTER TABLE `tbl` DELETE where a != 1 and b != 2 settings a=1,mutations_sync=2,b='a'",
                         StatementType.DELETE, null, null, "tbl", null, null, null, null, null, null, null, settings,
-                        null));
+                        null, null));
     }
 
     @Test(groups = "unit")
@@ -232,11 +232,11 @@ public class JdbcParseHandlerTest {
                         put("UPDATE", 0);
                         put("SET", 23);
                     }
-                }, null, null),
+                }, null, null, null),
                 new ClickHouseSqlStatement(
                         "ALTER TABLE `a\\`' a`.`tbl` UPDATE a=1 SETTINGS mutations_sync=1",
                         StatementType.UPDATE, null, "a\\`' a", "tbl", null, null, null, null, null, null, null, null,
-                        null));
+                        null, null));
         Assert.assertEquals(JdbcParseHandler.INSTANCE.handleStatement("update  `table\\`'1` set a=1",
                 StatementType.UPDATE, null, null, "table1", null, null, null, null, null, null,
                 new HashMap<String, Integer>() {
@@ -244,10 +244,10 @@ public class JdbcParseHandlerTest {
                         put("UPDATE", 0);
                         put("SET", 20);
                     }
-                }, null, null),
+                }, null, null, null),
                 new ClickHouseSqlStatement("ALTER TABLE `table1` UPDATE a=1 SETTINGS mutations_sync=1",
                         StatementType.UPDATE, null, null, "table1", null, null, null, null, null, null, null, null,
-                        null));
+                        null, null));
     }
 
     @Test(groups = "unit")
@@ -259,21 +259,21 @@ public class JdbcParseHandlerTest {
                 JdbcParseHandler.INSTANCE.handleStatement(
                         "Update  `a\\`' a` . tbl set a = 2 where a = b",
                         StatementType.UPDATE, null, "a\\`' a", "tbl", null, null, null, null, null, null, positions,
-                        null, null),
+                        null, null, null),
                 new ClickHouseSqlStatement(
                         "ALTER TABLE `a\\`' a`.`tbl` UPDATE a = 2 where a = b SETTINGS mutations_sync=1",
                         StatementType.UPDATE, null, "a\\`' a", "tbl", null, null, null, null, null, null, null, null,
-                        null));
+                        null, null));
         positions.put("UPDATE", 0);
         positions.put("SET", 19);
         Assert.assertEquals(
                 JdbcParseHandler.INSTANCE.handleStatement("update `table\\`'1` set a = b where 1",
                         StatementType.UPDATE, null, null, "table\\`'1", null, null, null, null, null, null, positions,
-                        null, null),
+                        null, null, null),
                 new ClickHouseSqlStatement(
                         "ALTER TABLE `table\\`'1` UPDATE a = b where 1 SETTINGS mutations_sync=1",
                         StatementType.UPDATE, null, null, "table\\`'1", null, null, null, null, null, null, null, null,
-                        null));
+                        null, null));
     }
 
     @Test(groups = "unit")
@@ -289,11 +289,11 @@ public class JdbcParseHandlerTest {
         Map<String, String> settings = Collections.singletonMap("a", "1");
         Assert.assertEquals(
                 JdbcParseHandler.INSTANCE.handleStatement(sql1, StatementType.UPDATE, null, null, "tbl",
-                        null, null, null, null, null, null, positions, settings, null),
+                        null, null, null, null, null, null, positions, settings, null, null),
                 new ClickHouseSqlStatement(
                         "ALTER TABLE `tbl` UPDATE x=1 SETTINGS mutations_sync=1, a=1",
                         StatementType.UPDATE, null, null, "tbl", null, null, null, null, null, null, null, settings,
-                        null));
+                        null, null));
 
         String sql2 = "update tbl set x=1, y=2 where a != 1 and b != 2 settings a=1,b='a'";
         positions = new HashMap<String, Integer>() {
@@ -312,11 +312,11 @@ public class JdbcParseHandlerTest {
         };
         Assert.assertEquals(
                 JdbcParseHandler.INSTANCE.handleStatement(sql2, StatementType.UPDATE, null, null, "tbl",
-                        null, null, null, null, null, null, positions, settings, null),
+                        null, null, null, null, null, null, positions, settings, null, null),
                 new ClickHouseSqlStatement(
                         "ALTER TABLE `tbl` UPDATE x=1, y=2 where a != 1 and b != 2 SETTINGS mutations_sync=1, a=1,b='a'",
                         StatementType.UPDATE, null, null, "tbl", null, null, null, null, null, null, null, settings,
-                        null));
+                        null, null));
 
         String sql3 = "update tbl set x=1,y=2 where a != 1 and b != 2 settings a=1,mutations_sync=2,b='a'";
         positions = new HashMap<String, Integer>() {
@@ -336,10 +336,10 @@ public class JdbcParseHandlerTest {
         };
         Assert.assertEquals(
                 JdbcParseHandler.INSTANCE.handleStatement(sql3, StatementType.UPDATE, null, null, "tbl",
-                        null, null, null, null, null, null, positions, settings, null),
+                        null, null, null, null, null, null, positions, settings, null, null),
                 new ClickHouseSqlStatement(
                         "ALTER TABLE `tbl` UPDATE x=1,y=2 where a != 1 and b != 2 settings a=1,mutations_sync=2,b='a'",
                         StatementType.UPDATE, null, null, "tbl", null, null, null, null, null, null, null, settings,
-                        null));
+                        null, null));
     }
 }


### PR DESCRIPTION
## Summary
Add dynamic query `{e <select query>}`.

## Usage

```sql
-- this will execute two queries
-- 1. select 2
-- 2. select * from numbers(100) where number = 2
select * from numbers(100) where number = {e select 2}

-- this will execute 3 queries
-- 1. select 'number in (2,3)' union all select 'number = 5'
-- 2. insert into my_table select * from numbers(100) where number in (2,3)
-- 3. insert into my_table select * from numbers(100) where number = 5
insert into my_table
select * from numbers(100) where {e
  select 'number in (2,3)' union all select 'number = 5'
}
```

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
