### PR TITLE
Fix TestNG URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -103,7 +103,7 @@ In the case you don't want to use docker and/or prefer to test against an existi
   ```
 
 ### Tooling
-We use [TestNG](http://org.testng/doc) as testing framework and for running ClickHouse Local instance [testcontainers](https://www.testcontainers.org/modules/databases/clickhouse/).
+We use [TestNG](https://testng.org/) as testing framework and for running ClickHouse Local instance [testcontainers](https://www.testcontainers.org/modules/databases/clickhouse/).
 
 ### Running unit tests
 


### PR DESCRIPTION
## Summary
Fix bad TestNG URL in the [CHANGELOG.md](https://github.com/ClickHouse/clickhouse-java/blob/main/CHANGELOG.md) guide

## Checklist
Nothing relevant enough to be added to [CHANGELOG.md](https://github.com/ClickHouse/clickhouse-java/blob/main/CHANGELOG.md)