### PR TITLE
Add client address to http referer by default

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java
@@ -420,7 +420,15 @@ public enum ClickHouseClientOption implements ClickHouseOption {
      * false.
      */
     USE_TIME_ZONE("use_time_zone", "", "Time zone of all DateTime* values. "
-            + "Only used when use_server_time_zone is false. Empty value means client time zone.");
+            + "Only used when use_server_time_zone is false. Empty value means client time zone."),
+    SEND_CLIENT_ADDRESS("send_client_address", true, "Sending client address to ClickHouse server. "
+            + "If true, client address will be sent by http_referer for http protocol or client_hostname for native protocol. "
+            + "you can get it in system.query_log table."),
+    /**
+     * Used only when SEND_CLIENT_ADDRESS is enabled, to specify the client address(ip) or hostname.
+     */
+    PREFER_HOST_NAME_TO_SEND("prefer_host_name_to_send", false, "Used only when SEND_CLIENT_ADDRESS "
+            + "is enabled, to specify the client address(ip) or hostname.");
 
     private final String key;
     private final Serializable defaultValue;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java
@@ -420,15 +420,7 @@ public enum ClickHouseClientOption implements ClickHouseOption {
      * false.
      */
     USE_TIME_ZONE("use_time_zone", "", "Time zone of all DateTime* values. "
-            + "Only used when use_server_time_zone is false. Empty value means client time zone."),
-    SEND_CLIENT_ADDRESS("send_client_address", true, "Sending client address to ClickHouse server. "
-            + "If true, client address will be sent by http_referer for http protocol or client_hostname for native protocol. "
-            + "you can get it in system.query_log table."),
-    /**
-     * Used only when SEND_CLIENT_ADDRESS is enabled, to specify the client address(ip) or hostname.
-     */
-    PREFER_HOST_NAME_TO_SEND("prefer_host_name_to_send", false, "Used only when SEND_CLIENT_ADDRESS "
-            + "is enabled, to specify the client address(ip) or hostname.");
+            + "Only used when use_server_time_zone is false. Empty value means client time zone.");
 
     private final String key;
     private final Serializable defaultValue;

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/ClickHouseHttpOption.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/ClickHouseHttpOption.java
@@ -42,7 +42,17 @@ public enum ClickHouseHttpOption implements ClickHouseOption {
      * headers.
      */
     RECEIVE_QUERY_PROGRESS("receive_query_progress", true,
-            "Whether to receive information about the progress of a query in response headers.");
+            "Whether to receive information about the progress of a query in response headers."),
+    /**
+     * Indicates whether http client would send its identification through Referer header to server.
+     * Valid values:
+     *      1. empty string - nothing is sent
+     *      2. IP_ADDRESS - client's IP address is used
+     *      3. HOST_NAME - host name is used
+     */
+    SEND_HTTP_CLIENT_ID("send_http_client_id", "", "Indicates whether http client would send its identification through Referer header to server. " +
+            "Valid values: empty string - nothing is sent. IP_ADDRESS - client's IP address is used. HOST_NAME - host name is used.");
+
     // SEND_PROGRESS("send_progress_in_http_headers", false,
     // "Enables or disables X-ClickHouse-Progress HTTP response headers in
     // clickhouse-server responses."),

--- a/clickhouse-http-client/src/test/java/com/clickhouse/client/http/ClickHouseHttpClientTest.java
+++ b/clickhouse-http-client/src/test/java/com/clickhouse/client/http/ClickHouseHttpClientTest.java
@@ -535,4 +535,24 @@ public class ClickHouseHttpClientTest extends ClientIntegrationTest {
         }
 
     }
+
+    @Test(groups = {"integration"})
+    public void testLongHttpHeaderReferer() throws ClickHouseException {
+        super.testMutation();
+
+        StringBuilder referer = new StringBuilder();
+        for (int i = 0; i < 100; i++) {
+            referer.append(i);
+        }
+        ClickHouseNode server = getServer();
+        try (ClickHouseClient client = getClient();
+             ClickHouseResponse response = newRequest(client, server)
+                     .option(ClickHouseHttpOption.CUSTOM_HEADERS, "Referer=" + referer)
+                     .set("send_progress_in_http_headers", 1)
+                     .query("select 1")
+                     .executeAndWait()) {
+            ClickHouseResponseSummary summary = response.getSummary();
+            Assert.assertEquals(summary.getReadRows(), 1L);
+        }
+    }
 }

--- a/clickhouse-http-client/src/test/java/com/clickhouse/client/http/ClickHouseHttpConnectionTest.java
+++ b/clickhouse-http-client/src/test/java/com/clickhouse/client/http/ClickHouseHttpConnectionTest.java
@@ -73,4 +73,27 @@ public class ClickHouseHttpConnectionTest {
             Assert.assertEquals(c.getBaseUrl(), "https://localhost:8443/");
         }
     }
+
+    @Test(groups = { "unit" })
+    public void testReferer() {
+
+        ClickHouseNode server = ClickHouseNode.of("https://localhost/db1");
+        ClickHouseRequest<?> request = ClickHouseClient.newInstance().read(server);
+
+        try (SimpleHttpConnection sc = new SimpleHttpConnection(server, request)) {
+            Assert.assertFalse(sc.defaultHeaders.containsKey("referer"));
+        }
+
+        request.option(ClickHouseHttpOption.SEND_HTTP_CLIENT_ID, "IP_ADDRESS");
+        try (SimpleHttpConnection sc = new SimpleHttpConnection(server, request)) {
+            Assert.assertTrue(sc.defaultHeaders.containsKey("referer"));
+            Assert.assertEquals(ClickHouseHttpClient.LOCAL_HOST.address, sc.defaultHeaders.get("referer"));
+        }
+
+        request.option(ClickHouseHttpOption.SEND_HTTP_CLIENT_ID, "HOST_NAME");
+        try (SimpleHttpConnection sc = new SimpleHttpConnection(server, request)) {
+            Assert.assertTrue(sc.defaultHeaders.containsKey("referer"));
+            Assert.assertEquals(ClickHouseHttpClient.LOCAL_HOST.hostName, sc.defaultHeaders.get("referer"));
+        }
+    }
 }


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

- Add client address to http referer by default

Send a request to ClickHouse with default settings and We will get client address in ClickHouse `system.query_log`

```
Row 1:
──────
query:           select * from system.numbers limit 53
client_hostname:
client_name:
http_referer:    10.211.42.53
http_user_agent: ClickHouse-JdbcDriver/0.6.0-SNAPSHOT (Linux/5.4.0-53-generic; OpenJDK 64-Bit Server VM/17.0.10+7-Ubuntu-120.04.1; HttpURLConnection; rv:be06439)
```

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
