### PR TITLE
Revert "fix response close for getRowsUpdated(#1538)"

### DIFF
--- a/clickhouse-r2dbc/src/main/java/com/clickhouse/r2dbc/ClickHouseResult.java
+++ b/clickhouse-r2dbc/src/main/java/com/clickhouse/r2dbc/ClickHouseResult.java
@@ -31,18 +31,10 @@ public class ClickHouseResult implements Result {
                                 .map(rec -> ClickHousePair.of(resp.getColumns(), rec))))
                     .map(pair -> new ClickHouseRow(pair.getRight(), pair.getLeft()))
                 .map(RowSegment::new);
-
-        this.updatedCount = Mono.using(() -> response,
-                resp -> Mono.just(response).map(ClickHouseResponse::getSummary)
-                        .map(ClickHouseResponseSummary::getProgress)
-                        .map(ClickHouseResponseSummary.Progress::getWrittenRows)
-                        .map(UpdateCount::new),
-                resp -> {
-                    if (!resp.isClosed()) {
-                        resp.close();
-                    }
-                });
-
+        this.updatedCount =  Mono.just(response).map(ClickHouseResponse::getSummary)
+                .map(ClickHouseResponseSummary::getProgress)
+                .map(ClickHouseResponseSummary.Progress::getWrittenRows)
+                .map(UpdateCount::new);
         this.segments = Flux.concat(this.updatedCount, this.rowSegments);
     }
 

--- a/clickhouse-r2dbc/src/main/java/com/clickhouse/r2dbc/ClickHouseResult091.java
+++ b/clickhouse-r2dbc/src/main/java/com/clickhouse/r2dbc/ClickHouseResult091.java
@@ -31,16 +31,10 @@ class ClickHouseResult implements Result {
                                 .map(rec -> ClickHousePair.of(resp.getColumns(), rec))))
                     .map(pair -> new ClickHouseRow(pair.getRight(), pair.getLeft()))
                 .map(RowSegment::new);
-        this.updatedCount = Mono.using(() -> response,
-                resp -> Mono.just(response).map(ClickHouseResponse::getSummary)
-                        .map(ClickHouseResponseSummary::getProgress)
-                        .map(ClickHouseResponseSummary.Progress::getWrittenRows)
-                        .map(UpdateCount::new),
-                resp -> {
-                    if (!resp.isClosed()) {
-                        resp.close();
-                    }
-                });
+        this.updatedCount =  Mono.just(response).map(ClickHouseResponse::getSummary)
+                .map(ClickHouseResponseSummary::getProgress)
+                .map(ClickHouseResponseSummary.Progress::getWrittenRows)
+                .map(UpdateCount::new);
         this.segments = Flux.concat(this.updatedCount, this.rowSegments);
     }
 


### PR DESCRIPTION
Reverts ClickHouse/clickhouse-java#1539

Fails the  com.clickhouse.r2dbc.spi.test.R2DBCTestKitImplTest.segmentSelectWithEmitsRow what is part of a 3rd party test kit