### PR TITLE
Remove deprecated api settings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,7 +179,7 @@ jobs:
       matrix:
         # most recent LTS releases as well as latest stable builds
         # https://github.com/ClickHouse/ClickHouse/pulls?q=is%3Aopen+is%3Apr+label%3Arelease
-        clickhouse: ["22.3", "22.8", "23.3", "latest"]
+        clickhouse: ["22.8", "23.3", "23.7", "latest"]
       fail-fast: false
     timeout-minutes: 15
     name: Java client + CH ${{ matrix.clickhouse }}
@@ -234,7 +234,7 @@ jobs:
     needs: compile
     strategy:
       matrix:
-        clickhouse: ["22.3", "22.8", "23.3", "latest"]
+        clickhouse: ["22.8", "23.3", "23.7", "latest"]
         # here http, http_client and apache_http_client represent different value of http_connection_provider
         protocol: ["http", "http_client", "apache_http_client", "grpc"]
       fail-fast: false
@@ -293,7 +293,7 @@ jobs:
     needs: compile
     strategy:
       matrix:
-        clickhouse: ["22.3", "22.8", "23.3", "latest"]
+        clickhouse: ["22.8", "23.3", "23.7", "latest"]
         # grpc is not fully supported, and http_client and apache_http_client do not work in CI environment(due to limited threads?)
         protocol: ["http"]
         r2dbc: ["1.0.0.RELEASE", "0.9.1.RELEASE"]

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -179,7 +179,7 @@ jobs:
       matrix:
         # most recent LTS releases as well as latest stable builds
         # https://github.com/ClickHouse/ClickHouse/pulls?q=is%3Aopen+is%3Apr+label%3Arelease
-        clickhouse: ["22.8", "23.3", "23.7", "latest"]
+        clickhouse: ["22.3", "22.8", "23.3", "latest"]
       fail-fast: false
     timeout-minutes: 15
     name: Java client + CH ${{ matrix.clickhouse }}
@@ -234,7 +234,7 @@ jobs:
     needs: compile
     strategy:
       matrix:
-        clickhouse: ["22.8", "23.3", "23.7", "latest"]
+        clickhouse: ["22.3", "22.8", "23.3", "latest"]
         # here http, http_client and apache_http_client represent different value of http_connection_provider
         protocol: ["http", "http_client", "apache_http_client", "grpc"]
       fail-fast: false
@@ -293,7 +293,7 @@ jobs:
     needs: compile
     strategy:
       matrix:
