### PR TITLE
[client-v2] fixed passing properties to old client

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNode.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNode.java
@@ -787,7 +787,9 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
         String scheme = normalizedUri.getScheme();
         ClickHouseProtocol protocol = ClickHouseProtocol.fromUriScheme(scheme);
         int port = extract(scheme, normalizedUri.getPort(), protocol, params);
-
+        if (options.get(ClickHouseClientOption.SSL.getKey()) == null && scheme.equalsIgnoreCase("https")) {
+            params.put(ClickHouseClientOption.SSL.getKey(), "true");
+        }
         ClickHouseCredentials credentials = extract(normalizedUri.getRawUserInfo(), params, null);
 
         return new ClickHouseNode(normalizedUri.getHost(), protocol, port, credentials, params, tags);

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNode.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNode.java
@@ -787,7 +787,8 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
         String scheme = normalizedUri.getScheme();
         ClickHouseProtocol protocol = ClickHouseProtocol.fromUriScheme(scheme);
         int port = extract(scheme, normalizedUri.getPort(), protocol, params);
-        if (options.get(ClickHouseClientOption.SSL.getKey()) == null && scheme.equalsIgnoreCase("https")) {
+        if ((options == null || options.get(ClickHouseClientOption.SSL.getKey()) == null)
+                && scheme.equalsIgnoreCase("https")) {
             params.put(ClickHouseClientOption.SSL.getKey(), "true");
         }
         ClickHouseCredentials credentials = extract(normalizedUri.getRawUserInfo(), params, null);

--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -191,7 +191,11 @@ public class Client {
             ValidationUtils.checkNonBlank(host, "host");
             ValidationUtils.checkNotNull(protocol, "protocol");
             ValidationUtils.checkRange(port, 1, ValidationUtils.TCP_PORT_NUMBER_MAX, "port");
-
+            if (secure) {
+                // For some reason com.clickhouse.client.http.ApacheHttpConnectionImpl.newConnection checks only client config
+                // for SSL, so we need to set it here. But it actually should be set for each node separately.
+                this.configuration.put(ClickHouseClientOption.SSL.getKey(), "true");
+            }
             String endpoint = String.format("%s%s://%s:%d", protocol.toString().toLowerCase(), secure ? "s": "", host, port);
             this.addEndpoint(endpoint);
             return this;

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/ClientV1AdaptorHelper.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/ClientV1AdaptorHelper.java
@@ -18,27 +18,29 @@ import java.util.Map;
 
 public class ClientV1AdaptorHelper {
 
-    private static void copyProxySettings(Map<ClickHouseOption, Serializable> target, Map<String, String> config) {
-        ClickHouseClientOption opt = ClickHouseClientOption.PROXY_HOST;
-        String value = config.get(opt.getKey());
-        if (value != null) {
-            target.put(opt, value);
-        }
-        opt = ClickHouseClientOption.PROXY_PORT;
-        value = config.get(opt.getKey());
-        if (value != null) {
-            target.put(opt, Integer.parseInt(value));
-        }
-        opt = ClickHouseClientOption.PROXY_TYPE;
-        value = config.get(opt.getKey());
-        if (value != null) {
-            target.put(opt, ClickHouseProxyType.valueOf(value));
+    private static void copyClientOptions(Map<ClickHouseOption, Serializable> target, Map<String, String> config) {
+
+        for (ClickHouseClientOption opt : ClickHouseClientOption.values()) {
+            String value = config.get(opt.getKey());
+            if (value == null) {
+                continue;
+            }
+
+            if (opt.getValueType().isAssignableFrom(Integer.class)) {
+                target.put(opt, Integer.parseInt(value));
+            } else if (opt.getValueType().isAssignableFrom(Boolean.class)) {
+                target.put(opt, Boolean.parseBoolean(value));
+            } else if (opt.getValueType().isEnum()) {
+                target.put(opt, Enum.valueOf((Class<Enum>) opt.getValueType(), value));
+            } else if (opt.getValueType().isAssignableFrom(String.class)) {
+                target.put(opt, value);
+            }
         }
     }
 
     public static ClickHouseClient createClient(Map<String, String> configuration) {
         Map<ClickHouseOption, Serializable> config = new HashMap<>();
-        copyProxySettings(config, configuration);
+        copyClientOptions(config, configuration);
 
         ClickHouseConfig clientConfig = new ClickHouseConfig(config);
 

--- a/client-v2/src/test/java/com/clickhouse/client/ClientTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/ClientTests.java
@@ -1,0 +1,31 @@
+package com.clickhouse.client;
+
+import com.clickhouse.client.api.Client;
+import com.clickhouse.client.api.enums.Protocol;
+import com.clickhouse.client.api.query.GenericRecord;
+import org.junit.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Optional;
+
+public class ClientTests extends BaseIntegrationTest {
+
+
+    @Test(enabled = false)
+    public void testWithSSL() {
+
+        ClickHouseNode secureNode = getSecureServer(ClickHouseProtocol.HTTP);
+        Client client = new Client.Builder()
+                .addEndpoint(Protocol.HTTP, "localhost", secureNode.getPort(), true)
+                .setUsername("default")
+                .setPassword("")
+                .build();
+
+
+        Optional<GenericRecord> genericRecord = client
+                .queryAll("SELECT hostname()").stream().findFirst();
+        Assert.assertTrue(genericRecord.isPresent());
+
+        System.out.println(genericRecord.get().getString(1));
+    }
+}


### PR DESCRIPTION
## Summary
Because not every property is passed to the config of underlying client, it was not possible to connect over SSL. 

