### PR TITLE
WIP - Lower the datetime limit to what CH also accepts - 1900-01-01

### DIFF
--- a/clickhouse-data/src/main/java/com/clickhouse/data/format/BinaryDataProcessor.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/format/BinaryDataProcessor.java
@@ -289,17 +289,11 @@ public interface BinaryDataProcessor {
         @Override
         public void serialize(ClickHouseValue value, ClickHouseOutputStream output) throws IOException {
             LocalDateTime dt = value.asDateTime(scale);
-            long v = ClickHouseChecker.between(
-                    ClickHouseValues.UTC_ZONE.equals(zoneId) ? dt.toEpochSecond(ZoneOffset.UTC)
-                            : dt.atZone(zoneId).toEpochSecond(),
-                    ClickHouseValues.TYPE_DATE_TIME, BinaryStreamUtils.DATETIME64_MIN,
-                    BinaryStreamUtils.DATETIME64_MAX);
-            if (ClickHouseChecker.between(scale, ClickHouseValues.PARAM_SCALE, 0, 9) > 0) {
-                v *= BASES[scale];
-                int nanoSeconds = dt.getNano();
-                if (nanoSeconds > 0L) {
-                    v += nanoSeconds / BASES[9 - scale];
-                }
+            long v =  dt.toEpochSecond(ZoneOffset.UTC);
+            v *= BASES[scale];
+            int nanoSeconds = dt.getNano();
+            if (nanoSeconds > 0L) {
+                v += nanoSeconds / BASES[9 - scale];
             }
 
             BinaryStreamUtils.writeInt64(output, v);

--- a/clickhouse-data/src/main/java/com/clickhouse/data/format/BinaryStreamUtils.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/format/BinaryStreamUtils.java
@@ -71,7 +71,7 @@ public final class BinaryStreamUtils {
 
     public static final long DATETIME64_MAX = LocalDateTime.of(LocalDate.of(2283, 11, 11), LocalTime.MAX)
             .toEpochSecond(ZoneOffset.UTC);
-    public static final long DATETIME64_MIN = LocalDateTime.of(LocalDate.of(1925, 1, 1), LocalTime.MIN)
+    public static final long DATETIME64_MIN = LocalDateTime.of(LocalDate.of(1900, 1, 1), LocalTime.MIN)
             .toEpochSecond(ZoneOffset.UTC);
 
     public static final long MILLIS_IN_DAY = TimeUnit.DAYS.toMillis(1);

--- a/clickhouse-data/src/main/java/com/clickhouse/data/format/BinaryStreamUtils.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/format/BinaryStreamUtils.java
@@ -69,7 +69,7 @@ public final class BinaryStreamUtils {
     public static final BigDecimal DECIMAL256_MIN = new BigDecimal(
             "-10000000000000000000000000000000000000000000000000000000000000000000000000000");
 
-    public static final long DATETIME64_MAX = LocalDateTime.of(LocalDate.of(2283, 11, 11), LocalTime.MAX)
+    public static final long DATETIME64_MAX = LocalDateTime.of(LocalDate.of(2299, 12, 31), LocalTime.MAX)
             .toEpochSecond(ZoneOffset.UTC);
     public static final long DATETIME64_MIN = LocalDateTime.of(LocalDate.of(1900, 1, 1), LocalTime.MIN)
             .toEpochSecond(ZoneOffset.UTC);

--- a/clickhouse-data/src/test/java/com/clickhouse/data/format/BinaryStreamUtilsTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/format/BinaryStreamUtilsTest.java
@@ -1256,7 +1256,7 @@ public class BinaryStreamUtilsTest {
 
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> getWrittenBytes(o -> BinaryStreamUtils.writeDateTime64(o,
-                        LocalDateTime.of(LocalDate.of(1925, 1, 1).minus(1L, ChronoUnit.DAYS),
+                        LocalDateTime.of(LocalDate.of(1900, 1, 1).minus(1L, ChronoUnit.DAYS),
                                 LocalTime.MAX),
                         null)));
         Assert.assertThrows(IllegalArgumentException.class,
@@ -1325,7 +1325,7 @@ public class BinaryStreamUtilsTest {
                 () -> getWrittenBytes(
                         o -> BinaryStreamUtils.writeDateTime64(o,
                                 LocalDateTime.of(
-                                        LocalDate.of(1925, 1, 1).minus(1L,
+                                        LocalDate.of(1900, 1, 1).minus(1L,
                                                 ChronoUnit.DAYS),
                                         LocalTime.MAX)
                                         .atOffset(ZoneOffset.UTC)

--- a/clickhouse-data/src/test/java/com/clickhouse/data/format/BinaryStreamUtilsTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/format/BinaryStreamUtilsTest.java
@@ -1261,7 +1261,7 @@ public class BinaryStreamUtilsTest {
                         null)));
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> getWrittenBytes(o -> BinaryStreamUtils.writeDateTime64(o,
-                        LocalDateTime.of(LocalDate.of(2283, 11, 11).plus(1L, ChronoUnit.DAYS),
+                        LocalDateTime.of(LocalDate.of(2299, 12, 31).plus(1L, ChronoUnit.DAYS),
                                 LocalTime.MIN),
                         null)));
     }
@@ -1336,7 +1336,7 @@ public class BinaryStreamUtilsTest {
                 () -> getWrittenBytes(
                         o -> BinaryStreamUtils.writeDateTime64(o,
                                 LocalDateTime.of(
-                                        LocalDate.of(2283, 11, 11).plus(1L,
+                                        LocalDate.of(2299, 12, 31).plus(1L,
                                                 ChronoUnit.DAYS),
                                         LocalTime.MIN)
                                         .atOffset(ZoneOffset.UTC)


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->


Removing the layer that performs whether a datetime is within a predefined range works fine.

```
On Postgres
created_datetime     |    sent_datetime    
---------------------+---------------------
 2022-11-10 13:39:35 | 2300-11-09 20:38:58
 
On CH
"created_datetime": "2022-11-10 13:39:35.000000"
"sent_datetime": "2299-12-31 23:38:58.000000"
 
 
PS. writeDateTime64 does not seem to be used anywhere
```
## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
