### PR TITLE
including back slf4j api for apache http

### DIFF
--- a/clickhouse-http-client/pom.xml
+++ b/clickhouse-http-client/pom.xml
@@ -45,10 +45,6 @@
                     <groupId>org.apache.httpcomponents.core5</groupId>
                     <artifactId>httpcore5</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
             </exclusions>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
The new default HTTP library (Apache HTTP) requires a slf4j dependency. Failing to provide this dependency will result in exceptions, leading the system to fall back to an alternative HTTP library.