### PR TITLE
Add error code extraction if errorMsg is empty.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
-## 0.6.1
+## 0.6.0-patch-3
+
+### Bug Fixes
+- Not detecting correctly ClickHouse error code
+- 
+## 0.6.0-patch-2
+
+### Dependency Updates
+- org.apache.commons:commons-compress from 1.23.0 to 1.26.1
+- org.postgresql:postgresql from 42.6.0 to 42.6.1
+- 
+## 0.6.0-patch-1
 
 ### Bug Fixes
 - Fix buffering issue caused by decompress flag not to work when working with HTTP Client.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,15 @@
-## 0.6.0-patch-3
+## 0.6.0-patch3
 
 ### Bug Fixes
 - Not detecting correctly ClickHouse error code
 - 
-## 0.6.0-patch-2
+## 0.6.0-patch2
 
 ### Dependency Updates
 - org.apache.commons:commons-compress from 1.23.0 to 1.26.1
 - org.postgresql:postgresql from 42.6.0 to 42.6.1
 - 
-## 0.6.0-patch-1
+## 0.6.0-patch1
 
 ### Bug Fixes
 - Fix buffering issue caused by decompress flag not to work when working with HTTP Client.

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
@@ -206,6 +206,17 @@ public class ApacheHttpConnectionImpl extends ClickHouseHttpConnection {
             errorMsg = parseErrorFromException(errorCode != null ? errorCode.getValue() : null,
                     serverName != null ? serverName.getValue() : null, e, bytes);
         }
+        if (errorMsg != null && errorMsg.isEmpty()) {
+            // if we have both errorCode and serverName, we can wrap them into the exception message ????
+            if (errorCode != null && serverName != null ) {
+                String errorCodeValue = errorCode.getValue();
+                String serverNameValue = serverName.getValue();
+                if (errorCodeValue != null && serverNameValue != null) {
+                    throw new IOException(
+                            ClickHouseUtils.format("Code: %s, server: %s, %s", errorCodeValue, serverNameValue, response.toString()));
+                }
+            }
+        }
         throw new IOException(errorMsg);
     }
 


### PR DESCRIPTION
## Summary
Add error code extraction if errorMsg is empty.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
