### PR TITLE
Fix failover for Apache HTTP client. Connect timeout error is not detected correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 - Change RowBinaryWithDefaults settings. Output is changed from true to false
+- Fix failover for Apache HTTP client. Connect timout error is not detected correctly
 
 ## 0.6.0-patch3
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Bug Fixes
 - Change RowBinaryWithDefaults settings. Output is changed from true to false
-- Fix failover for Apache HTTP client. Connect timout error is not detected correctly
+- Fix failover for Apache HTTP client. Connect timeout error is not detected correctly
 
 ## 0.6.0-patch3
 

--- a/clickhouse-cli-client/src/test/java/com/clickhouse/client/cli/ClickHouseCommandLineClientTest.java
+++ b/clickhouse-cli-client/src/test/java/com/clickhouse/client/cli/ClickHouseCommandLineClientTest.java
@@ -3,22 +3,21 @@ package com.clickhouse.client.cli;
 import com.clickhouse.client.ClickHouseClient;
 import com.clickhouse.client.ClickHouseClientBuilder;
 import com.clickhouse.client.ClickHouseException;
+import com.clickhouse.client.ClickHouseLoadBalancingPolicy;
 import com.clickhouse.client.ClickHouseNode;
 import com.clickhouse.client.ClickHouseProtocol;
 import com.clickhouse.client.ClickHouseServerForTest;
 import com.clickhouse.client.ClientIntegrationTest;
 import com.clickhouse.client.cli.config.ClickHouseCommandLineOption;
 import com.clickhouse.data.ClickHouseCompression;
-
-import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-
 import org.testcontainers.containers.GenericContainer;
-import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 // deprecate from version 0.6.0
 @Deprecated
 public class ClickHouseCommandLineClientTest extends ClientIntegrationTest {
@@ -189,5 +188,15 @@ public class ClickHouseCommandLineClientTest extends ClientIntegrationTest {
     @Override
     public void testRowBinaryWithDefaults() throws ClickHouseException, IOException, ExecutionException, InterruptedException {
         throw new SkipException("Skip due to supported");
+    }
+
+    @Test(dataProvider = "loadBalancingPolicies", groups = {"unit"})
+    public void testLoadBalancingPolicyFailover(ClickHouseLoadBalancingPolicy loadBalancingPolicy) {
+        throw new SkipException("Skip due to failover is not supported");
+    }
+
+    @Test(groups = {"integration"})
+    public void testFailover() {
+        throw new SkipException("Skip due to failover is not supported");
     }
 }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseException.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseException.java
@@ -3,7 +3,6 @@ package com.clickhouse.client;
 import java.net.ConnectException;
 import java.net.SocketTimeoutException;
 import java.net.UnknownHostException;
-import java.util.Locale;
 import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -119,10 +118,7 @@ public class ClickHouseException extends Exception {
     public static boolean isConnectTimedOut(Throwable t) {
         if (t instanceof SocketTimeoutException || t instanceof TimeoutException) {
             String msg = t.getMessage();
-            if (msg != null && msg.length() >= MSG_CONNECT_TIMED_OUT.length()) {
-                msg = msg.substring(0, MSG_CONNECT_TIMED_OUT.length()).toLowerCase(Locale.ROOT);
-            }
-            return MSG_CONNECT_TIMED_OUT.equals(msg);
+            return msg != null && msg.toLowerCase().contains(MSG_CONNECT_TIMED_OUT);
         }
 
         return false;

--- a/clickhouse-grpc-client/src/test/java/com/clickhouse/client/grpc/ClickHouseGrpcClientTest.java
+++ b/clickhouse-grpc-client/src/test/java/com/clickhouse/client/grpc/ClickHouseGrpcClientTest.java
@@ -1,17 +1,8 @@
 package com.clickhouse.client.grpc;
 
-import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorInputStream;
-import org.testng.Assert;
-import org.testng.SkipException;
-import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.util.concurrent.ExecutionException;
-
 import com.clickhouse.client.ClickHouseClient;
 import com.clickhouse.client.ClickHouseException;
+import com.clickhouse.client.ClickHouseLoadBalancingPolicy;
 import com.clickhouse.client.ClickHouseNode;
 import com.clickhouse.client.ClickHouseProtocol;
 import com.clickhouse.client.ClickHouseResponse;
@@ -23,6 +14,15 @@ import com.clickhouse.data.ClickHouseFormat;
 import com.clickhouse.data.ClickHouseInputStream;
 import com.clickhouse.data.ClickHouseRecord;
 import com.clickhouse.data.ClickHouseVersion;
+import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorInputStream;
+import org.testng.Assert;
+import org.testng.SkipException;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
 @Deprecated
 public class ClickHouseGrpcClientTest extends ClientIntegrationTest {
     @DataProvider(name = "requestCompressionMatrix")
@@ -144,7 +144,7 @@ public class ClickHouseGrpcClientTest extends ClientIntegrationTest {
     public void testErrorDuringQuery() throws ClickHouseException {
         throw new SkipException("Skip due to grpc is too slow");
     }
-    
+
     @Test(groups = { "integration" })
     @Override
     public void testSessionLock() {
@@ -205,4 +205,13 @@ public class ClickHouseGrpcClientTest extends ClientIntegrationTest {
         throw new SkipException("Skip due to supported");
     }
 
+    @Test(dataProvider = "loadBalancingPolicies", groups = {"unit"})
+    public void testLoadBalancingPolicyFailover(ClickHouseLoadBalancingPolicy loadBalancingPolicy) {
+        throw new SkipException("Skip due to failover is not supported");
+    }
+
+    @Test(groups = {"integration"})
+    public void testFailover() {
+        throw new SkipException("Skip due to failover is not supported");
+    }
 }


### PR DESCRIPTION
## Summary
Fix for issue #1470 

### Issue
Connect time out errors are not detected correctly for Apache HTTP client because error message  for this client is in different format e.g: 
```
Connect to http://192.168.2.122:8123/ [/192.168.2.122] failed: connect timed out
```
As a result errors like
```
Caused by: com.clickhouse.client.internal.apache.hc.client5.http.ConnectTimeoutException: Connect to http://192.168.2.122:8123/ [/192.168.2.122] failed: connect timed out
```
are not detected as eligible errors to execute failover.

### Fix
`ClickHouseException.isConnectTimedOut` is changed to detect `connect timed out` substring in any part of error message

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG

