### PR TITLE
[bug #1389] Resolve processing Nested column type in combination with AggregateFunction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 ### Bug Fixes
 * Java client threw confusing error when query is invalid.
+* JDBC Driver correctly processes `AggregateFunction(Nested(...))` columns
 
 ## 0.4.6, 2023-05-02
 ### New Features

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseUtils.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseUtils.java
@@ -440,7 +440,7 @@ public final class ClickHouseUtils {
 
     /**
      * Escape quotes in given string.
-     * 
+     *
      * @param str   string
      * @param quote quote to escape
      * @return escaped string
@@ -466,7 +466,7 @@ public final class ClickHouseUtils {
 
     /**
      * Unescape quoted string.
-     * 
+     *
      * @param str quoted string
      * @return unescaped string
      */
@@ -1460,7 +1460,7 @@ public final class ClickHouseUtils {
     }
 
     public static int readParameters(String args, int startIndex, int len, List<String> params) {
-        char closeBracket = ')'; // startIndex points to the openning bracket
+        char closeBracket = ')'; // startIndex points to the opening bracket
         Deque<Character> stack = new ArrayDeque<>();
         StringBuilder builder = new StringBuilder();
 
@@ -1489,7 +1489,7 @@ public final class ClickHouseUtils {
 
         for (int i = startIndex; i < len; i++) {
             char ch = args.charAt(i);
-            if (Character.isWhitespace(ch)) {
+            if (Character.isWhitespace(ch) && stack.isEmpty()) {
                 continue;
             } else if (isQuote(ch)) {
                 builder.append(ch);

--- a/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseColumnTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseColumnTest.java
@@ -206,7 +206,7 @@ public class ClickHouseColumnTest {
         Assert.assertTrue(column.isAggregateFunction());
         Assert.assertEquals(column.getDataType(), ClickHouseDataType.AggregateFunction);
         Assert.assertEquals(column.getAggregateFunction(), ClickHouseAggregateFunction.quantiles);
-        Assert.assertEquals(column.getFunction(), "quantiles(0.5,0.9)");
+        Assert.assertEquals(column.getFunction(), "quantiles(0.5, 0.9)");
         Assert.assertEquals(column.getNestedColumns(),
                 Collections.singletonList(ClickHouseColumn.of("", "Nullable(UInt64)")));
         Assert.assertFalse(column.isFixedLength(), "Should not have fixed length in byte");

--- a/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseUtilsTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseUtilsTest.java
@@ -459,7 +459,7 @@ public class ClickHouseUtilsTest {
         List<String> params = new LinkedList<>();
         Assert.assertEquals(ClickHouseUtils.readParameters(args, args.indexOf('('), args.length(), params),
                 args.lastIndexOf(')') + 1);
-        Assert.assertEquals(params, Arrays.asList("quantiles(0.5,'c \\'''([1],2) d',0.9)", "UInt64"));
+        Assert.assertEquals(params, Arrays.asList("quantiles(0.5, 'c \\'''([1],2) d',0.9)", "UInt64"));
 
         params.clear();
         args = "   ('a'/* a*/, 1-- test\n, b)";
@@ -470,6 +470,12 @@ public class ClickHouseUtilsTest {
         args = " a, b c";
         Assert.assertEquals(ClickHouseUtils.readParameters(args, 0, args.length(), params), args.length());
         Assert.assertEquals(params, Arrays.asList("a", "bc"));
+
+        params.clear();
+        args = "column1 SimpleAggregateFunction(anyLast, Nested(a string, b string))";
+        Assert.assertEquals(ClickHouseUtils.readParameters(args, args.indexOf('('), args.length(), params),
+                args.lastIndexOf(')') + 1);
+        Assert.assertEquals(params, Arrays.asList("anyLast", "Nested(a string, b string)"));
     }
 
     @Test(groups = { "unit" })

--- a/clickhouse-data/src/test/java/com/clickhouse/data/stream/InputStreamImplTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/stream/InputStreamImplTest.java
@@ -373,7 +373,7 @@ public class InputStreamImplTest {
         }
         Assert.assertEquals(in.available(), 0);
         Assert.assertEquals(in.read(), -1);
-        Assert.assertFalse(in.isClosed(), "Should be still openning");
+        Assert.assertFalse(in.isClosed(), "Should be still opening");
         in.close();
         Assert.assertTrue(in.isClosed(), "Should have been closed");
     }
@@ -385,7 +385,7 @@ public class InputStreamImplTest {
         Assert.assertEquals(in.read(bytes, 1, 6), 6);
         Assert.assertEquals(new String(bytes, 1, 6), "efghip");
         Assert.assertEquals(in.read(bytes), -1);
-        Assert.assertFalse(in.isClosed(), "Should be still openning");
+        Assert.assertFalse(in.isClosed(), "Should be still opening");
         in.close();
         Assert.assertTrue(in.isClosed(), "Should have been closed");
     }
@@ -398,7 +398,7 @@ public class InputStreamImplTest {
             builder.append((char) in.readByte());
         }
         Assert.assertEquals(builder.toString(), "efghip");
-        Assert.assertFalse(in.isClosed(), "Should be still openning");
+        Assert.assertFalse(in.isClosed(), "Should be still opening");
         Assert.assertThrows(EOFException.class, () -> in.readByte());
         Assert.assertTrue(in.isClosed(), "Should have been closed");
     }
@@ -409,7 +409,7 @@ public class InputStreamImplTest {
         Assert.assertEquals(new String(in.readBytes(2)), "ef");
         Assert.assertEquals(new String(in.readBytes(1)), "g");
         Assert.assertEquals(new String(in.readBytes(3)), "hip");
-        Assert.assertFalse(in.isClosed(), "Should be still openning");
+        Assert.assertFalse(in.isClosed(), "Should be still opening");
         Assert.assertThrows(EOFException.class, () -> in.readBytes(1));
         Assert.assertTrue(in.isClosed(), "Should have been closed");
     }
@@ -418,7 +418,7 @@ public class InputStreamImplTest {
     public void testReadBytesAllFromInputStream(ClickHouseInputStream in) throws IOException {
         Assert.assertFalse(in.isClosed(), "Should be openned for read by default");
         Assert.assertEquals(new String(in.readBytes(6)), "efghip");
-        Assert.assertFalse(in.isClosed(), "Should be still openning");
+        Assert.assertFalse(in.isClosed(), "Should be still opening");
         Assert.assertThrows(EOFException.class, () -> in.readBytes(1));
         Assert.assertTrue(in.isClosed(), "Should have been closed");
     }
@@ -429,7 +429,7 @@ public class InputStreamImplTest {
         Assert.assertEquals(in.readBuffer(3).asUnicodeString(), "efg");
         Assert.assertEquals(in.readBuffer(2).asUnicodeString(), "hi");
         Assert.assertEquals(in.readBuffer(1).asUnicodeString(), "p");
-        Assert.assertFalse(in.isClosed(), "Should be still openning");
+        Assert.assertFalse(in.isClosed(), "Should be still opening");
         Assert.assertThrows(EOFException.class, () -> in.readBuffer(1));
         Assert.assertTrue(in.isClosed(), "Should have been closed");
     }
@@ -440,9 +440,9 @@ public class InputStreamImplTest {
         Assert.assertEquals(in.readBufferUntil(new byte[] { 'f', 'g' }).asUnicodeString(), "efg");
         Assert.assertEquals(in.readBufferUntil(new byte[] { 'i' }).asUnicodeString(), "hi");
         Assert.assertEquals(in.readBufferUntil(new byte[] { 'p' }).asUnicodeString(), "p");
-        Assert.assertFalse(in.isClosed(), "Should be still openning");
+        Assert.assertFalse(in.isClosed(), "Should be still opening");
         Assert.assertTrue(in.readBufferUntil(new byte[0]).isEmpty(), "Should got nothing");
-        Assert.assertFalse(in.isClosed(), "Should be still openning");
+        Assert.assertFalse(in.isClosed(), "Should be still opening");
         Assert.assertTrue(in.readBufferUntil(new byte[1]).isEmpty(), "Should got nothing");
         Assert.assertTrue(in.isClosed(), "Should have been closed");
     }
@@ -503,7 +503,7 @@ public class InputStreamImplTest {
         Assert.assertEquals(in.read(bytes, 6, 1), 1);
         Assert.assertEquals(bytes[6], 0x69);
         Assert.assertTrue(in.available() > 0, "Should have more to read");
-        Assert.assertFalse(in.isClosed(), "Should be still openning");
+        Assert.assertFalse(in.isClosed(), "Should be still opening");
         in.close();
         Assert.assertTrue(in.isClosed(), "Should have been closed");
     }


### PR DESCRIPTION

## Summary
Resolves https://github.com/ClickHouse/clickhouse-java/issues/1389

Skipping of whitespace is prevented when processing a section within brackets.
I had to change some other tests that were failing now, but don't think it would break anything else. Not sure why whitespace is removed in the first place?

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
