### PR TITLE
Remove server from exception message

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseException.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseException.java
@@ -35,11 +35,13 @@ public class ClickHouseException extends Exception {
 
     private final int errorCode;
 
-    private static String buildErrorMessage(int code, Throwable cause, ClickHouseNode server) {
-        return buildErrorMessage(code, cause != null ? cause.getMessage() : null, server);
+    private final ClickHouseNode server;
+
+    private static String buildErrorMessageImpl(int code, Throwable cause) {
+        return buildErrorMessageImpl(code, cause != null ? cause.getMessage() : null);
     }
 
-    private static String buildErrorMessage(int code, String message, ClickHouseNode server) {
+    private static String buildErrorMessageImpl(int code, String message) {
         StringBuilder builder = new StringBuilder();
 
         if (message != null && !message.isEmpty()) {
@@ -52,10 +54,6 @@ public class ClickHouseException extends Exception {
             builder.append(MSG_CODE).append(code).append(". Execution timed out");
         } else {
             builder.append("Unknown error ").append(code);
-        }
-
-        if (server != null) {
-            builder.append(", server ").append(server);
         }
 
         return builder.toString();
@@ -175,9 +173,9 @@ public class ClickHouseException extends Exception {
      * @param server server
      */
     public ClickHouseException(int code, Throwable cause, ClickHouseNode server) {
-        super(buildErrorMessage(code, cause, server), cause);
-
-        errorCode = code;
+        super(buildErrorMessageImpl(code, cause), cause);
+        this.server = server;
+        this.errorCode = code;
     }
 
     /**
@@ -188,9 +186,10 @@ public class ClickHouseException extends Exception {
      * @param server  server
      */
     public ClickHouseException(int code, String message, ClickHouseNode server) {
-        super(buildErrorMessage(code, message, server), null);
+        super(buildErrorMessageImpl(code, message), null);
 
-        errorCode = code;
+        this.server = server;
+        this.errorCode = code;
     }
 
     /**
@@ -203,7 +202,8 @@ public class ClickHouseException extends Exception {
     protected ClickHouseException(int code, String message, Throwable cause) {
         super(message, cause);
 
-        errorCode = code;
+        this.server = null;
+        this.errorCode = code;
     }
 
     /**
@@ -213,5 +213,14 @@ public class ClickHouseException extends Exception {
      */
     public int getErrorCode() {
         return errorCode;
+    }
+
+    /**
+     * Get the server that caused the exception.
+     * If the exception is not caused by a server, this method will return null.
+     * @return server
+     */
+    public ClickHouseNode getServer() {
+        return server;
     }
 }

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseExceptionTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseExceptionTest.java
@@ -18,19 +18,22 @@ public class ClickHouseExceptionTest {
         e = new ClickHouseException(233, (Throwable) null, server);
         Assert.assertEquals(e.getErrorCode(), 233);
         Assert.assertNull(e.getCause());
-        Assert.assertEquals(e.getMessage(), "Unknown error 233, server " + server);
+        Assert.assertEquals(e.getMessage(), "Unknown error 233");
+        Assert.assertEquals(e.getServer(), server);
 
         Throwable cause = new IllegalArgumentException();
         e = new ClickHouseException(123, cause, server);
         Assert.assertEquals(e.getErrorCode(), 123);
         Assert.assertEquals(e.getCause(), cause);
-        Assert.assertEquals(e.getMessage(), "Unknown error 123, server " + server);
+        Assert.assertEquals(e.getMessage(), "Unknown error 123");
+        Assert.assertEquals(e.getServer(), server);
 
         cause = new IllegalArgumentException("Some error");
         e = new ClickHouseException(111, cause, server);
         Assert.assertEquals(e.getErrorCode(), 111);
         Assert.assertEquals(e.getCause(), cause);
-        Assert.assertEquals(e.getMessage(), "Some error, server " + server);
+        Assert.assertEquals(e.getMessage(), "Some error");
+        Assert.assertEquals(e.getServer(), server);
     }
 
     @Test(groups = { "unit" })
@@ -44,17 +47,20 @@ public class ClickHouseExceptionTest {
         e = new ClickHouseException(233, (String) null, server);
         Assert.assertEquals(e.getErrorCode(), 233);
         Assert.assertNull(e.getCause());
-        Assert.assertEquals(e.getMessage(), "Unknown error 233, server " + server);
+        Assert.assertEquals(e.getMessage(), "Unknown error 233");
+        Assert.assertEquals(e.getServer(), server);
 
         e = new ClickHouseException(123, "", server);
         Assert.assertEquals(e.getErrorCode(), 123);
         Assert.assertNull(e.getCause());
-        Assert.assertEquals(e.getMessage(), "Unknown error 123, server " + server);
+        Assert.assertEquals(e.getMessage(), "Unknown error 123");
+        Assert.assertEquals(e.getServer(), server);
 
         e = new ClickHouseException(111, "Some error", server);
         Assert.assertEquals(e.getErrorCode(), 111);
         Assert.assertNull(e.getCause());
-        Assert.assertEquals(e.getMessage(), "Some error, server " + server);
+        Assert.assertEquals(e.getMessage(), "Some error");
+        Assert.assertEquals(e.getServer(), server);
     }
 
     @Test(groups = { "unit" })
@@ -65,12 +71,12 @@ public class ClickHouseExceptionTest {
         Assert.assertEquals(e.getErrorCode(), ClickHouseException.ERROR_UNKNOWN);
         Assert.assertEquals(e.getCause(), cause);
         Assert.assertEquals(e.getMessage(),
-                "Unknown error " + ClickHouseException.ERROR_UNKNOWN + ", server " + server);
+                "Unknown error " + ClickHouseException.ERROR_UNKNOWN);
 
         e = ClickHouseException.of("Some error", server);
         Assert.assertEquals(e.getErrorCode(), ClickHouseException.ERROR_UNKNOWN);
         Assert.assertNull(e.getCause());
-        Assert.assertEquals(e.getMessage(), "Some error, server " + server);
+        Assert.assertEquals(e.getMessage(), "Some error");
 
         Assert.assertEquals(e, ClickHouseException.of(e, server));
 
@@ -79,57 +85,57 @@ public class ClickHouseExceptionTest {
         Assert.assertEquals(e.getErrorCode(), ClickHouseException.ERROR_UNKNOWN);
         Assert.assertEquals(e.getCause(), cause);
         Assert.assertEquals(e.getMessage(),
-                "Unknown error " + ClickHouseException.ERROR_UNKNOWN + ", server " + server);
+                "Unknown error " + ClickHouseException.ERROR_UNKNOWN);
 
         e = ClickHouseException.of((ExecutionException) null, server);
         Assert.assertEquals(e.getErrorCode(), ClickHouseException.ERROR_UNKNOWN);
         Assert.assertNull(e.getCause());
         Assert.assertEquals(e.getMessage(),
-                "Unknown error " + ClickHouseException.ERROR_UNKNOWN + ", server " + server);
+                "Unknown error " + ClickHouseException.ERROR_UNKNOWN);
 
         cause = new ExecutionException(new ClickHouseException(-100, (Throwable) null, server));
         e = ClickHouseException.of(cause, server);
         Assert.assertEquals(e, cause.getCause());
         Assert.assertEquals(e.getErrorCode(), -100);
         Assert.assertNull(e.getCause());
-        Assert.assertEquals(e.getMessage(), "Unknown error -100, server " + server);
+        Assert.assertEquals(e.getMessage(), "Unknown error -100");
 
         cause = new ExecutionException(new IllegalArgumentException());
         e = ClickHouseException.of(cause, server);
         Assert.assertEquals(e.getErrorCode(), ClickHouseException.ERROR_UNKNOWN);
         Assert.assertEquals(e.getCause(), cause.getCause());
         Assert.assertEquals(e.getMessage(),
-                "Unknown error " + ClickHouseException.ERROR_UNKNOWN + ", server " + server);
+                "Unknown error " + ClickHouseException.ERROR_UNKNOWN);
 
         cause = new ExecutionException(new IllegalArgumentException("Code: 12345. Something goes wrong..."));
         e = ClickHouseException.of(cause, server);
         Assert.assertEquals(e.getErrorCode(), 12345);
         Assert.assertEquals(e.getCause(), cause.getCause());
-        Assert.assertEquals(e.getMessage(), cause.getCause().getMessage() + ", server " + server);
+        Assert.assertEquals(e.getMessage(), cause.getCause().getMessage());
 
         cause = new ExecutionException(new IllegalArgumentException("Code:12345. Something goes wrong..."));
         e = ClickHouseException.of(cause, server);
         Assert.assertEquals(e.getErrorCode(), 12345);
         Assert.assertEquals(e.getCause(), cause.getCause());
-        Assert.assertEquals(e.getMessage(), cause.getCause().getMessage() + ", server " + server);
+        Assert.assertEquals(e.getMessage(), cause.getCause().getMessage());
 
         cause = new ExecutionException(new IllegalArgumentException("Poco::Exception. Code: 1000, "));
         e = ClickHouseException.of(cause, server);
         Assert.assertEquals(e.getErrorCode(), 1000);
         Assert.assertEquals(e.getCause(), cause.getCause());
-        Assert.assertEquals(e.getMessage(), cause.getCause().getMessage() + ", server " + server);
+        Assert.assertEquals(e.getMessage(), cause.getCause().getMessage());
 
         cause = new ExecutionException(new IllegalArgumentException("Code:       123"));
         e = ClickHouseException.of(cause, server);
         Assert.assertEquals(e.getErrorCode(), 123);
         Assert.assertEquals(e.getCause(), cause.getCause());
-        Assert.assertEquals(e.getMessage(), cause.getCause().getMessage() + ", server " + server);
+        Assert.assertEquals(e.getMessage(), cause.getCause().getMessage());
 
         cause = new ExecutionException(new IllegalArgumentException("Code: ab123"));
         e = ClickHouseException.of(cause, server);
         Assert.assertEquals(e.getErrorCode(), 1002);
         Assert.assertEquals(e.getCause(), cause.getCause());
-        Assert.assertEquals(e.getMessage(), cause.getCause().getMessage() + ", server " + server);
+        Assert.assertEquals(e.getMessage(), cause.getCause().getMessage());
 
     }
 


### PR DESCRIPTION
## Summary
Removed server from exception message and moved to exception itself

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
