### PR TITLE
Fix duplicate query ID error 

### DIFF
--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseRequestTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseRequestTest.java
@@ -11,11 +11,17 @@ import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -653,5 +659,36 @@ public class ClickHouseRequestTest {
         expectedSql += "\n FORMAT Arrow";
         Assert.assertEquals(request.getQuery(), expectedSql);
         Assert.assertEquals(request.getStatements().get(0), expectedSql);
+    }
+
+    @Test
+    public void testConcurrentUse() {
+        ClickHouseRequest<?> request = ClickHouseClient.newInstance().read(ClickHouseNode.builder().build());
+        Assert.assertNotNull(request);
+
+        ScheduledExecutorService executor = Executors.newScheduledThreadPool(3);
+
+        final List<ClickHouseRequest<?>> sealedRequests = new ArrayList<>();
+
+        for (int i = 0; i < 3; i++) {
+            executor.scheduleWithFixedDelay(() -> {
+                String queryID = UUID.randomUUID().toString();
+//                System.out.println(System.currentTimeMillis() + "  Thread " + Thread.currentThread().getId() + " qId: " + queryID);
+                sealedRequests.add(request.query("select 1", queryID).seal());
+            }, 100, 100, TimeUnit.MILLISECONDS);
+        }
+
+        try {
+            Thread.sleep(1000);
+        } catch (InterruptedException e) {
+            Assert.fail("Thread sleep interrupted");
+        }
+        executor.shutdown();
+        final Set<String> queryIDs = new HashSet<>();
+        for (ClickHouseRequest<?> r : sealedRequests) {
+//            System.out.println(queryIDs);
+            Assert.assertTrue(queryIDs.add(r.getQueryId().get()), "Query ID should be unique: " +
+                    r.getQueryId().get());
+        }
     }
 }

--- a/clickhouse-http-client/src/main/java11/com/clickhouse/client/http/HttpClientConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java11/com/clickhouse/client/http/HttpClientConnectionImpl.java
@@ -81,7 +81,6 @@ public class HttpClientConnectionImpl extends ClickHouseHttpConnection {
 
     private static final String USER_AGENT = ClickHouseClientOption.buildUserAgent(null, "HttpClient");
 
-    private final AtomicBoolean busy;
     private final HttpClient httpClient;
     private final HttpRequest pingRequest;
 
@@ -197,15 +196,13 @@ public class HttpClientConnectionImpl extends ClickHouseHttpConnection {
             builder.sslContext(ClickHouseSslContextProvider.getProvider().getSslContext(SSLContext.class, config)
                     .orElse(null));
         }
-
-        busy = new AtomicBoolean(false);
         httpClient = builder.build();
         pingRequest = newRequest(getBaseUrl() + "ping");
     }
 
     @Override
     protected boolean isReusable() {
-        return !busy.get();
+        return true; // httpClient is stateless and can be reused
     }
 
     private CompletableFuture<HttpResponse<InputStream>> postRequest(HttpRequest request) {
@@ -243,8 +240,6 @@ public class HttpClientConnectionImpl extends ClickHouseHttpConnection {
             }
 
             return buildResponse(config, r, output, postAction);
-        } finally {
-            busy.set(false);
         }
     }
 
@@ -267,8 +262,6 @@ public class HttpClientConnectionImpl extends ClickHouseHttpConnection {
                 }
             }
             return buildResponse(config, r, output, postAction);
-        } finally {
-            busy.set(false);
         }
     }
 
@@ -281,9 +274,7 @@ public class HttpClientConnectionImpl extends ClickHouseHttpConnection {
     protected ClickHouseHttpResponse post(ClickHouseConfig config, String sql, ClickHouseInputStream data,
             List<ClickHouseExternalTable> tables, ClickHouseOutputStream output, String url,
             Map<String, String> headers, Runnable postAction) throws IOException {
-        if (!busy.compareAndSet(false, true)) {
-            throw new ConnectException("Connection is busy");
-        }
+
         ClickHouseConfig c = config == null ? this.config : config;
         HttpRequest.Builder reqBuilder = HttpRequest.newBuilder()
                 .uri(URI.create(ClickHouseChecker.isNullOrEmpty(url) ? this.url : url))

--- a/clickhouse-http-client/src/main/java11/com/clickhouse/client/http/HttpClientConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java11/com/clickhouse/client/http/HttpClientConnectionImpl.java
@@ -205,7 +205,7 @@ public class HttpClientConnectionImpl extends ClickHouseHttpConnection {
 
     @Override
     protected boolean isReusable() {
-        return busy.get();
+        return !busy.get();
     }
 
     private CompletableFuture<HttpResponse<InputStream>> postRequest(HttpRequest request) {

--- a/clickhouse-http-client/src/main/java11/com/clickhouse/client/http/HttpClientConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java11/com/clickhouse/client/http/HttpClientConnectionImpl.java
@@ -215,7 +215,7 @@ public class HttpClientConnectionImpl extends ClickHouseHttpConnection {
     private ClickHouseHttpResponse postStream(ClickHouseConfig config, HttpRequest.Builder reqBuilder, byte[] boundary,
             String sql, ClickHouseInputStream data, List<ClickHouseExternalTable> tables, ClickHouseOutputStream output,
             Runnable postAction) throws IOException {
-        try {
+
             ClickHousePipedOutputStream stream = ClickHouseDataStreamFactory.getInstance()
                     .createPipedOutputStream(config);
             reqBuilder.POST(HttpRequest.BodyPublishers.ofInputStream(stream::getInputStream));
@@ -240,12 +240,11 @@ public class HttpClientConnectionImpl extends ClickHouseHttpConnection {
             }
 
             return buildResponse(config, r, output, postAction);
-        }
     }
 
     private ClickHouseHttpResponse postString(ClickHouseConfig config, HttpRequest.Builder reqBuilder, String sql,
             ClickHouseOutputStream output, Runnable postAction) throws IOException {
-        try {
+
             reqBuilder.POST(HttpRequest.BodyPublishers.ofString(sql));
             HttpResponse<InputStream> r;
             try {
@@ -262,7 +261,6 @@ public class HttpClientConnectionImpl extends ClickHouseHttpConnection {
                 }
             }
             return buildResponse(config, r, output, postAction);
-        }
     }
 
     @Override

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseStatementTest.java
@@ -36,6 +36,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 
 import com.clickhouse.client.ClickHouseClient;
 import com.clickhouse.client.ClickHouseException;
@@ -1409,13 +1410,13 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
 
             ScheduledExecutorService executor = Executors.newScheduledThreadPool(3);
 
-            final WeakReference<Exception> failedException = new WeakReference<>(null);
+            final AtomicReference<Exception> failedException = new AtomicReference<>(null);
             for (int i = 0; i < 3; i++) {
                 executor.scheduleWithFixedDelay(() -> {
                     try {
                         stmt.execute("select 1");
                     } catch (Exception e) {
-                        failedException.refersTo(e);
+                        failedException.set(e);
                     }
                 }, 100, 100, TimeUnit.MILLISECONDS);
             }


### PR DESCRIPTION
## Summary
In the JDBC driver every Statement has own request object, but it is shared among requests. If statement object is used by different threads then one thread may copy query_id set by another. Ignoring the fact that threads should not share Statements there should be a proper synchronization when working with shared request object. 
Current PR implements locking on request object while making copy (seal operation). 

Closes: 
- https://github.com/ClickHouse/clickhouse-java/issues/1529

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG

