### PR TITLE
Fixed max buffer limitation

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseConfig.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseConfig.java
@@ -312,13 +312,16 @@ public class ClickHouseConfig implements ClickHouseDataConfig {
         this.connectionTimeout = getIntOption(ClickHouseClientOption.CONNECTION_TIMEOUT);
         this.database = (String) getOption(ClickHouseClientOption.DATABASE, ClickHouseDefaults.DATABASE);
         this.format = (ClickHouseFormat) getOption(ClickHouseClientOption.FORMAT, ClickHouseDefaults.FORMAT);
-        this.maxBufferSize = ClickHouseDataConfig.getBufferSize(getIntOption(ClickHouseClientOption.MAX_BUFFER_SIZE),
-                -1, -1);
-        this.bufferSize = getIntOption(ClickHouseClientOption.BUFFER_SIZE);
+        this.maxBufferSize = getIntOption(ClickHouseClientOption.MAX_BUFFER_SIZE);
+        int size = getIntOption(ClickHouseClientOption.BUFFER_SIZE);
+        this.bufferSize = Math.min(size < 1? DEFAULT_BUFFER_SIZE: size, this.maxBufferSize);
+        size = getIntOption(ClickHouseClientOption.READ_BUFFER_SIZE);
+        this.readBufferSize = Math.min(size < 1? this.bufferSize : size, this.maxBufferSize);
+        size = getIntOption(ClickHouseClientOption.WRITE_BUFFER_SIZE);
+        this.writeBufferSize = Math.min(size < 1 ? this.bufferSize : size , this.maxBufferSize);
         this.bufferQueueVariation = getIntOption(ClickHouseClientOption.BUFFER_QUEUE_VARIATION);
-        this.readBufferSize = getIntOption(ClickHouseClientOption.READ_BUFFER_SIZE);
-        this.writeBufferSize = getIntOption(ClickHouseClientOption.WRITE_BUFFER_SIZE);
-        this.requestChunkSize = getIntOption(ClickHouseClientOption.REQUEST_CHUNK_SIZE);
+        int chunkSize = getIntOption(ClickHouseClientOption.REQUEST_CHUNK_SIZE);
+        this.requestChunkSize = chunkSize < 1 ? this.writeBufferSize : chunkSize;
         this.requestBuffering = (ClickHouseBufferingMode) getOption(ClickHouseClientOption.REQUEST_BUFFERING,
                 ClickHouseDefaults.BUFFERING);
         this.responseBuffering = (ClickHouseBufferingMode) getOption(ClickHouseClientOption.RESPONSE_BUFFERING,
@@ -504,12 +507,12 @@ public class ClickHouseConfig implements ClickHouseDataConfig {
 
     @Override
     public int getReadBufferSize() {
-        return ClickHouseDataConfig.getBufferSize(readBufferSize, getBufferSize(), getMaxBufferSize());
+        return readBufferSize;
     }
 
     @Override
     public int getWriteBufferSize() {
-        return ClickHouseDataConfig.getBufferSize(writeBufferSize, getBufferSize(), getMaxBufferSize());
+        return writeBufferSize;
     }
 
     /**

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseConfigTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseConfigTest.java
@@ -1,16 +1,17 @@
 package com.clickhouse.client;
 
+import com.clickhouse.client.config.ClickHouseClientOption;
+import com.clickhouse.client.config.ClickHouseDefaults;
+import com.clickhouse.config.ClickHouseOption;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
 import java.io.Serializable;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
-import org.testng.Assert;
-import org.testng.annotations.Test;
-import com.clickhouse.client.config.ClickHouseClientOption;
-import com.clickhouse.client.config.ClickHouseDefaults;
-import com.clickhouse.config.ClickHouseOption;
 
 public class ClickHouseConfigTest {
     @Test(groups = { "unit" })
@@ -105,5 +106,38 @@ public class ClickHouseConfigTest {
                 "Should have at least one sensitive option");
         Assert.assertEquals(ClickHouseConfig.ClientOptions.INSTANCE.sensitiveOptions.get("sslkey"),
                 ClickHouseClientOption.SSL_KEY);
+    }
+
+
+    @Test
+    public void testCustomBufferSizes() {
+        final int writeBuffSize = 5 * ClickHouseConfig.DEFAULT_MAX_BUFFER_SIZE;
+        final int readBuffSize = 6 * ClickHouseConfig.DEFAULT_MAX_BUFFER_SIZE;
+        Map<ClickHouseOption, Serializable> options = new HashMap<>();
+        options.put(ClickHouseClientOption.WRITE_BUFFER_SIZE, writeBuffSize);
+        options.put(ClickHouseClientOption.READ_BUFFER_SIZE, readBuffSize);
+        options.put(ClickHouseClientOption.REQUEST_CHUNK_SIZE, writeBuffSize);
+        ClickHouseConfig configWithDefaultMax = new ClickHouseConfig(options);
+
+        Assert.assertEquals(configWithDefaultMax.getWriteBufferSize(), ClickHouseConfig.DEFAULT_MAX_BUFFER_SIZE);
+        Assert.assertEquals(configWithDefaultMax.getReadBufferSize(), ClickHouseConfig.DEFAULT_MAX_BUFFER_SIZE);
+
+        final int customMaxBufferSize = 100 * ClickHouseConfig.DEFAULT_MAX_BUFFER_SIZE;
+        options.put(ClickHouseClientOption.MAX_BUFFER_SIZE, customMaxBufferSize);
+        ClickHouseConfig configWithCustomMax = new ClickHouseConfig(options);
+
+        Assert.assertEquals(configWithCustomMax.getWriteBufferSize(), writeBuffSize);
+        Assert.assertEquals(configWithCustomMax.getReadBufferSize(), readBuffSize);
+        Assert.assertEquals(configWithCustomMax.getMaxBufferSize(), customMaxBufferSize);
+
+        // Test defaults
+        options.clear();
+        options.put(ClickHouseClientOption.WRITE_BUFFER_SIZE, -1);
+        options.put(ClickHouseClientOption.READ_BUFFER_SIZE, -1);
+        options.put(ClickHouseClientOption.REQUEST_CHUNK_SIZE, -1);
+        ClickHouseConfig config = new ClickHouseConfig(options);
+
+        Assert.assertEquals(config.getWriteBufferSize(), config.getBufferSize());
+        Assert.assertEquals(config.getReadBufferSize(), config.getBufferSize());
     }
 }

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataConfig.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataConfig.java
@@ -1,11 +1,11 @@
 package com.clickhouse.data;
 
+import com.clickhouse.config.ClickHouseBufferingMode;
+import com.clickhouse.config.ClickHouseRenameMethod;
+
 import java.io.Serializable;
 import java.math.RoundingMode;
 import java.util.TimeZone;
-
-import com.clickhouse.config.ClickHouseBufferingMode;
-import com.clickhouse.config.ClickHouseRenameMethod;
 
 public interface ClickHouseDataConfig extends Serializable {
     static class Wrapped implements ClickHouseDataConfig {
@@ -137,7 +137,7 @@ public interface ClickHouseDataConfig extends Serializable {
     static final int DEFAULT_BUFFER_SIZE = 8192;
     static final int DEFAULT_READ_BUFFER_SIZE = DEFAULT_BUFFER_SIZE;
     static final int DEFAULT_WRITE_BUFFER_SIZE = DEFAULT_BUFFER_SIZE;
-    static final int DEFAULT_MAX_BUFFER_SIZE = 128 * 1024;
+    static final int DEFAULT_MAX_BUFFER_SIZE = 128 * DEFAULT_BUFFER_SIZE;
     static final int DEFAULT_MAX_MAPPER_CACHE = 100;
     static final int DEFAULT_MAX_QUEUED_BUFFERS = 512;
     static final int DEFAULT_BUFFER_QUEUE_VARIATION = 100;


### PR DESCRIPTION
## Summary
Max buffer size can now be overridden by user 

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
