### PR TITLE
Add support for custom socket factory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+### New Features
+* Add support for customer socket factory [#1391](https://github.com/ClickHouse/clickhouse-java/issues/1391)
+
 ## 0.5.0
 ### Breaking Changes
 * ClickHouseByteBuffer can no longer be extended

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/Utils.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/Utils.java
@@ -1,0 +1,48 @@
+package com.clickhouse.client.http;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import static java.lang.String.format;
+
+public class Utils {
+
+    @SuppressWarnings("unchecked")
+    public static <T> T getInstance(Class<T> returnType, String className, Class<?>[] argTypes, Object[] args) {
+        try {
+            Class<?> clazz = Class.forName(className, false, Utils.class.getClassLoader());
+            if (!returnType.isAssignableFrom(clazz)) {
+                throw new IllegalArgumentException(String.format("Invalid %s class type. Input class should be a superclass of %s.", className, returnType));
+            }
+            return getInstance(className, ((Class<T>) clazz).getConstructor(argTypes), argTypes, args);
+        }
+        catch (ClassNotFoundException e) {
+            throw new IllegalArgumentException(format("Class %s is not found in the classpath.", className));
+        }
+        catch (NoSuchMethodException e) {
+            throw new IllegalArgumentException(format("Class this does not have a constructor with %s argument type(s).", Arrays.stream(argTypes).collect(Collectors.toList())));
+        }
+    }
+
+    public static <T> T getInstance(String className, Constructor<T> ctor, Class<?>[] argTypes, Object[] args) {
+        try {
+            return ctor.newInstance(args);
+        }
+        catch (SecurityException e) {
+            throw new IllegalArgumentException((format("Error while creating an %s class instance. " +
+                    "Number of constructor arguments or type of arguments differs. Expected arguments type: %s, given arguments: %s",
+                    className, Arrays.toString(argTypes), Arrays.toString(args))));
+        }
+        catch (InvocationTargetException e) {
+            throw new IllegalArgumentException(format("Error while creating an %s class instance. Constructor threw an exception.", className));
+        }
+        catch (IllegalAccessException e) {
+            throw new IllegalArgumentException(format("Error while creating an %s class instance. Constructor is inaccessible.", className));
+        }
+        catch (InstantiationException e) {
+            throw new IllegalArgumentException(format("Error while creating an %s class instance. Class is an abstract class.", className));
+        }
+    }
+}

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/ClickHouseHttpOption.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/ClickHouseHttpOption.java
@@ -35,6 +35,13 @@ public enum ClickHouseHttpOption implements ClickHouseOption {
      */
     CUSTOM_SECURE_SOCKET_FACTORY("custom_secure_socket_factory", "", "Custom https socket factory class name."),
     /**
+     * Additional HTTPS socket factory options. Only useful only when {@link #CUSTOM_SECURE_SOCKET_FACTORY} is set.
+     * Accessible {@code com.clickhouse.client.ClickHouseConfig} through {@link #CUSTOM_SECURE_SOCKET_FACTORY} socket factory class constructor.
+     */
+    CUSTOM_SECURE_SOCKET_FACTORY_OPTIONS("custom_secure_socket_factory_options", "",
+            "Additional properties to be useful while creating an instance of CUSTOM_SECURE_SOCKET_FACTORY. "
+                    + "Properties are accessible through ClickHouseConfig."),
+    /**
      * Custom HTTP socket factory class name. Takes effect only when CONNECTION_PROVIDER is set to APACHE_HTTP_CLIENT.<br/>
      * Given class should
      * <ul>
@@ -44,6 +51,13 @@ public enum ClickHouseHttpOption implements ClickHouseOption {
      * </ul>
      */
     CUSTOM_SOCKET_FACTORY("custom_socket_factory", "", "Custom http socket factory class name."),
+    /**
+     * Additional HTTP socket factory options. Only useful only when {@link #CUSTOM_SOCKET_FACTORY} is set.
+     * Accessible from {@code com.clickhouse.client.ClickHouseConfig} through {@link #CUSTOM_SOCKET_FACTORY} socket factory class constructor.
+     */
+    CUSTOM_SOCKET_FACTORY_OPTIONS("custom_socket_factory_options", "",
+            "Additional properties to be useful while creating an instance of CUSTOM_SOCKET_FACTORY. "
+                    + "Properties are accessible through ClickHouseConfig."),
     /**
      * Default server response.
      */

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/ClickHouseHttpOption.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/ClickHouseHttpOption.java
@@ -25,6 +25,26 @@ public enum ClickHouseHttpOption implements ClickHouseOption {
      */
     CUSTOM_PARAMS("custom_http_params", "", "Custom HTTP query parameters."),
     /**
+     * Custom HTTPS socket factory class name. Takes effect only when CONNECTION_PROVIDER is set to APACHE_HTTP_CLIENT.<br/>
+     * Given class should
+     * <ul>
+     * <li>be accessible from the classpath</li>
+     * <li>extend {@code com.clickhouse.client.internal.apache.hc.client5.http.ssl.SSLConnectionSocketFactory}</li>
+     * <li>have a single arg constructor of {@code com.clickhouse.client.ClickHouseConfig} arg type</li>
+     * </ul>
+     */
+    CUSTOM_SECURE_SOCKET_FACTORY("custom_secure_socket_factory", "", "Custom https socket factory class name."),
+    /**
+     * Custom HTTP socket factory class name. Takes effect only when CONNECTION_PROVIDER is set to APACHE_HTTP_CLIENT.<br/>
+     * Given class should
+     * <ul>
+     * <li>be accessible from the classpath</li>
+     * <li>extend {@code com.clickhouse.client.internal.apache.hc.client5.http.socket.PlainConnectionSocketFactory}}</li>
+     * <li>have a single arg constructor of {@code com.clickhouse.client.ClickHouseConfig} arg type</li>
+     * </ul>
+     */
+    CUSTOM_SOCKET_FACTORY("custom_socket_factory", "", "Custom http socket factory class name."),
+    /**
      * Default server response.
      */
     DEFAULT_RESPONSE("http_server_default_response", "Ok.\n",


### PR DESCRIPTION
## Summary
https://github.com/ClickHouse/clickhouse-java/issues/1391 - Attempt to inject a custom socket factory with `APACHE_HTTP_CLIENT` connection provider.
## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
