### PR TITLE
ClickHouseDatabaseMetaData.getTables dont ignoreError

### DIFF
--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDatabaseMetaData.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDatabaseMetaData.java
@@ -785,7 +785,7 @@ public class ClickHouseDatabaseMetaData extends JdbcWrapper implements DatabaseM
                             + "from system.tables t inner join system.databases d on t.database = d.name\n"
                             + "where t.database like :database and t.name like :table and TABLE_TYPE in (:types) "
                             + "order by t.database, t.name", params);
-            results.add(query(sql, true));
+            results.add(query(sql));
         }
         return new CombinedResultSet(results);
     }


### PR DESCRIPTION
because getTables method is very commonly used. Just for me, I don't import org.lz4:lz4-java:1.8.0 but because ClickHouseDatabaseMetaData.getTables ignore error, I debug for a long time.