-        clickhouse: ["22.8", "23.3", "23.7", "latest"]
+        clickhouse: ["22.3", "22.8", "23.3", "latest"]
         # grpc is not fully supported, and http_client and apache_http_client do not work in CI environment(due to limited threads?)
         protocol: ["http"]
         r2dbc: ["1.0.0.RELEASE", "0.9.1.RELEASE"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * ClickHouseByteBuffer can no longer be extended
 * rename ClickHouseByteUtils methods by removing LE suffix
 * change default databaseTerm from schema to catalog
+* remove deprecated API load, dump and connect
+* remove use_no_proxy settings
 
 ### New Features
 * Adding new proxy support [#1338](https://github.com/ClickHouse/clickhouse-java/issues/1338)

--- a/clickhouse-benchmark/src/main/java/com/clickhouse/benchmark/client/ClientState.java
+++ b/clickhouse-benchmark/src/main/java/com/clickhouse/benchmark/client/ClientState.java
@@ -92,7 +92,7 @@ public class ClientState extends BaseState {
                 "create table if not exists system.test_insert(id String, i Nullable(UInt64), s Nullable(String), t Nullable(DateTime))engine=Memory" };
 
         for (String sql : sqls) {
-            try (ClickHouseResponse resp = client.connect(server).query(sql).executeAndWait()) {
+            try (ClickHouseResponse resp = client.read(server).query(sql).executeAndWait()) {
 
             }
         }
@@ -102,7 +102,7 @@ public class ClientState extends BaseState {
     public void doTearDown(ServerState serverState) throws ClickHouseException {
         dispose();
 
-        try (ClickHouseResponse resp = client.connect(server).query("truncate table system.test_insert")
+        try (ClickHouseResponse resp = client.read(server).query("truncate table system.test_insert")
                 .executeAndWait()) {
 
         } finally {
@@ -161,7 +161,7 @@ public class ClientState extends BaseState {
     }
 
     public ClickHouseRequest<?> newRequest() {
-        return client.connect(server);
+        return client.read(server);
     }
 
     public void consume(Blackhole blackhole, Future<ClickHouseResponse> future) throws InterruptedException {

--- a/clickhouse-cli-client/src/main/java/com/clickhouse/client/cli/ClickHouseCommandLineClient.java
+++ b/clickhouse-cli-client/src/main/java/com/clickhouse/client/cli/ClickHouseCommandLineClient.java
@@ -29,7 +29,7 @@ public class ClickHouseCommandLineClient extends AbstractClient<ClickHouseComman
 
     @Override
     protected boolean checkHealth(ClickHouseNode server, int timeout) {
-        try (ClickHouseCommandLine cli = getConnection(connect(server).query("SELECT 1"));
+        try (ClickHouseCommandLine cli = getConnection(read(server).query("SELECT 1"));
                 ClickHouseCommandLineResponse response = new ClickHouseCommandLineResponse(getConfig(), cli)) {
             return response.firstRecord().getValue(0).asInteger() == 1;
         } catch (Exception e) {

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseClient.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseClient.java
@@ -365,29 +365,6 @@ public interface ClickHouseClient extends AutoCloseable {
     }
 
     /**
-     * Dumps a table or query result from server into a file. File will be
-     * created/overwrited as needed.
-     *
-     * @param server       non-null server to connect to
-     * @param tableOrQuery table name or a select query
-     * @param format       output format to use
-     * @param compression  compression algorithm to use
-     * @param file         output file
-     * @return non-null future object to get result
-     * @throws IllegalArgumentException if any of server, tableOrQuery, and output
-     *                                  is null
-     * @throws CompletionException      when error occurred during execution
-     * @deprecated will be dropped in 0.5, please use
-     *             {@link #dump(ClickHouseNode, String, String, ClickHouseCompression, ClickHouseFormat)}
-     *             instead
-     */
-    @Deprecated
-    static CompletableFuture<ClickHouseResponseSummary> dump(ClickHouseNode server, String tableOrQuery,
-            ClickHouseFormat format, ClickHouseCompression compression, String file) {
-        return dump(server, tableOrQuery, file, compression, format);
-    }
-
-    /**
      * Dumps a table or query result from server into output stream.
      *
      * @param server       non-null server to connect to
@@ -436,31 +413,6 @@ public interface ClickHouseClient extends AutoCloseable {
                 }
             }
         });
-    }
-
-    /**
-     * Dumps a table or query result from server into output stream.
-     *
-     * @param server       non-null server to connect to
-     * @param tableOrQuery table name or a select query
-     * @param format       output format to use, null means
-     *                     {@link ClickHouseFormat#TabSeparated}
-     * @param compression  compression algorithm to use, null means
-     *                     {@link ClickHouseCompression#NONE}
-     * @param output       output stream, which will be closed automatically at the
-     *                     end of the call
-     * @return future object to get result
-     * @throws IllegalArgumentException if any of server, tableOrQuery, and output
-     *                                  is null
-     * @throws CompletionException      when error occurred during execution
-     * @deprecated will be dropped in 0.5, please use
-     *             {@link #dump(ClickHouseNode, String, OutputStream, ClickHouseCompression, ClickHouseFormat)}
-     *             instead
-     */
-    @Deprecated
-    static CompletableFuture<ClickHouseResponseSummary> dump(ClickHouseNode server, String tableOrQuery,
-            ClickHouseFormat format, ClickHouseCompression compression, OutputStream output) {
-        return dump(server, tableOrQuery, output, compression, format);
     }
 
     /**
@@ -544,50 +496,6 @@ public interface ClickHouseClient extends AutoCloseable {
     }
 
     /**
-     * Loads data from a file into table using specified format and compression
-     * algorithm.
-     *
-     * @param server      non-null server to connect to
-     * @param table       non-null target table
-     * @param format      input format to use
-     * @param compression compression algorithm to use
-     * @param file        file to load
-     * @return future object to get result
-     * @throws IllegalArgumentException if any of server, table, and input is null
-     * @throws CompletionException      when error occurred during execution
-     * @deprecated will be dropped in 0.5, please use
-     *             {@link #load(ClickHouseNode, String, String, ClickHouseCompression, ClickHouseFormat)}
-     *             instead
-     */
-    @Deprecated
-    static CompletableFuture<ClickHouseResponseSummary> load(ClickHouseNode server, String table,
-            ClickHouseFormat format, ClickHouseCompression compression, String file) {
-        return load(server, table, file, compression, format);
-    }
-
-    /**
-     * Loads data from a custom writer into a table using specified format and
-     * compression algorithm.
-     *
-     * @param server      non-null server to connect to
-     * @param table       non-null target table
-     * @param writer      non-null custom writer to generate data
-     * @param compression compression algorithm to use
-     * @param format      input format to use
-     * @return future object to get result
-     * @throws IllegalArgumentException if any of server, table, and writer is null
-     * @throws CompletionException      when error occurred during execution
-     * @deprecated will be dropped in 0.5, please use
-     *             {@link #load(ClickHouseNode, String, ClickHouseWriter, ClickHouseCompression, ClickHouseFormat)}
-     *             instead
-     */
-    @Deprecated
-    static CompletableFuture<ClickHouseResponseSummary> load(ClickHouseNode server, String table,
-            ClickHouseFormat format, ClickHouseCompression compression, ClickHouseWriter writer) {
-        return load(server, table, writer, compression, format);
-    }
-
-    /**
      * Loads data from input stream into a table using specified format and
      * compression algorithm.
      *
@@ -623,29 +531,6 @@ public interface ClickHouseClient extends AutoCloseable {
                 }
             }
         });
-    }
-
-    /**
-     * Loads data from input stream into a table using specified format and
-     * compression algorithm.
-     *
-     * @param server      non-null server to connect to
-     * @param table       non-null target table
-     * @param format      input format to use
-     * @param compression compression algorithm to use
-     * @param input       input stream, which will be closed automatically at the
-     *                    end of the call
-     * @return future object to get result
-     * @throws IllegalArgumentException if any of server, table, and input is null
-     * @throws CompletionException      when error occurred during execution
-     * @deprecated will be dropped in 0.5, please use
-     *             {@link #load(ClickHouseNode, String, InputStream, ClickHouseCompression, ClickHouseFormat)}
-     *             instead
-     */
-    @Deprecated
-    static CompletableFuture<ClickHouseResponseSummary> load(ClickHouseNode server, String table,
-            ClickHouseFormat format, ClickHouseCompression compression, InputStream input) {
-        return load(server, table, input, compression, format);
     }
 
     /**
@@ -904,70 +789,6 @@ public interface ClickHouseClient extends AutoCloseable {
      */
     default boolean accept(ClickHouseProtocol protocol) {
         return protocol == null || protocol == ClickHouseProtocol.ANY;
-    }
-
-    /**
-     * Connects to one or more ClickHouse servers. Same as
-     * {@code connect(ClickHouseNodes.of(uri))}.
-     *
-     * @param endpoints non-empty URIs separated by comma
-     * @return non-null request object holding references to this client and node
-     *         provider
-     * @deprecated will be dropped in 0.5, please use {@link #read(String)} instead
-     */
-    @Deprecated
-    default ClickHouseRequest<?> connect(String endpoints) {
-        return read(endpoints);
-    }
-
-    /**
-     * Connects to a list of managed ClickHouse servers.
-     *
-     * @param nodes non-null list of servers to connect to
-     * @return non-null request object holding references to this client and node
-     *         provider
-     * @deprecated will be dropped in 0.5, please use {@link #read(ClickHouseNodes)}
-     *             instead
-     */
-    @Deprecated
-    default ClickHouseRequest<?> connect(ClickHouseNodes nodes) {
-        return read(nodes);
-    }
-
-    /**
-     * Connects to a ClickHouse server.
-     *
-     * @param node non-null server for read
-     * @return non-null request object holding references to this client and node
-     *         provider
-     * @deprecated will be dropped in 0.5, please use {@link #read(ClickHouseNode)}
-     *             instead
-     */
-    @Deprecated
-    default ClickHouseRequest<?> connect(ClickHouseNode node) {
-        return read(node);
-    }
-
-    /**
-     * Connects to a ClickHouse server defined by the given
-     * {@link java.util.function.Function}. You can pass either
-     * {@link ClickHouseCluster}, {@link ClickHouseNodes} or {@link ClickHouseNode}
-     * here, as all of them implemented the same interface.
-     *
-     * <p>
-     * Please be aware that this is nothing but an intention, so no network
-     * communication happens until {@link #execute(ClickHouseRequest)} is
-     * invoked(usually triggered by {@code request.execute()}).
-     *
-     * @param nodeFunc function to get a {@link ClickHouseNode} to connect to
-     * @return non-null request object holding references to this client and node
-     *         provider
-     * @deprecated will be dropped in 0.5, please use {@link #read(Function, Map)}
-     *             instead
-     */
-    @Deprecated
-    default ClickHouseRequest<?> connect(Function<ClickHouseNodeSelector, ClickHouseNode> nodeFunc) {
-        return read(nodeFunc, null);
     }
 
     /**

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseConfig.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseConfig.java
@@ -235,7 +235,6 @@ public class ClickHouseConfig implements ClickHouseDataConfig {
     private final boolean useBlockingQueue;
     private final boolean useCompilation;
     private final boolean useObjectsInArray;
-    private final boolean useNoProxy;
     private final boolean useServerTimeZone;
     private final boolean useServerTimeZoneForDates;
     private final TimeZone timeZoneForDate;
@@ -353,7 +352,6 @@ public class ClickHouseConfig implements ClickHouseDataConfig {
         this.useBlockingQueue = getBoolOption(ClickHouseClientOption.USE_BLOCKING_QUEUE);
         this.useCompilation = getBoolOption(ClickHouseClientOption.USE_COMPILATION);
         this.useObjectsInArray = getBoolOption(ClickHouseClientOption.USE_OBJECTS_IN_ARRAYS);
-        this.useNoProxy = getBoolOption(ClickHouseClientOption.USE_NO_PROXY);
         this.useServerTimeZone = getBoolOption(ClickHouseClientOption.USE_SERVER_TIME_ZONE);
         this.useServerTimeZoneForDates = getBoolOption(ClickHouseClientOption.USE_SERVER_TIME_ZONE_FOR_DATES);
 
@@ -662,10 +660,6 @@ public class ClickHouseConfig implements ClickHouseDataConfig {
      * @deprecated will be dropped in 0.5, please use {@link #getProxyType()}
      *             instead
      */
-    @Deprecated
-    public boolean isUseNoProxy() {
-        return useNoProxy;
-    }
 
     public ClickHouseProxyType getProxyType() {
         return proxyType;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodes.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodes.java
@@ -415,7 +415,7 @@ public class ClickHouseNodes implements ClickHouseNodeManager {
 
             try (ClickHouseClient client = ClickHouseClient.builder().agent(false)
                     .nodeSelector(ClickHouseNodeSelector.of(server.getProtocol())).build()) {
-                ClickHouseRequest<?> request = client.connect(server)
+                ClickHouseRequest<?> request = client.read(server)
                         .format(ClickHouseFormat.RowBinaryWithNamesAndTypes);
                 String clusterName = server.getCluster();
                 Set<String> clusters = new LinkedHashSet<>();

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseTransaction.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseTransaction.java
@@ -420,7 +420,7 @@ public final class ClickHouseTransaction implements Serializable {
         }
 
         id.updateAndGet(x -> {
-            try (ClickHouseResponse response = ClickHouseClient.newInstance(server.getProtocol()).connect(server)
+            try (ClickHouseResponse response = ClickHouseClient.newInstance(server.getProtocol()).read(server)
                     .query("KILL TRANSACTION WHERE tid=" + x.asTupleString()).executeAndWait()) {
                 // ignore
             } catch (ClickHouseException e) {

--- a/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java
@@ -378,16 +378,6 @@ public enum ClickHouseClientOption implements ClickHouseOption {
     USE_OBJECTS_IN_ARRAYS("use_objects_in_arrays", ClickHouseDataConfig.DEFAULT_USE_OBJECT_IN_ARRAY,
             "Whether Object[] should be used instead of primitive arrays."),
     /**
-     * Whether to access ClickHouse server directly without using system wide proxy
-     * including the one defined in JVM system properties.
-     * 
-     * @deprecated will be dropped in 0.5, please use {@link #PROXY_TYPE} instead
-     */
-    @Deprecated
-    USE_NO_PROXY("use_no_proxy", false,
-            "Whether to access ClickHouse server directly without using system wide proxy including the one defined in JVM system properties."),
-
-    /**
      * Type of proxy can be used to access ClickHouse server. To use an HTTP/SOCKS
      * proxy, you must specify the {@link #PROXY_HOST} and {@link #PROXY_PORT}.
      */

--- a/clickhouse-client/src/test/java/com/clickhouse/client/AbstractClientTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/AbstractClientTest.java
@@ -68,7 +68,7 @@ public class AbstractClientTest {
 
         SimpleClient client = new SimpleClient();
         client.init(new ClickHouseConfig());
-        ClickHouseRequest<?> req = client.connect(ClickHouseNode.builder().build());
+        ClickHouseRequest<?> req = client.read(ClickHouseNode.builder().build());
         ClickHouseConfig config = new ClickHouseConfig();
         sc.init(config);
         Assert.assertNotNull(sc.getExecutor());
@@ -88,7 +88,7 @@ public class AbstractClientTest {
     public void testCloseRunningClient() throws InterruptedException {
         SimpleClient client = new SimpleClient();
         client.init(new ClickHouseConfig());
-        ClickHouseRequest<?> req = client.connect(ClickHouseNode.builder().build());
+        ClickHouseRequest<?> req = client.read(ClickHouseNode.builder().build());
 
         CountDownLatch latch = new CountDownLatch(1);
         new Thread(() -> {
@@ -112,13 +112,13 @@ public class AbstractClientTest {
     public void testGetAndCloseConnection() {
         SimpleClient client = new SimpleClient();
         client.init(new ClickHouseConfig());
-        ClickHouseRequest<?> req = client.connect(ClickHouseNode.builder().build());
+        ClickHouseRequest<?> req = client.read(ClickHouseNode.builder().build());
 
         SimpleClient sc = new SimpleClient();
         sc.init(new ClickHouseConfig());
         Assert.assertEquals(sc.getConnection(req), new Object[] { req.getConfig(), req.getServer() });
 
-        req = client.connect(ClickHouseNode.of("127.0.0.1", ClickHouseProtocol.POSTGRESQL, 9100, "test"));
+        req = client.read(ClickHouseNode.of("127.0.0.1", ClickHouseProtocol.POSTGRESQL, 9100, "test"));
         Object[] conn = sc.getConnection(req);
         Assert.assertEquals(conn, new Object[] { req.getConfig(), req.getServer() });
         sc.close();
@@ -131,12 +131,12 @@ public class AbstractClientTest {
         SimpleClient client = new SimpleClient();
         client.init(new ClickHouseConfig());
         Assert.assertThrows(IllegalArgumentException.class,
-                () -> client.connect(ClickHouseNode.builder().port(ClickHouseProtocol.MYSQL).build()).getServer());
+                () -> client.read(ClickHouseNode.builder().port(ClickHouseProtocol.MYSQL).build()).getServer());
 
-        ClickHouseRequest<?> req = client.connect(ClickHouseNode.builder().build());
+        ClickHouseRequest<?> req = client.read(ClickHouseNode.builder().build());
         SimpleClient sc = new SimpleClient();
         Assert.assertFalse(sc.isInitialized());
-        Assert.assertThrows(IllegalStateException.class, () -> sc.connect(ClickHouseNode.builder().build()));
+        Assert.assertThrows(IllegalStateException.class, () -> sc.read(ClickHouseNode.builder().build()));
         Assert.assertThrows(IllegalStateException.class, () -> sc.getConfig());
         Assert.assertThrows(IllegalStateException.class, () -> sc.getConnection(req));
         Assert.assertThrows(IllegalStateException.class, () -> sc.getExecutor());
@@ -175,9 +175,9 @@ public class AbstractClientTest {
         ClickHouseConfig config = new ClickHouseConfig();
         SimpleClient client = new SimpleClient();
         client.init(config);
-        ClickHouseRequest<?> req1 = client.connect(ClickHouseNode.builder().build());
+        ClickHouseRequest<?> req1 = client.read(ClickHouseNode.builder().build());
         ClickHouseRequest<?> req2 = client
-                .connect(ClickHouseNode.of("127.0.0.1", ClickHouseProtocol.POSTGRESQL, 9100, "test"));
+                .read(ClickHouseNode.of("127.0.0.1", ClickHouseProtocol.POSTGRESQL, 9100, "test"));
 
         Object[] conn1 = client.getConnection(req1);
         CountDownLatch latch = new CountDownLatch(1);

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseClientTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseClientTest.java
@@ -40,7 +40,7 @@ public class ClickHouseClientTest {
     public void testQuery() throws ExecutionException, InterruptedException {
         ClickHouseClient client = ClickHouseClient.builder().build();
         Assert.assertNotNull(client);
-        ClickHouseRequest<?> req = client.connect(ClickHouseNode.builder().build());
+        ClickHouseRequest<?> req = client.read(ClickHouseNode.builder().build());
         Assert.assertNotNull(req);
         Assert.assertNull(req.config);
         Assert.assertNotNull(req.getConfig());
@@ -55,7 +55,7 @@ public class ClickHouseClientTest {
     public void testMutation() throws ExecutionException, InterruptedException {
         ClickHouseClient client = ClickHouseClient.builder().build();
         Assert.assertNotNull(client);
-        Mutation req = client.connect(ClickHouseNode.builder().build()).write();
+        Mutation req = client.read(ClickHouseNode.builder().build()).write();
         Assert.assertNotNull(req);
         Assert.assertNull(req.config);
         Assert.assertNotNull(req.getConfig());

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
@@ -148,7 +148,7 @@ public abstract class ClientIntegrationTest extends BaseIntegrationTest {
     }
 
     protected ClickHouseRequest<?> newRequest(ClickHouseClient client, ClickHouseNode server) {
-        ClickHouseRequest<?> request = client.connect(server);
+        ClickHouseRequest<?> request = client.read(server);
         Map<ClickHouseOption, Serializable> options = getClientOptions();
         if (options != null) {
             for (Entry<ClickHouseOption, Serializable> e : options.entrySet()) {

--- a/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcChannelFactory.java
+++ b/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcChannelFactory.java
@@ -9,6 +9,8 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+
+import com.clickhouse.client.config.ClickHouseProxyType;
 import com.google.gson.Gson;
 import com.google.gson.stream.JsonReader;
 import io.grpc.ManagedChannel;
@@ -193,6 +195,9 @@ public abstract class ClickHouseGrpcChannelFactory {
             builder.enableFullStreamDecompression();
         }
 
+        if (config.getProxyType() == ClickHouseProxyType.DIRECT) {
+            builder.proxyDetector(NoProxyDetector.INSTANCE);
+        }
         // TODO add interceptor to customize retry
         builder.maxInboundMessageSize(config.getIntOption(ClickHouseGrpcOption.MAX_INBOUND_MESSAGE_SIZE))
                 .maxInboundMetadataSize(config.getIntOption(ClickHouseGrpcOption.MAX_INBOUND_METADATA_SIZE));

--- a/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcChannelFactory.java
+++ b/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcChannelFactory.java
@@ -193,9 +193,6 @@ public abstract class ClickHouseGrpcChannelFactory {
             builder.enableFullStreamDecompression();
         }
 
-        if (config.isUseNoProxy()) {
-            builder.proxyDetector(NoProxyDetector.INSTANCE);
-        }
         // TODO add interceptor to customize retry
         builder.maxInboundMessageSize(config.getIntOption(ClickHouseGrpcOption.MAX_INBOUND_MESSAGE_SIZE))
                 .maxInboundMetadataSize(config.getIntOption(ClickHouseGrpcOption.MAX_INBOUND_METADATA_SIZE));

--- a/clickhouse-grpc-client/src/test/java/com/clickhouse/client/grpc/ClickHouseGrpcChannelFactoryTest.java
+++ b/clickhouse-grpc-client/src/test/java/com/clickhouse/client/grpc/ClickHouseGrpcChannelFactoryTest.java
@@ -14,7 +14,7 @@ public class ClickHouseGrpcChannelFactoryTest extends BaseIntegrationTest {
     public void testGetFactory() {
         ClickHouseNode server = getServer(ClickHouseProtocol.GRPC);
         try (ClickHouseClient client = ClickHouseClient.newInstance()) {
-            ClickHouseRequest<?> request = client.connect(server);
+            ClickHouseRequest<?> request = client.read(server);
             Assert.assertTrue(ClickHouseGrpcChannelFactory.getFactory(request.getConfig(),
                     server) instanceof NettyChannelFactoryImpl);
             Assert.assertTrue(ClickHouseGrpcChannelFactory.getFactory(

--- a/clickhouse-grpc-client/src/test/java/com/clickhouse/client/grpc/ClickHouseGrpcClientTest.java
+++ b/clickhouse-grpc-client/src/test/java/com/clickhouse/client/grpc/ClickHouseGrpcClientTest.java
@@ -96,7 +96,7 @@ public class ClickHouseGrpcClientTest extends ClientIntegrationTest {
         ClickHouseNode server = getServer();
 
         try (ClickHouseClient client = getClient();
-                ClickHouseResponse resp = client.connect(server)
+                ClickHouseResponse resp = client.read(server)
                         .option(ClickHouseClientOption.READ_BUFFER_SIZE, 8)
                         .format(ClickHouseFormat.TabSeparatedWithNamesAndTypes)
                         .query("select number, number+1 from numbers(100)").executeAndWait()) {

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
@@ -97,7 +97,7 @@ public class ApacheHttpConnectionImpl extends ClickHouseHttpConnection {
 
         HttpClientBuilder builder = HttpClientBuilder.create().setConnectionManager(connManager)
                 .disableContentCompression();
-        if (!c.isUseNoProxy() && c.getProxyType() == ClickHouseProxyType.HTTP) {
+        if (c.getProxyType() == ClickHouseProxyType.HTTP) {
             builder.setProxy(new HttpHost(c.getProxyHost(), c.getProxyPort()));
         }
         return builder.build();
@@ -377,7 +377,7 @@ public class ApacheHttpConnectionImpl extends ClickHouseHttpConnection {
             if (config.hasOption(ClickHouseClientOption.SOCKET_TCP_NODELAY)) {
                 builder.setTcpNoDelay(config.getBoolOption(ClickHouseClientOption.SOCKET_TCP_NODELAY));
             }
-            if (!config.isUseNoProxy() && config.getProxyType() == ClickHouseProxyType.SOCKS) {
+            if (config.getProxyType() == ClickHouseProxyType.SOCKS) {
                 builder.setSocksProxyAddress(new InetSocketAddress(config.getProxyHost(), config.getProxyPort()));
             }
             setDefaultSocketConfig(builder.build());

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpClient.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpClient.java
@@ -37,7 +37,7 @@ public class ClickHouseHttpClient extends AbstractClient<ClickHouseHttpConnectio
 
     @Override
     protected boolean checkHealth(ClickHouseNode server, int timeout) {
-        return getConnection(connect(server)).ping(timeout);
+        return getConnection(read(server)).ping(timeout);
     }
 
     @Override

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
@@ -243,8 +243,7 @@ public abstract class ClickHouseHttpConnection implements AutoCloseable {
     }
 
     protected static Proxy getProxy(ClickHouseConfig config) {
-        final ClickHouseProxyType proxyType = config.isUseNoProxy() ? ClickHouseProxyType.DIRECT
-                : config.getProxyType();
+        final ClickHouseProxyType proxyType = config.getProxyType();
 
         Proxy proxy;
         switch (proxyType) {

--- a/clickhouse-http-client/src/main/java11/com/clickhouse/client/http/HttpClientConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java11/com/clickhouse/client/http/HttpClientConnectionImpl.java
@@ -183,7 +183,7 @@ public class HttpClientConnectionImpl extends ClickHouseHttpConnection {
             builder.executor(executor);
         }
         ClickHouseProxyType proxyType = config.getProxyType();
-        if (config.isUseNoProxy() || proxyType == ClickHouseProxyType.DIRECT) {
+        if (proxyType == ClickHouseProxyType.DIRECT) {
             builder.proxy(NoProxySelector.INSTANCE);
         } else if (proxyType == ClickHouseProxyType.HTTP) {
             builder.proxy(ProxySelector.of(new InetSocketAddress(config.getProxyHost(), config.getProxyPort())));

--- a/clickhouse-http-client/src/test/java/com/clickhouse/client/http/ClickHouseHttpConnectionTest.java
+++ b/clickhouse-http-client/src/test/java/com/clickhouse/client/http/ClickHouseHttpConnectionTest.java
@@ -44,7 +44,7 @@ public class ClickHouseHttpConnectionTest {
     @Test(groups = { "unit" })
     public void testBuildUrl() {
         ClickHouseNode server = ClickHouseNode.builder().port(ClickHouseProtocol.HTTP).build();
-        ClickHouseRequest<?> request = ClickHouseClient.newInstance().connect(server);
+        ClickHouseRequest<?> request = ClickHouseClient.newInstance().read(server);
         ClickHouseNode s = request.getServer();
         Assert.assertEquals(ClickHouseHttpConnection.buildUrl(server.getBaseUri(), request),
                 "http://localhost:8123/?compress=1&extremes=0");
@@ -98,7 +98,7 @@ public class ClickHouseHttpConnectionTest {
     @Test(groups = { "unit" })
     public void testDefaultHeaders() {
         ClickHouseNode server = ClickHouseNode.builder().build();
-        ClickHouseRequest<?> request = ClickHouseClient.newInstance().connect(server);
+        ClickHouseRequest<?> request = ClickHouseClient.newInstance().read(server);
         SimpleHttpConnection sc = new SimpleHttpConnection(server, request);
         Assert.assertTrue(!sc.defaultHeaders.isEmpty());
         Assert.assertEquals(sc.defaultHeaders, sc.mergeHeaders(null));
@@ -111,7 +111,7 @@ public class ClickHouseHttpConnectionTest {
     @Test(groups = { "unit" })
     public void testGetBaseUrl() {
         ClickHouseNode server = ClickHouseNode.of("https://localhost/db1");
-        ClickHouseRequest<?> request = ClickHouseClient.newInstance().connect(server);
+        ClickHouseRequest<?> request = ClickHouseClient.newInstance().read(server);
         Assert.assertEquals(ClickHouseHttpConnection.buildUrl(server.getBaseUri(), request),
                 "https://localhost:8443/?compress=1&extremes=0");
         try (SimpleHttpConnection c = new SimpleHttpConnection(server, request)) {

--- a/clickhouse-http-client/src/test/java/com/clickhouse/client/http/DefaultHttpConnectionTest.java
+++ b/clickhouse-http-client/src/test/java/com/clickhouse/client/http/DefaultHttpConnectionTest.java
@@ -17,7 +17,7 @@ public class DefaultHttpConnectionTest extends BaseIntegrationTest {
         ClickHouseNode server = getServer(ClickHouseProtocol.HTTP);
 
         try (ClickHouseClient client = ClickHouseClient.newInstance()) {
-            ClickHouseRequest<?> req = client.connect(server);
+            ClickHouseRequest<?> req = client.read(server);
 
             ClickHouseHttpConnection conn = ClickHouseHttpConnectionFactory.createConnection(server, req, null);
             Assert.assertNotNull(conn);

--- a/clickhouse-r2dbc/src/main/java/com/clickhouse/r2dbc/connection/ClickHouseConnection.java
+++ b/clickhouse-r2dbc/src/main/java/com/clickhouse/r2dbc/connection/ClickHouseConnection.java
@@ -93,7 +93,7 @@ public class ClickHouseConnection implements Connection {
      */
     @Override
     public Batch createBatch() {
-        ClickHouseRequest<?> req = client.connect(node).option(ClickHouseClientOption.PRODUCT_NAME, PRODUCT_NAME);
+        ClickHouseRequest<?> req = client.read(node).option(ClickHouseClientOption.PRODUCT_NAME, PRODUCT_NAME);
         if (isHttp()) {
             req = req.set("send_progress_in_http_headers", 1);
         }
@@ -113,7 +113,7 @@ public class ClickHouseConnection implements Connection {
 
     @Override
     public Statement createStatement(String sql) {
-        ClickHouseRequest<?> req = client.connect(node).option(ClickHouseClientOption.PRODUCT_NAME, PRODUCT_NAME);
+        ClickHouseRequest<?> req = client.read(node).option(ClickHouseClientOption.PRODUCT_NAME, PRODUCT_NAME);
         if (isHttp()) {
             req = req.set("send_progress_in_http_headers", 1);
         }

--- a/clickhouse-r2dbc/src/main/java/com/clickhouse/r2dbc/connection/ClickHouseConnectionMetadata.java
+++ b/clickhouse-r2dbc/src/main/java/com/clickhouse/r2dbc/connection/ClickHouseConnectionMetadata.java
@@ -38,7 +38,7 @@ public class ClickHouseConnectionMetadata implements ConnectionMetadata {
         String version = serverVersion.get();
         if (version.isEmpty()) {
             // blocking here
-            try (ClickHouseResponse resp = client.connect(server).query("SELECT version()").executeAndWait()) {
+            try (ClickHouseResponse resp = client.read(server).query("SELECT version()").executeAndWait()) {
                 version = resp.firstRecord().getValue(0).asString();
                 if (!serverVersion.compareAndSet("", version)) {
                     return serverVersion.get();

--- a/examples/client/src/main/java/com/clickhouse/examples/jdbc/Main.java
+++ b/examples/client/src/main/java/com/clickhouse/examples/jdbc/Main.java
@@ -23,7 +23,7 @@ import com.clickhouse.data.format.BinaryStreamUtils;
 public class Main {
     static void dropAndCreateTable(ClickHouseNode server, String table) throws ClickHouseException {
         try (ClickHouseClient client = ClickHouseClient.newInstance(server.getProtocol())) {
-            ClickHouseRequest<?> request = client.read(server);
+            ClickHouseRequest<?> request = client.connect(server);
             // or use future chaining
             request.query("drop table if exists " + table).execute().get();
             request.query("create table " + table + "(a String, b Nullable(String)) engine=MergeTree() order by a")
@@ -38,7 +38,7 @@ public class Main {
 
     static long insert(ClickHouseNode server, String table) throws ClickHouseException {
         try (ClickHouseClient client = ClickHouseClient.newInstance(server.getProtocol())) {
-            ClickHouseRequest.Mutation request = client.read(server).write().table(table)
+            ClickHouseRequest.Mutation request = client.connect(server).write().table(table)
                     .format(ClickHouseFormat.RowBinary);
             ClickHouseConfig config = request.getConfig();
             CompletableFuture<ClickHouseResponse> future;

--- a/examples/client/src/main/java/com/clickhouse/examples/jdbc/Main.java
+++ b/examples/client/src/main/java/com/clickhouse/examples/jdbc/Main.java
@@ -23,7 +23,7 @@ import com.clickhouse.data.format.BinaryStreamUtils;
 public class Main {
     static void dropAndCreateTable(ClickHouseNode server, String table) throws ClickHouseException {
         try (ClickHouseClient client = ClickHouseClient.newInstance(server.getProtocol())) {
-            ClickHouseRequest<?> request = client.connect(server);
+            ClickHouseRequest<?> request = client.read(server);
             // or use future chaining
             request.query("drop table if exists " + table).execute().get();
             request.query("create table " + table + "(a String, b Nullable(String)) engine=MergeTree() order by a")
@@ -38,7 +38,7 @@ public class Main {
 
     static long insert(ClickHouseNode server, String table) throws ClickHouseException {
         try (ClickHouseClient client = ClickHouseClient.newInstance(server.getProtocol())) {
-            ClickHouseRequest.Mutation request = client.connect(server).write().table(table)
+            ClickHouseRequest.Mutation request = client.read(server).write().table(table)
                     .format(ClickHouseFormat.RowBinary);
             ClickHouseConfig config = request.getConfig();
             CompletableFuture<ClickHouseResponse> future;


### PR DESCRIPTION
## Summary
* remove deprecated API load, dump, and connect
* remove use_no_proxy settings

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
