### PR TITLE
Added insert that accepts byte[]

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -42,6 +42,7 @@ import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.URL;
+import java.nio.ByteBuffer;
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
@@ -566,7 +567,55 @@ public class Client {
     }
 
     /**
-     * <p>Sends write request to database. Input data is read from the input stream.</p>
+     * <p>Sends write request to database. Input data is read from the buffer. Data should be already in target format.</p>
+     * @param tableName - destination table name
+     * @param src - data buffer to insert
+     * @param format - target format
+     * @return
+     */
+    public CompletableFuture<InsertResponse> insert(String tableName, byte[] src, ClickHouseFormat format, InsertSettings settings) {
+        String operationId = (String) settings.getOperationId();
+        if (operationId == null) {
+            operationId = startOperation();
+            settings.setOperationId(operationId);
+        }
+        OperationStatistics.ClientStatistics clientStats = globalClientStats.remove(operationId);
+        clientStats.start("insert");
+
+        CompletableFuture<InsertResponse> responseFuture = new CompletableFuture<>();
+
+        try (ClickHouseClient client = createClient()) {
+            ClickHouseRequest.Mutation request = createMutationRequest(client.write(getServerNode()), tableName, settings).format(format);
+            CompletableFuture<ClickHouseResponse> future = null;
+            try(ClickHousePipedOutputStream stream = ClickHouseDataStreamFactory.getInstance().createPipedOutputStream(request.getConfig())) {
+                future = request.data(stream.getInputStream()).execute();
+
+                // All bytes are copied from the buffer to the output stream
+                // PipedOutputStream will handle growing the buffer if needed
+                ByteArrayInputStream data = new ByteArrayInputStream(src);
+                data.transferTo(stream);
+
+            } catch (IOException e) {
+                responseFuture.completeExceptionally(new ClientException("Failed to write data to the output stream", e));
+            }
+
+            if (!responseFuture.isCompletedExceptionally()) {
+                try {
+                    InsertResponse response = new InsertResponse(client, future.get(), clientStats);
+                    responseFuture.complete(response);
+                } catch (InterruptedException | ExecutionException e) {
+                    responseFuture.completeExceptionally(new ClientException("Operation has likely timed out.", e));
+                }
+            }
+            clientStats.stop("insert");
+            LOG.debug("Total insert (InputStream) time: {}", clientStats.getElapsedTime("insert"));
+        }
+
+        return responseFuture;
+    }
+
+    /**
+     * <p>Sends write request to database. Input data is read from the input stream. Data should be already in target format.</p>
      *
      * @param tableName - destination table name
      * @param data  - data stream to insert


### PR DESCRIPTION
## Summary
There are 3 major usecase for insert data:
- Data is read from some source and InputStream is created already. User just passes it to the method 
- There list of POJO's that is where serializer shines
- Data is transformed and it is written to some buffer. In most cases it is a `byte[]` 

PR add such handy method. 
