### PR TITLE
wrappend req execution. added test

### DIFF
--- a/clickhouse-http-client/pom.xml
+++ b/clickhouse-http-client/pom.xml
@@ -103,6 +103,13 @@
             <artifactId>testng</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>3.5.2</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
@@ -3,6 +3,7 @@ package com.clickhouse.client.http;
 import com.clickhouse.client.AbstractSocketClient;
 import com.clickhouse.client.ClickHouseClient;
 import com.clickhouse.client.ClickHouseConfig;
+import com.clickhouse.client.ClickHouseException;
 import com.clickhouse.client.ClickHouseNode;
 import com.clickhouse.client.ClickHouseRequest;
 import com.clickhouse.client.ClickHouseSocketFactory;
@@ -249,7 +250,12 @@ public class ApacheHttpConnectionImpl extends ClickHouseHttpConnection {
         ClickHouseHttpEntity postBody = new ClickHouseHttpEntity(config, contentType, contentEncoding, boundary,
                 sql, data, tables);
         post.setEntity(postBody);
-        CloseableHttpResponse response = client.execute(post);
+        CloseableHttpResponse response;
+        try {
+            response = client.execute(post);
+        } catch (IOException e) {
+            throw new ConnectException(ClickHouseUtils.format("HTTP request failed: %s", post));
+        }
 
         checkResponse(config, response);
         // buildResponse should use the config of current request in case of reusable


### PR DESCRIPTION
## Summary
Wrapped request execution code with try-catch to catch `com.github.dockerjava.zerodep.shaded.org.apache.hc.core5.http.NoHttpResponseException`

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
