### PR TITLE
[clickhouse-jdbc] describe SELECT queries to retrieve metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## Latest 
 
+### New Features
+- Describe non-executed SELECT queries in prepared statements to provide metadata (https://github.com/ClickHouse/clickhouse-java/issues/1430)
+
 ## 0.6.1
 
 ### New Features

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHousePreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHousePreparedStatement.java
@@ -109,7 +109,17 @@ public interface ClickHousePreparedStatement extends PreparedStatement {
     @Override
     default ResultSetMetaData getMetaData() throws SQLException {
         ResultSet currentResult = getResultSet();
-        return currentResult != null ? currentResult.getMetaData() : null;
+        if (currentResult != null) {
+            return currentResult.getMetaData();
+        } else if (getLargeUpdateCount() != -1L) {
+            return null; // Update query
+        }
+
+        return describeQueryResult();
+    }
+
+    default ResultSetMetaData describeQueryResult() throws SQLException {
+        return null;
     }
 
     @Override


### PR DESCRIPTION
## Summary
This is an attempt to reanimate #1434 to enable `getMetadata()` method to return metadata for a prepared `SELECT` query that hasn't yet been executed. Also see #1430 .

This functionality is needed (among other use-cases) to support [query passthrough](https://github.com/trinodb/trino/pull/12325) for [clickhouse-connector](https://trino.io/docs/current/connector/clickhouse.html) inside [Trino](https://trino.io/).

### Implementation
`DESCRIBE (<select>)` is used to retrieve metadata about `SELECT` query that hasn't yet been executed. 

Contrary to #1434 the method requires the query to be "recognized" and be `SELECT`, thus removing the ambiguity of supporting different query types. Otherwise it wraps the query inside `DESCRIBE ()` clause to build respective metadata object.

Additional unit tests were added to address remarks to the original PR.

<!-- A short description of the changes with a link to an open issue. -->

## Checklist
Delete items not relevant to your PR:
- [X ] Unit and integration tests covering the common scenarios were added
- [X ] A human-readable description of the changes was provided to include in CHANGELOG

cc: @zhicwu , @ebyhr 