### PR TITLE
Disable Object Reuse By Default

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseRequest.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseRequest.java
@@ -1768,6 +1768,18 @@ public class ClickHouseRequest<SelfT extends ClickHouseRequest<SelfT>> implement
     }
 
     /**
+     * Enable object reuse during result collection, resulting in better memmory efficiency.
+     * WARNING: If you plan to pass the underlying {@link com.clickhouse.data.ClickHouseRecord} back without
+     * intermediate extraction, this object will potentially be overwritten with the last seen value of the stream.
+     * @return the request with object reuse enabled
+     */
+    @SuppressWarnings("unchecked")
+    public SelfT reuseObjects() {
+        option(ClickHouseClientOption.REUSE_VALUE_WRAPPER, "true");
+        return (SelfT) this;
+    }
+
+    /**
      * Sets a setting. See
      * https://clickhouse.tech/docs/en/operations/settings/settings/ for more
      * information.

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
@@ -75,7 +75,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
 import java.util.Map.Entry;

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
@@ -470,7 +470,7 @@ public abstract class ClientIntegrationTest extends BaseIntegrationTest {
             List<ClickHouseRecord> records = new ArrayList<>(10);
             response.stream().forEach(records::add);
             Assert.assertEquals(records.size(), 10);
-            // Verify that all records are the same (object reuse)
+            // Verify all records are unique (different number)
             for (int i = 0; i < numbers; i++) {
                 // Numbers will increment correctly, as object reuse is disabled by default
                 Assert.assertEquals(records.get(i).getValue(0).asInteger(), i);

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
@@ -442,8 +442,8 @@ public abstract class ClientIntegrationTest extends BaseIntegrationTest {
 
     @Test(groups = { "integration" })
     public void testWithObjectReuse() throws ClickHouseException {
-        ClickHouseNode server = getServer();
         int numbers = 10;
+        ClickHouseNode server = getServer();
         try (ClickHouseClient client = getClient();
              ClickHouseResponse response = newRequest(client, server).query("select * from numbers(10)")
                      .reuseObjects()

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
@@ -445,7 +445,7 @@ public abstract class ClientIntegrationTest extends BaseIntegrationTest {
         ClickHouseNode server = getServer();
         int numbers = 10;
         try (ClickHouseClient client = getClient();
-             ClickHouseResponse response = newRequest(client, server).query("select number from numbers(10)")
+             ClickHouseResponse response = newRequest(client, server).query("select * from numbers(10)")
                      .reuseObjects()
                      .executeAndWait()) {
             List<ClickHouseRecord> records = new ArrayList<>(10);

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataConfig.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataConfig.java
@@ -146,7 +146,7 @@ public interface ClickHouseDataConfig extends Serializable {
 
     static final ClickHouseFormat DEFAULT_FORMAT = ClickHouseFormat.TabSeparated;
 
-    static final boolean DEFAULT_REUSE_VALUE_WRAPPER = true;
+    static final boolean DEFAULT_REUSE_VALUE_WRAPPER = false;
     static final boolean DEFAULT_USE_BINARY_STRING = false;
     static final boolean DEFAULT_USE_BLOCKING_QUEUE = false;
     static final boolean DEFAULT_USE_COMPILATION = false;


### PR DESCRIPTION
## Summary
- Enabling object reuse by default has the potential to cause unforeseen bugs in user code.

- When a user decides to pass a `Stream<ClickHouseRecord>` back as a `List<ClickHouseRecord>`, all objects by default will be pointing back to the same object. This can be extremely jarring for users who aren't aware objects are being reused.

- Added a `reuseObjects()` method to quickly enable object reuse when appropriate. This allows the user to decide when memory efficiency is a goal.


## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
