### PR TITLE
DoubleValue update of inf str

### DIFF
--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseDoubleValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseDoubleValue.java
@@ -258,6 +258,12 @@ public class ClickHouseDoubleValue implements ClickHouseValue {
             resetToNullOrEmpty();
         } else if (value.isEmpty()) {
             resetToDefault();
+        } else if (value.equals("nan")) {
+            set(false, Double.NaN);
+        } else if (value.equals("+inf") || value.equals("inf")) {
+            set(false, Double.POSITIVE_INFINITY);
+        } else if (value.equals("-inf")) {
+            set(false, Double.NEGATIVE_INFINITY);
         } else {
             set(false, Double.parseDouble(value));
         }


### PR DESCRIPTION
## Summary
When SQL is formatted using the `FORMAT TabSeparatedWithNamesAndTypes` in ClickHouse
the `ClickHouseTabSeparatedProcessor` will `update` the value as a `String`. In this case, if the double type is `inf, -inf, or nan`, it will not be able to be parsed.

for example
![image](https://github.com/ClickHouse/clickhouse-java/assets/67011523/a9cd9f23-058e-4075-a965-403a754a7dee)

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
