### PR TITLE
clickhouse-http-client: ignore link local addresses in getLocalhost

### DIFF
--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpClient.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpClient.java
@@ -52,7 +52,7 @@ public class ClickHouseHttpClient extends AbstractClient<ClickHouseHttpConnectio
                 Enumeration<InetAddress> inetAddresses = ni.getInetAddresses();
                 for (InetAddress ia : Collections.list(inetAddresses)) {
                     // We just use the first non-loopback address
-                    if (!ia.isLoopbackAddress()) {
+                    if (!ia.isLoopbackAddress() && !ia.isLinkLocalAddress()) {
                         hostNameAndAddress.address = ia.getHostAddress();
                         hostNameAndAddress.hostName = ia.getCanonicalHostName();
                         break;

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpClient.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpClient.java
@@ -48,6 +48,7 @@ public class ClickHouseHttpClient extends AbstractClient<ClickHouseHttpConnectio
         try {
             Enumeration<NetworkInterface> networkInterfaces = NetworkInterface.getNetworkInterfaces();
 
+            outer:
             for (NetworkInterface ni : Collections.list(networkInterfaces)) {
                 Enumeration<InetAddress> inetAddresses = ni.getInetAddresses();
                 for (InetAddress ia : Collections.list(inetAddresses)) {
@@ -55,7 +56,7 @@ public class ClickHouseHttpClient extends AbstractClient<ClickHouseHttpConnectio
                     if (!ia.isLoopbackAddress() && !ia.isLinkLocalAddress()) {
                         hostNameAndAddress.address = ia.getHostAddress();
                         hostNameAndAddress.hostName = ia.getCanonicalHostName();
-                        break;
+                        break outer;
                     }
                 }
             }


### PR DESCRIPTION
## Summary

This a possible fix for #1729.

As far as I can tell link-local addresses are useless for the purpose of `getLocalhost` since it's used to get a referrer address, so I ignored them.

This solves my issue on my macOS system: for all others addresses the `getCanonicalHostName` is almost instantaneous.

Additionally, the comment says "use the first non-loopback address" but the code didn't actually do that because the break doesn't apply to the outer loop, I fixed that too.

## Checklist
Delete items not relevant to your PR: