### PR TITLE
fix response close for getRowsUpdated(#1538)

### DIFF
--- a/clickhouse-r2dbc/src/main/java/com/clickhouse/r2dbc/ClickHouseResult.java
+++ b/clickhouse-r2dbc/src/main/java/com/clickhouse/r2dbc/ClickHouseResult.java
@@ -31,10 +31,18 @@ public class ClickHouseResult implements Result {
                                 .map(rec -> ClickHousePair.of(resp.getColumns(), rec))))
                     .map(pair -> new ClickHouseRow(pair.getRight(), pair.getLeft()))
                 .map(RowSegment::new);
-        this.updatedCount =  Mono.just(response).map(ClickHouseResponse::getSummary)
-                .map(ClickHouseResponseSummary::getProgress)
-                .map(ClickHouseResponseSummary.Progress::getWrittenRows)
-                .map(UpdateCount::new);
+
+        this.updatedCount = Mono.using(() -> response,
+                resp -> Mono.just(response).map(ClickHouseResponse::getSummary)
+                        .map(ClickHouseResponseSummary::getProgress)
+                        .map(ClickHouseResponseSummary.Progress::getWrittenRows)
+                        .map(UpdateCount::new),
+                resp -> {
+                    if (!resp.isClosed()) {
+                        resp.close();
+                    }
+                });
+
         this.segments = Flux.concat(this.updatedCount, this.rowSegments);
     }
 

--- a/clickhouse-r2dbc/src/main/java/com/clickhouse/r2dbc/ClickHouseResult091.java
+++ b/clickhouse-r2dbc/src/main/java/com/clickhouse/r2dbc/ClickHouseResult091.java
@@ -31,10 +31,16 @@ class ClickHouseResult implements Result {
                                 .map(rec -> ClickHousePair.of(resp.getColumns(), rec))))
                     .map(pair -> new ClickHouseRow(pair.getRight(), pair.getLeft()))
                 .map(RowSegment::new);
-        this.updatedCount =  Mono.just(response).map(ClickHouseResponse::getSummary)
-                .map(ClickHouseResponseSummary::getProgress)
-                .map(ClickHouseResponseSummary.Progress::getWrittenRows)
-                .map(UpdateCount::new);
+        this.updatedCount = Mono.using(() -> response,
+                resp -> Mono.just(response).map(ClickHouseResponse::getSummary)
+                        .map(ClickHouseResponseSummary::getProgress)
+                        .map(ClickHouseResponseSummary.Progress::getWrittenRows)
+                        .map(UpdateCount::new),
+                resp -> {
+                    if (!resp.isClosed()) {
+                        resp.close();
+                    }
+                });
         this.segments = Flux.concat(this.updatedCount, this.rowSegments);
     }
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Mono resource manager for updateCount close the response when complete

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
