### PR TITLE
Deprecation of ClickHouse GRPC Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 ### WARNING -- ClickHouse CLI Client deprecation
 `clickhouse-cli-client` package is deprecated from version 0.6.0 and it's going to be removed in `0.7.0`. We recommend using [clickhouse-client](https://clickhouse.com/docs/en/interfaces/cli) instead. 
 
+### WARNING -- ClickHouse GRPC Client deprecation
+`clickhouse-grpc-client` package is deprecated from version 0.6.0 and it's going to be removed in `0.7.0`. We recommend using [HTTP](https://github.com/ClickHouse/clickhouse-java/blob/main/examples/client/src/main/java/com/clickhouse/examples/jdbc/Main.java) protocol instead.
+
 ## 0.5.0
 ### Breaking Changes
 * ClickHouseByteBuffer can no longer be extended

--- a/README.md
+++ b/README.md
@@ -9,12 +9,12 @@ Java libraries for connecting to ClickHouse and processing data in various forma
 ## Features
 
 | Category          | Feature                                                                             | Supported          | Remark                                                                                                                                                                                                                   |
-| ----------------- | ----------------------------------------------------------------------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| ----------------- | ----------------------------------------------------------------------------------- | ------------------ |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | API               | [JDBC](https://docs.oracle.com/javase/8/docs/technotes/guides/jdbc/)                | :white_check_mark: |                                                                                                                                                                                                                          |
 |                   | [R2DBC](https://r2dbc.io/)                                                          | :white_check_mark: | supported since 0.4.0                                                                                                                                                                                                    |
 | Protocol          | [HTTP](https://clickhouse.com/docs/en/interfaces/http/)                             | :white_check_mark: | recommended, defaults to `java.net.HttpURLConnection` and it can be changed to `java.net.http.HttpClient`(unstable) or `Apache HTTP Client 5`. Note that the latter was added in 0.4.0 to support custom socket options. |
-|                   | [gRPC](https://clickhouse.com/docs/en/interfaces/grpc/)                             | :white_check_mark: | :warning: experimental, works with 22.3+, known to has issue with lz4 compression and may cause high memory usage on server                                                                                              |
-|                   | [TCP/Native](https://clickhouse.com/docs/en/interfaces/tcp/)                        | :x: | `clickhouse-cli-client`(wrapper of ClickHouse native command-line client) was added in 0.3.2-patch10.                                                                     |
+|                   | [gRPC](https://clickhouse.com/docs/en/interfaces/grpc/)                             | :white_check_mark: | :warning: experimental, works with 22.3+, known to has issue with lz4 compression and may cause high memory usage on server. Planed to be removed from version 0.7.0                                                     |
+|                   | [TCP/Native](https://clickhouse.com/docs/en/interfaces/tcp/)                        | :x: | `clickhouse-cli-client`(wrapper of ClickHouse native command-line client) was added in 0.3.2-patch10.                                                                                                                    |
 |                   | [Local/File](https://clickhouse.com/docs/en/operations/utilities/clickhouse-local/) | :x:                | `clickhouse-cli-client` will be enhanced to support `clickhouse-local`                                                                                                                                                   |
 | Compatibility     | Server < 20.7                                                                       | :x:                | use 0.3.1-patch(or 0.2.6 if you're stuck with JDK 7)                                                                                                                                                                     |
 |                   | Server >= 20.7                                                                      | :white_check_mark: | use 0.3.2 or above. All [active releases](https://github.com/ClickHouse/ClickHouse/pulls?q=is%3Aopen+is%3Apr+label%3Arelease) are supported.                                                                             |
@@ -51,10 +51,10 @@ Java libraries for connecting to ClickHouse and processing data in various forma
 
 ## Planed to be removed
 
-| Feature                        | Version | Remark                                 |
-|--------------------------------|---------|----------------------------------------|
-| Clickhouse ClI Client package  | 0.7.0   | Use clickhouse-client directly instead | 
-
+| Feature                        | Version | Remark                                           |
+|--------------------------------|---------|--------------------------------------------------|
+| Clickhouse ClI Client package  | 0.7.0   | Use clickhouse-client directly instead           | 
+| ClickHouse GRPC Client package | 0.7.0   | Please use the clickhouse http protocol instead  |
 ## Usage
 
 The library can be downloaded from both [Github Releases](../../releases) and [Maven Central](https://repo1.maven.org/maven2/com/clickhouse/). Development snapshots(aka. nightly build) are available on [Sonatype OSSRH](https://s01.oss.sonatype.org/content/repositories/snapshots/com/clickhouse/).

--- a/clickhouse-grpc-client/pom.xml
+++ b/clickhouse-grpc-client/pom.xml
@@ -13,7 +13,7 @@
     <packaging>jar</packaging>
 
     <name>ClickHouse gRPC Client</name>
-    <description>gRPC client for ClickHouse</description>
+    <description>gRPC client for ClickHouse planed to be deprecated from version 0.6.0 and removed at 0.7.0</description>
     <url>https://github.com/ClickHouse/clickhouse-java/tree/main/clickhouse-grpc-client</url>
 
     <dependencies>

--- a/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcChannelFactory.java
+++ b/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcChannelFactory.java
@@ -27,7 +27,7 @@ import com.clickhouse.data.ClickHouseChecker;
 import com.clickhouse.data.ClickHouseUtils;
 import com.clickhouse.logging.Logger;
 import com.clickhouse.logging.LoggerFactory;
-
+@Deprecated
 public abstract class ClickHouseGrpcChannelFactory {
     static class NoProxyDetector implements ProxyDetector {
         static final NoProxyDetector INSTANCE = new NoProxyDetector();

--- a/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcClient.java
+++ b/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcClient.java
@@ -12,7 +12,7 @@ import com.clickhouse.client.ClickHouseResponse;
 import com.clickhouse.client.UnsupportedProtocolException;
 import com.clickhouse.client.grpc.config.ClickHouseGrpcOption;
 import com.clickhouse.config.ClickHouseOption;
-
+@Deprecated
 public class ClickHouseGrpcClient implements ClickHouseClient {
     private final AtomicReference<ClickHouseClient> ref;
 

--- a/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcClientImpl.java
+++ b/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcClientImpl.java
@@ -47,7 +47,7 @@ import com.clickhouse.data.ClickHousePipedOutputStream;
 import com.clickhouse.data.ClickHouseUtils;
 import com.clickhouse.logging.Logger;
 import com.clickhouse.logging.LoggerFactory;
-
+@Deprecated
 public class ClickHouseGrpcClientImpl extends AbstractClient<ManagedChannel> {
     private static final Logger log = LoggerFactory.getLogger(ClickHouseGrpcClientImpl.class);
 

--- a/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcResponse.java
+++ b/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcResponse.java
@@ -14,7 +14,7 @@ import com.clickhouse.client.grpc.impl.Progress;
 import com.clickhouse.client.grpc.impl.Result;
 import com.clickhouse.client.grpc.impl.Stats;
 import com.clickhouse.data.ClickHouseInputStream;
-
+@Deprecated
 public class ClickHouseGrpcResponse extends ClickHouseStreamResponse {
     private final transient ClickHouseStreamObserver observer;
 

--- a/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseStreamObserver.java
+++ b/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseStreamObserver.java
@@ -28,7 +28,7 @@ import com.clickhouse.data.ClickHousePipedOutputStream;
 import com.clickhouse.data.ClickHouseUtils;
 import com.clickhouse.logging.Logger;
 import com.clickhouse.logging.LoggerFactory;
-
+@Deprecated
 public class ClickHouseStreamObserver implements StreamObserver<Result> {
     private static final Logger log = LoggerFactory.getLogger(ClickHouseStreamObserver.class);
 

--- a/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/FramedLZ4Utils.java
+++ b/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/FramedLZ4Utils.java
@@ -3,7 +3,7 @@ package com.clickhouse.client.grpc;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-
+@Deprecated
 final class FramedLZ4Utils {
     static InputStream wrap(InputStream input) throws IOException {
         return new org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorInputStream(input);

--- a/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/NettyChannelFactoryImpl.java
+++ b/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/NettyChannelFactoryImpl.java
@@ -18,7 +18,7 @@ import com.clickhouse.client.config.ClickHouseSslMode;
 import com.clickhouse.client.grpc.config.ClickHouseGrpcOption;
 import com.clickhouse.data.ClickHouseChecker;
 import com.clickhouse.data.ClickHouseUtils;
-
+@Deprecated
 final class NettyChannelFactoryImpl extends ClickHouseGrpcChannelFactory {
     private static final String USER_AGENT = ClickHouseClientOption.buildUserAgent(null, "gRPC-Netty");
 

--- a/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/OkHttpChannelFactoryImpl.java
+++ b/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/OkHttpChannelFactoryImpl.java
@@ -11,7 +11,7 @@ import com.clickhouse.client.ClickHouseNode;
 import com.clickhouse.client.ClickHouseSslContextProvider;
 import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.client.grpc.config.ClickHouseGrpcOption;
-
+@Deprecated
 final class OkHttpChannelFactoryImpl extends ClickHouseGrpcChannelFactory {
     private static final String USER_AGENT = ClickHouseClientOption.buildUserAgent(null, "gRPC-OkHttp");
 

--- a/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/config/ClickHouseGrpcOption.java
+++ b/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/config/ClickHouseGrpcOption.java
@@ -8,6 +8,7 @@ import com.clickhouse.data.ClickHouseChecker;
 /**
  * gRPC client options.
  */
+@Deprecated
 public enum ClickHouseGrpcOption implements ClickHouseOption {
     /**
      * Flow control window.

--- a/clickhouse-grpc-client/src/test/java/com/clickhouse/client/grpc/ClickHouseGrpcChannelFactoryTest.java
+++ b/clickhouse-grpc-client/src/test/java/com/clickhouse/client/grpc/ClickHouseGrpcChannelFactoryTest.java
@@ -8,7 +8,7 @@ import com.clickhouse.client.ClickHouseNode;
 import com.clickhouse.client.ClickHouseProtocol;
 import com.clickhouse.client.ClickHouseRequest;
 import com.clickhouse.client.grpc.config.ClickHouseGrpcOption;
-
+@Deprecated
 public class ClickHouseGrpcChannelFactoryTest extends BaseIntegrationTest {
     @Test(groups = { "integration" })
     public void testGetFactory() {

--- a/clickhouse-grpc-client/src/test/java/com/clickhouse/client/grpc/ClickHouseGrpcClientTest.java
+++ b/clickhouse-grpc-client/src/test/java/com/clickhouse/client/grpc/ClickHouseGrpcClientTest.java
@@ -23,7 +23,7 @@ import com.clickhouse.data.ClickHouseFormat;
 import com.clickhouse.data.ClickHouseInputStream;
 import com.clickhouse.data.ClickHouseRecord;
 import com.clickhouse.data.ClickHouseVersion;
-
+@Deprecated
 public class ClickHouseGrpcClientTest extends ClientIntegrationTest {
     @DataProvider(name = "requestCompressionMatrix")
     @Override


### PR DESCRIPTION
## Summary
Deprecation of ClickHouse GRPC Client

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
