### PR TITLE
Change default http client to apache http client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * Adding new proxy support [#1338](https://github.com/ClickHouse/clickhouse-java/issues/1338)
 * Add support for customer socket factory [#1391](https://github.com/ClickHouse/clickhouse-java/issues/1391)
 * use VarHandle in JDK 9+ to read/write numbers
+* Change default HTTP Client to Apache HTTP client [#1421](https://github.com/ClickHouse/clickhouse-java/issues/1421)
 
 ### Bug Fixes
 * Java client threw confusing error when query is invalid.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataConfig.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataConfig.java
@@ -134,7 +134,7 @@ public interface ClickHouseDataConfig extends Serializable {
 
     static final ClickHouseBufferingMode DEFAULT_BUFFERING_MODE = ClickHouseBufferingMode.RESOURCE_EFFICIENT;
 
-    static final int DEFAULT_BUFFER_SIZE = 4096;
+    static final int DEFAULT_BUFFER_SIZE = 8192;
     static final int DEFAULT_READ_BUFFER_SIZE = DEFAULT_BUFFER_SIZE;
     static final int DEFAULT_WRITE_BUFFER_SIZE = DEFAULT_BUFFER_SIZE;
     static final int DEFAULT_MAX_BUFFER_SIZE = 128 * 1024;

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
@@ -57,6 +57,7 @@ import java.net.ConnectException;
 import java.net.HttpURLConnection;
 import java.net.InetSocketAddress;
 import java.net.Socket;
+import java.net.StandardSocketOptions;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Map;
@@ -379,6 +380,22 @@ public class ApacheHttpConnectionImpl extends ClickHouseHttpConnection {
             }
             if (config.getProxyType() == ClickHouseProxyType.SOCKS) {
                 builder.setSocksProxyAddress(new InetSocketAddress(config.getProxyHost(), config.getProxyPort()));
+            }
+            if (config.hasOption(ClickHouseClientOption.SOCKET_RCVBUF)) {
+                int bufferSize = config.getIntOption(ClickHouseClientOption.SOCKET_RCVBUF);
+                builder.setRcvBufSize(bufferSize > 0 ? bufferSize : config.getReadBufferSize());
+            } else {
+                int bufferSize = config.getBufferSize();
+                int maxQueuedBuffers = config.getMaxQueuedBuffers();
+                builder.setRcvBufSize(bufferSize * maxQueuedBuffers);
+            }
+            if (config.hasOption(ClickHouseClientOption.SOCKET_SNDBUF)) {
+                int bufferSize = config.getIntOption(ClickHouseClientOption.SOCKET_SNDBUF);
+                builder.setSndBufSize(bufferSize > 0 ? bufferSize : config.getWriteBufferSize());
+            } else {
+                int bufferSize = config.getBufferSize();
+                int maxQueuedBuffers = config.getMaxQueuedBuffers();
+                builder.setSndBufSize(bufferSize * maxQueuedBuffers);
             }
             setDefaultSocketConfig(builder.build());
         }

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/ClickHouseHttpOption.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/ClickHouseHttpOption.java
@@ -12,8 +12,8 @@ public enum ClickHouseHttpOption implements ClickHouseOption {
     /**
      * HTTP connection provider.
      */
-    CONNECTION_PROVIDER("http_connection_provider", HttpConnectionProvider.HTTP_URL_CONNECTION,
-            "HTTP connection provider. HTTP_CLIENT is only supported in JDK 11 or above."),
+    CONNECTION_PROVIDER("http_connection_provider", HttpConnectionProvider.APACHE_HTTP_CLIENT,
+            "APACHE HTTP CLIENT connection provider. HTTP_CLIENT is only supported in JDK 11 or above."),
     /**
      * Custom HTTP headers.
      */


### PR DESCRIPTION
## Summary
Change default HTTP Client to Apache HTTP Client 
set automatically snd/rcv socket buffer 

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
