### PR TITLE
Fix faulty node detection in ClickHouseNodes

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseClient.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseClient.java
@@ -17,6 +17,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 
 import com.clickhouse.client.ClickHouseRequest.Mutation;
@@ -945,7 +946,9 @@ public interface ClickHouseClient extends AutoCloseable {
             if (server.getProtocol() == ClickHouseProtocol.ANY) {
                 server = ClickHouseNode.probe(server.getHost(), server.getPort(), timeout);
             }
-            try (ClickHouseResponse resp = read(server) // create request
+            // Request to this specific ClickHouse node
+            ClickHouseRequest<?> request = new ClickHouseRequest<>(this, server, new AtomicReference<>(server), server.config.getAllOptions(), false);
+            try (ClickHouseResponse resp = request
                     .option(ClickHouseClientOption.ASYNC, false) // use current thread
                     .option(ClickHouseClientOption.CONNECTION_TIMEOUT, timeout)
                     .option(ClickHouseClientOption.SOCKET_TIMEOUT, timeout)

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseNodesTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseNodesTest.java
@@ -526,4 +526,17 @@ public class ClickHouseNodesTest {
             Assert.assertEquals(nodes.faultyNodes.size(), 0);
         }
     }
+
+    @Test(groups = { "unit" })
+    public void testHealthCheck() {
+        Map<String, String> options = new HashMap<>();
+        options.put(ClickHouseClientOption.CHECK_ALL_NODES.getKey(), "true");
+        ClickHouseNodes nodes = ClickHouseNodes.of("http://a,http://b", options);
+        Assert.assertEquals(nodes.nodes.size(), 2);
+        Assert.assertEquals(nodes.faultyNodes.size(), 0);
+
+        nodes.check();
+        Assert.assertEquals(nodes.nodes.size(), 0);
+        Assert.assertEquals(nodes.faultyNodes.size(), 2);
+    }
 }

--- a/clickhouse-http-client/src/test/java/com/clickhouse/client/http/ClickHouseHttpClientTest.java
+++ b/clickhouse-http-client/src/test/java/com/clickhouse/client/http/ClickHouseHttpClientTest.java
@@ -9,6 +9,8 @@ import com.clickhouse.client.ClickHouseConfig;
 import com.clickhouse.client.ClickHouseCredentials;
 import com.clickhouse.client.ClickHouseException;
 import com.clickhouse.client.ClickHouseNode;
+import com.clickhouse.client.ClickHouseNode.Status;
+import com.clickhouse.client.ClickHouseNodes;
 import com.clickhouse.client.ClickHouseNodeSelector;
 import com.clickhouse.client.ClickHouseParameterizedQuery;
 import com.clickhouse.client.ClickHouseProtocol;
@@ -213,6 +215,15 @@ public class ClickHouseHttpClientTest extends ClientIntegrationTest {
         try (ClickHouseClient client = ClickHouseClient.builder().options(getClientOptions())
                 .nodeSelector(ClickHouseNodeSelector.of(ClickHouseProtocol.HTTP)).build()) {
             Assert.assertTrue(client.ping(getServer(), 3000));
+        }
+
+        try (ClickHouseClient client = ClickHouseClient.builder().options(getClientOptions())
+                .nodeSelector(ClickHouseNodeSelector.of(ClickHouseProtocol.HTTP)).build()) {
+            ClickHouseNodes nodes = ClickHouseNodes.of("http://notthere," + getServer().getBaseUri());
+            ClickHouseNode nonExistingNode = nodes.getNodes().get(0);
+            nodes.update(nonExistingNode, Status.FAULTY);
+
+            Assert.assertFalse(client.ping(nonExistingNode, 3000));
         }
     }
 


### PR DESCRIPTION
## Summary
Fixes two bugs in how `ClickHouseNodes.check()` detects faulty nodes:

1. `ClickHouseNodes.check()` uses `ClickHouseClient.ping` to figure out if a node is up and running. The `ping` method uses `ClickHouseClient.read(ClickHouseNode)`. Before this fix it wasn't always querying the specified node, but could query any available nodes.
2. Healthy nodes weren't marked as faulty because of an incorrect condition.

Fixes https://github.com/ClickHouse/clickhouse-java/issues/1502.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
