### PR TITLE
[client-v2] Migrate to use InputStream do read data

### DIFF
--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
@@ -115,7 +115,8 @@ public class ApacheHttpConnectionImpl extends ClickHouseHttpConnection {
         // {"read_rows":"0","read_bytes":"0","written_rows":"0","written_bytes":"0","total_rows_to_read":"0"}
         String displayName = getResponseHeader(response, "X-ClickHouse-Server-Display-Name", server.getHost());
         String queryId = getResponseHeader(response, "X-ClickHouse-Query-Id", "");
-        String summary = getResponseHeader(response, "X-ClickHouse-Summary", "{}");
+        Header hSum = response.getLastHeader("X-ClickHouse-Summary");
+        String summary = hSum == null ? "{}" : hSum.getValue(); // getResponseHeader(response, "X-ClickHouse-Summary", "{}");
 
         ClickHouseFormat format = config.getFormat();
         TimeZone timeZone = config.getServerTimeZone();

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/ClickHouseHttpOption.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/ClickHouseHttpOption.java
@@ -58,7 +58,7 @@ public enum ClickHouseHttpOption implements ClickHouseOption {
     // "Enables or disables X-ClickHouse-Progress HTTP response headers in
     // clickhouse-server responses."),
     // SEND_PROGRESS_INTERVAL("http_headers_progress_interval_ms", 3000, ""),
-    // WAIT_END_OF_QUERY("wait_end_of_query", false, ""),
+     WAIT_END_OF_QUERY("wait_end_of_query", false, ""),
 
     /**
      * Whether to remember last set role and send them in every next requests as query parameters.

--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -30,6 +30,7 @@ import com.clickhouse.client.api.query.QuerySettings;
 import com.clickhouse.client.api.query.Records;
 import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.client.config.ClickHouseDefaults;
+import com.clickhouse.client.http.config.ClickHouseHttpOption;
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseDataStreamFactory;
 import com.clickhouse.data.ClickHouseFormat;
@@ -801,6 +802,7 @@ public class Client {
             settings = new QuerySettings();
         }
         settings.setFormat(ClickHouseFormat.RowBinaryWithNamesAndTypes);
+        settings.waitEndOfQuery(true); // we rely on the summery
         ClientStatisticsHolder clientStats = new ClientStatisticsHolder();
         clientStats.start("query");
         ClickHouseClient client = ClientV1AdaptorHelper.createClient(configuration);
@@ -846,9 +848,9 @@ public class Client {
     public List<GenericRecord> queryAll(String sqlQuery) {
         try {
             int operationTimeout = getOperationTimeout();
-
-            try (QueryResponse response = operationTimeout == 0 ? query(sqlQuery).get() :
-                    query(sqlQuery).get(operationTimeout, TimeUnit.MILLISECONDS)) {
+            QuerySettings settings = new QuerySettings().waitEndOfQuery(true);
+            try (QueryResponse response = operationTimeout == 0 ? query(sqlQuery, settings).get() :
+                    query(sqlQuery, settings).get(operationTimeout, TimeUnit.MILLISECONDS)) {
                 List<GenericRecord> records = new ArrayList<>();
                 if (response.getResultRows() > 0) {
                     ClickHouseBinaryFormatReader reader = new RowBinaryWithNamesAndTypesFormatReader(response.getInputStream());

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/NativeFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/NativeFormatReader.java
@@ -1,12 +1,10 @@
 package com.clickhouse.client.api.data_formats;
 
-import com.clickhouse.client.api.ClientException;
 import com.clickhouse.client.api.data_formats.internal.AbstractBinaryFormatReader;
+import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
 import com.clickhouse.client.api.query.QuerySettings;
 import com.clickhouse.data.ClickHouseColumn;
-import com.clickhouse.data.ClickHouseDataType;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -43,14 +41,15 @@ public class NativeFormatReader extends AbstractBinaryFormatReader {
     }
 
     private void readBlock() throws IOException {
-        int nColumns = chInputStream.readVarInt();
-        int nRows = chInputStream.readVarInt();
+        int nColumns = BinaryStreamReader.readVarInt(input);
+        int nRows = BinaryStreamReader.readVarInt(input);
 
         List<String> names = new ArrayList<>(nColumns);
         List<String> types = new ArrayList<>(nColumns);
         currentBlock = new Block(names, types, nRows);
         for (int i = 0; i < nColumns; i++) {
-            ClickHouseColumn column = ClickHouseColumn.of(chInputStream.readUnicodeString(), chInputStream.readUnicodeString());
+            ClickHouseColumn column = ClickHouseColumn.of(BinaryStreamReader.readString(input),
+                    BinaryStreamReader.readString(input));
             names.add(column.getColumnName());
             types.add(column.getDataType().name());
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryFormatReader.java
@@ -1,12 +1,10 @@
 package com.clickhouse.client.api.data_formats;
 
-import com.clickhouse.client.api.ClientException;
 import com.clickhouse.client.api.data_formats.internal.AbstractBinaryFormatReader;
 import com.clickhouse.client.api.metadata.TableSchema;
 import com.clickhouse.client.api.query.QuerySettings;
 import com.clickhouse.data.ClickHouseColumn;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Map;

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryWithNamesAndTypesFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryWithNamesAndTypesFormatReader.java
@@ -2,18 +2,17 @@ package com.clickhouse.client.api.data_formats;
 
 import com.clickhouse.client.api.ClientException;
 import com.clickhouse.client.api.data_formats.internal.AbstractBinaryFormatReader;
+import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
 import com.clickhouse.client.api.metadata.TableSchema;
 import com.clickhouse.client.api.query.QuerySettings;
 import com.clickhouse.data.ClickHouseColumn;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.NoSuchElementException;
 
 public class RowBinaryWithNamesAndTypesFormatReader extends AbstractBinaryFormatReader implements Iterator<Map<String, Object>> {
 
@@ -28,18 +27,18 @@ public class RowBinaryWithNamesAndTypesFormatReader extends AbstractBinaryFormat
 
     private void readSchema() {
         try {
-            if (inputStream.available() < 1) {
+            if (input.available() < 1) {
                 return;
             }
             TableSchema headerSchema = new TableSchema();
             List<String> columns = new ArrayList<>();
-            int nCol = chInputStream.readVarInt();
+            int nCol = BinaryStreamReader.readVarInt(input);
             for (int i = 0; i < nCol; i++) {
-                columns.add(chInputStream.readUnicodeString());
+                columns.add(BinaryStreamReader.readString(input));
             }
 
             for (int i = 0; i < nCol; i++) {
-                headerSchema.addColumn(columns.get(i), chInputStream.readUnicodeString());
+                headerSchema.addColumn(columns.get(i), BinaryStreamReader.readString(input));
             }
 
             setSchema(headerSchema);

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryWithNamesFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryWithNamesFormatReader.java
@@ -1,12 +1,11 @@
 package com.clickhouse.client.api.data_formats;
 
-import com.clickhouse.client.api.ClientException;
 import com.clickhouse.client.api.data_formats.internal.AbstractBinaryFormatReader;
+import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
 import com.clickhouse.client.api.metadata.TableSchema;
 import com.clickhouse.client.api.query.QuerySettings;
 import com.clickhouse.data.ClickHouseColumn;
 
-import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -30,9 +29,9 @@ public class RowBinaryWithNamesFormatReader extends AbstractBinaryFormatReader {
     public void readRecord(Map<String, Object> record) throws IOException {
         if (columns == null) {
             columns = new ArrayList<>();
-            int nCol = chInputStream.readVarInt();
+            int nCol = BinaryStreamReader.readVarInt(input);
             for (int i = 0; i < nCol; i++) {
-                columns.add(chInputStream.readUnicodeString());
+                columns.add(BinaryStreamReader.readString(input));
             }
 
             columns = Collections.unmodifiableList(columns);

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
@@ -6,7 +6,6 @@ import com.clickhouse.client.api.metadata.TableSchema;
 import com.clickhouse.client.api.query.NullValueException;
 import com.clickhouse.client.api.query.QuerySettings;
 import com.clickhouse.data.ClickHouseColumn;
-import com.clickhouse.data.ClickHouseInputStream;
 import com.clickhouse.data.value.ClickHouseArrayValue;
 import com.clickhouse.data.value.ClickHouseGeoMultiPolygonValue;
 import com.clickhouse.data.value.ClickHouseGeoPointValue;
@@ -41,9 +40,7 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
 
     private static final Logger LOG = LoggerFactory.getLogger(AbstractBinaryFormatReader.class);
 
-    protected InputStream inputStream;
-
-    protected ClickHouseInputStream chInputStream;
+    protected InputStream input;
 
     protected Map<String, Object> settings;
 
@@ -54,14 +51,11 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
     protected volatile boolean hasNext = true;
 
     protected AbstractBinaryFormatReader(InputStream inputStream, QuerySettings querySettings, TableSchema schema) {
-        this.inputStream = inputStream;
-        this.chInputStream = inputStream instanceof ClickHouseInputStream ?
-                (ClickHouseInputStream) inputStream : ClickHouseInputStream.of(inputStream);
+        this.input = inputStream;
         this.settings = querySettings == null ? Collections.emptyMap() : new HashMap<>(querySettings.getAllSettings());
-        this.binaryStreamReader = new BinaryStreamReader(chInputStream, LOG);
+        this.binaryStreamReader = new BinaryStreamReader(inputStream, LOG);
         setSchema(schema);
     }
-
 
     protected Map<String, Object> currentRecord = new ConcurrentHashMap<>();
 
@@ -85,7 +79,7 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
     public boolean hasNext() {
         if (hasNext) {
             try {
-                hasNext = chInputStream.available() > 0;
+                hasNext = input.available() > 0;
                 return hasNext;
             } catch (IOException e) {
                 hasNext = false;

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -1,34 +1,39 @@
 package com.clickhouse.client.api.data_formats.internal;
 
-import com.clickhouse.data.ClickHouseArraySequence;
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseDataType;
-import com.clickhouse.data.ClickHouseDeserializer;
-import com.clickhouse.data.ClickHouseInputStream;
-import com.clickhouse.data.format.BinaryStreamUtils;
-import com.clickhouse.data.value.ClickHouseArrayValue;
+import com.clickhouse.data.ClickHouseValues;
 import org.slf4j.Logger;
 import org.slf4j.helpers.NOPLogger;
 
+import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.IOException;
+import java.io.InputStream;
 import java.lang.reflect.Array;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.net.Inet4Address;
+import java.net.Inet6Address;
 import java.nio.charset.StandardCharsets;
-import java.util.Arrays;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.TimeZone;
+import java.util.UUID;
 
 public class BinaryStreamReader {
 
-    private final ClickHouseInputStream chInputStream;
+    private final DataInputStream input;
 
     private final Logger log;
 
-    BinaryStreamReader(ClickHouseInputStream chInputStream, Logger log) {
-        this.chInputStream = chInputStream;
+    BinaryStreamReader(InputStream input, Logger log) {
         this.log = log == null ? NOPLogger.NOP_LOGGER : log;
+        this.input = new DataInputStream(input); // wrap input stream
     }
 
     public <T> T readValue(ClickHouseColumn column) throws IOException {
@@ -37,7 +42,8 @@ public class BinaryStreamReader {
 
     private <T> T readValueImpl(ClickHouseColumn column) throws IOException {
         if (column.isNullable()) {
-            if (BinaryStreamUtils.readNull(chInputStream)) {
+
+            if (input.readBoolean()) { // is Null?
                 return (T) null;
             }
         }
@@ -46,70 +52,71 @@ public class BinaryStreamReader {
             switch (column.getDataType()) {
                 // Primitives
                 case FixedString: {
-
-                    return (T) BinaryStreamUtils.readFixedString(chInputStream, column.getEstimatedLength(), StandardCharsets.UTF_8).trim();
+                    return (T) new String(readNBytes(input, column.getEstimatedLength()), StandardCharsets.UTF_8);
                 }
                 case String: {
                     // TODO: BinaryStreamUtils.readString() - requires reader that may be causing EOF exception
-                    int len = chInputStream.readVarInt();
-                    return (T) chInputStream.readUnicodeString(len);
+                    int len =  readVarInt(input);
+                    if ( len == 0 ) {
+                        return (T) "";
+                    }
+                    return (T) new String(readNBytes(input, len), StandardCharsets.UTF_8);
                 }
                 case Int8:
-                    return (T) Byte.valueOf(BinaryStreamUtils.readInt8(chInputStream));
+                    return (T) Byte.valueOf(input.readByte());
                 case UInt8:
-                    return (T) Short.valueOf(BinaryStreamUtils.readUnsignedInt8(chInputStream));
+                    return (T) Short.valueOf((short) input.readUnsignedByte());
                 case Int16:
-                    return (T) Short.valueOf(BinaryStreamUtils.readInt16(chInputStream));
+                    return (T) Short.valueOf(input.readShort());
                 case UInt16:
-                    return (T) Integer.valueOf(BinaryStreamUtils.readUnsignedInt16(chInputStream));
+                    return (T) Integer.valueOf(input.readUnsignedShort());
                 case Int32:
-                    return (T) Integer.valueOf(BinaryStreamUtils.readInt32(chInputStream));
+                    return (T) Integer.valueOf(input.readInt());
                 case UInt32:
-                    return (T) Long.valueOf(BinaryStreamUtils.readUnsignedInt32(chInputStream));
+                    return (T) Long.valueOf(input.readInt() & 0xFFFFFFFFL);
                 case Int64:
-                    return (T) Long.valueOf(BinaryStreamUtils.readInt64(chInputStream));
+                    return (T) Long.valueOf(input.readLong());
                 case UInt64:
-                    return (T) BinaryStreamUtils.readUnsignedInt64(chInputStream);
+                    return (T) new BigInteger(readNBytes(input, 8));
                 case Int128:
-                    return (T) BinaryStreamUtils.readInt128(chInputStream);
+                    return (T) new BigInteger(readNBytes(input, 16));
                 case UInt128:
-                    return (T) BinaryStreamUtils.readUnsignedInt128(chInputStream);
+                    return (T) new BigInteger(readNBytes(input, 16));
                 case Int256:
-                    return (T) BinaryStreamUtils.readInt256(chInputStream);
+                    return (T) new BigInteger(readNBytes(input, 32));
                 case UInt256:
-                    return (T) BinaryStreamUtils.readUnsignedInt256(chInputStream);
+                    return (T) new BigInteger(readNBytes(input, 64));
                 case Decimal:
-                    return (T) BinaryStreamUtils.readDecimal(chInputStream, column.getPrecision(), column.getScale());
+                    return (T) readDecimal(input, column.getPrecision(), column.getScale());
                 case Decimal32:
-                    return (T) BinaryStreamUtils.readDecimal32(chInputStream, column.getScale());
+                    return (T) readDecimal(input, column.getPrecision(), column.getScale());
                 case Decimal64:
-                    return (T) BinaryStreamUtils.readDecimal64(chInputStream, column.getScale());
+                    return (T) readDecimal(input, column.getPrecision(), column.getScale());
                 case Decimal128:
-                    return (T) BinaryStreamUtils.readDecimal128(chInputStream, column.getScale());
+                    return (T) readDecimal(input, column.getPrecision(), column.getScale());
                 case Decimal256:
-                    return (T) BinaryStreamUtils.readDecimal256(chInputStream, column.getScale());
+                    return (T) readDecimal(input, column.getPrecision(), column.getScale());
                 case Float32:
-                    return (T) Float.valueOf(BinaryStreamUtils.readFloat32(chInputStream));
+                    return (T) Float.valueOf(input.readFloat());
                 case Float64:
-                    return (T) Double.valueOf(BinaryStreamUtils.readFloat64(chInputStream));
-
+                    return (T) Double.valueOf(input.readDouble());
                 case Bool:
-                    return (T) Boolean.valueOf(BinaryStreamUtils.readBoolean(chInputStream));
+                    return (T) Boolean.valueOf(input.readBoolean());
                 case Enum8:
-                    return (T) Byte.valueOf(BinaryStreamUtils.readEnum8(chInputStream));
+                    return (T) Byte.valueOf(input.readByte());
                 case Enum16:
-                    return (T) Short.valueOf(BinaryStreamUtils.readEnum16(chInputStream));
+                    return (T) Short.valueOf(input.readShort());
 
                 case Date:
-                    return (T) BinaryStreamUtils.readDate(chInputStream, column.getTimeZone());
+                    return (T) readDate(input, column.getTimeZone());
                 case Date32:
-                    return (T) BinaryStreamUtils.readDate32(chInputStream, column.getTimeZone());
+                    return (T) readDate32(input, column.getTimeZone());
                 case DateTime:
-                    return (T) BinaryStreamUtils.readDateTime(chInputStream, column.getTimeZone());
+                    return (T) readDateTime32(input, column.getTimeZone());
                 case DateTime32:
-                    return (T) BinaryStreamUtils.readDateTime32(chInputStream, column.getTimeZone());
+                    return (T) readDateTime32(input, column.getTimeZone());
                 case DateTime64:
-                    return (T) BinaryStreamUtils.readDateTime64(chInputStream, column.getTimeZone());
+                    return (T) readDateTime64(input, 3, column.getTimeZone());
 
                 case IntervalYear:
                 case IntervalQuarter:
@@ -122,22 +129,22 @@ public class BinaryStreamReader {
                 case IntervalMicrosecond:
                 case IntervalMillisecond:
                 case IntervalNanosecond:
-                    return (T) BinaryStreamUtils.readUnsignedInt64(chInputStream);
+                    return (T) new BigInteger(readNBytes(input, 8));
 
                 case IPv4:
-                    return (T) BinaryStreamUtils.readInet4Address(chInputStream);
+                    return (T) Inet4Address.getByAddress(readNBytes(input, 4));
                 case IPv6:
-                    return (T) BinaryStreamUtils.readInet6Address(chInputStream);
+                    return (T) Inet6Address.getByAddress(readNBytes(input, 16));
                 case UUID:
-                    return (T) BinaryStreamUtils.readUuid(chInputStream);
+                    return (T) new UUID(input.readLong(), input.readLong());
                 case Point:
-                    return (T) BinaryStreamUtils.readGeoPoint(chInputStream);
+                    return (T) readGeoPoint(input);
                 case Polygon:
-                    return (T) BinaryStreamUtils.readGeoPolygon(chInputStream);
+                    return (T) readGeoPolygon(input);
                 case MultiPolygon:
-                    return (T) BinaryStreamUtils.readGeoMultiPolygon(chInputStream);
+                    return (T) readGeoMultiPolygon(input);
                 case Ring:
-                    return (T) BinaryStreamUtils.readGeoRing(chInputStream);
+                    return (T) readGeoRing(input);
 
 //                case JSON: // obsolete https://clickhouse.com/docs/en/sql-reference/data-types/json#displaying-json-column
 //                case Object:
@@ -164,9 +171,31 @@ public class BinaryStreamReader {
         }
     }
 
+    public BigDecimal readDecimal(DataInputStream input, int precision, int scale) throws IOException {
+        BigDecimal v;
+
+        if (precision <= ClickHouseDataType.Decimal32.getMaxScale()) {
+            return BigDecimal.valueOf(input.readInt(), scale);
+        } else if (precision <= ClickHouseDataType.Decimal64.getMaxScale()) {
+            v =  BigDecimal.valueOf(input.readLong(), scale);
+        } else if (precision <= ClickHouseDataType.Decimal128.getMaxScale()) {
+            v = new BigDecimal(new BigInteger(readNBytes(input, 16)), scale);
+        } else {
+            v = new BigDecimal(new BigInteger(readNBytes(input, 32)), scale);
+        }
+
+        return v;
+    }
+
+    private byte[] readNBytes(DataInputStream inputStream, int len) throws IOException {
+        byte[] bytes = new byte[len];
+        inputStream.readFully(bytes);
+        return bytes;
+    }
+
     private ArrayValue readArray(ClickHouseColumn column) throws IOException {
         Class<?> itemType = column.getArrayBaseColumn().getDataType().getWiderPrimitiveClass();
-        int len = chInputStream.readVarInt();
+        int len = readVarInt(input);
         ArrayValue array = new ArrayValue(column.getArrayNestedLevel() > 1 ? ArrayValue.class : itemType, len);
 
         if (len == 0) {
@@ -222,7 +251,7 @@ public class BinaryStreamReader {
     }
 
     private Map<?,?> readMap(ClickHouseColumn column) throws IOException {
-        int len = chInputStream.readVarInt();
+        int len = readVarInt(input);
 
         if (len == 0) {
             return Collections.emptyMap();
@@ -248,5 +277,143 @@ public class BinaryStreamReader {
         }
 
         return tuple;
+    }
+
+    public double[] readGeoPoint(DataInputStream input) throws IOException {
+        return new double[] { input.readDouble(), input.readDouble() };
+    }
+
+    public double[][] readGeoRing(DataInputStream input) throws IOException {
+        int count = readVarInt(input);
+        double[][] value = new double[count][2];
+        for (int i = 0; i < count; i++) {
+            value[i] = readGeoPoint(input);
+        }
+        return value;
+    }
+
+
+    public double[][][] readGeoPolygon(DataInputStream input) throws IOException {
+        int count = readVarInt(input);
+        double[][][] value = new double[count][][];
+        for (int i = 0; i < count; i++) {
+            value[i] = readGeoRing(input);
+        }
+        return value;
+    }
+
+    private double[][][][] readGeoMultiPolygon(DataInputStream input) throws IOException {
+        int count = readVarInt(input);
+        double[][][][] value = new double[count][][][];
+        for (int i = 0; i < count; i++) {
+            value[i] = readGeoPolygon(input);
+        }
+        return value;
+    }
+
+    /**
+     * Reads a varint from input stream.
+     *
+     * @return varint
+     * @throws IOException when failed to read value from input stream or reached
+     *                     end of the stream
+     */
+    private int readVarInt(DataInputStream input) throws IOException {
+        // https://github.com/ClickHouse/ClickHouse/blob/abe314feecd1647d7c2b952a25da7abf5c19f352/src/IO/VarInt.h#L126
+        int b = input.readByte();
+        if (b >= 0) {
+            return b;
+        }
+
+        int result = b & 0x7F;
+        for (int shift = 7; shift <= 28; shift += 7) {
+            if ((b = input.readByte()) >= 0) {
+                result |= b << shift;
+                break;
+            } else {
+                result |= (b & 0x7F) << shift;
+            }
+        }
+        // consume a few more bytes - readVarLong() should be called instead
+//        if (b < 0) {
+//            for (int shift = 35; shift <= 63; shift += 7) {
+//                if (peek() < 0 || readByte() >= 0) {
+//                    break;
+//                }
+//            }
+//        }
+        return result;
+    }
+
+    /**
+     * Reads 64-bit varint as long from input stream.
+     *
+     * @return 64-bit varint
+     * @throws IOException when failed to read value from input stream or reached
+     *                     end of the stream
+     */
+    public long readVarLong(DataInputStream input) throws IOException {
+        long b = input.readByte();
+        if (b >= 0L) {
+            return b;
+        }
+
+        long result = b & 0x7F;
+        for (int shift = 7; shift <= 63; shift += 7) {
+            if ((b = input.readByte()) >= 0) {
+                result |= b << shift;
+                break;
+            } else {
+                result |= (b & 0x7F) << shift;
+            }
+        }
+        return result;
+    }
+
+    public static LocalDate readDate(DataInputStream input, TimeZone tz)
+            throws IOException {
+        LocalDate d = LocalDate.ofEpochDay(input.readUnsignedShort());
+        if (tz != null && !tz.toZoneId().equals(ClickHouseValues.SYS_ZONE)) {
+            d = d.atStartOfDay(ClickHouseValues.SYS_ZONE).withZoneSameInstant(tz.toZoneId()).toLocalDate();
+        }
+        return d;
+    }
+
+    public static LocalDate readDate32(DataInputStream input, TimeZone tz)
+            throws IOException {
+        LocalDate d = LocalDate.ofEpochDay(input.readInt());
+        if (tz != null && !tz.toZoneId().equals(ClickHouseValues.SYS_ZONE)) {
+            d = d.atStartOfDay(ClickHouseValues.SYS_ZONE).withZoneSameInstant(tz.toZoneId()).toLocalDate();
+        }
+        return d;
+    }
+
+    public static LocalDateTime readDateTime32(DataInputStream input, TimeZone tz) throws IOException {
+        long time = input.readLong();
+
+        return LocalDateTime.ofInstant(Instant.ofEpochSecond(time < 0L ? 0L : time),
+                tz != null ? tz.toZoneId() : ClickHouseValues.UTC_ZONE);
+    }
+    private static final int[] BASES = new int[] { 1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000,
+            1000000000 };
+
+    public static LocalDateTime readDateTime64(DataInputStream input, int scale, TimeZone tz) throws IOException {
+        long value = input.readLong();
+        int nanoSeconds = 0;
+        if (scale > 0) {
+            int factor = BASES[scale];
+            nanoSeconds = (int) (value % factor);
+            value /= factor;
+            if (nanoSeconds < 0) {
+                nanoSeconds += factor;
+                value--;
+            }
+            if (nanoSeconds > 0L) {
+                nanoSeconds *= BASES[9 - scale];
+            }
+        }
+
+        return LocalDateTime.ofInstant(Instant.ofEpochSecond(value, nanoSeconds),
+                tz != null ? tz.toZoneId() : TimeZone.getTimeZone("UTC").toZoneId());
     }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -65,7 +65,6 @@ public class BinaryStreamReader {
                     return (T) new String(bytes, 0, end, StandardCharsets.UTF_8);
                 }
                 case String: {
-                    // TODO: BinaryStreamUtils.readString() - requires reader that may be causing EOF exception
                     int len =  readVarInt(input);
                     if ( len == 0 ) {
                         return (T) "";
@@ -230,7 +229,7 @@ public class BinaryStreamReader {
     }
 
     public static float readFloatLE(InputStream input) throws IOException {
-        return Float.floatToRawIntBits(readIntLE(input));
+        return Float.intBitsToFloat(readIntLE(input));
     }
 
     public static double readDoubleLE(InputStream input) throws IOException {
@@ -488,5 +487,13 @@ public class BinaryStreamReader {
 
         return LocalDateTime.ofInstant(Instant.ofEpochSecond(value, nanoSeconds),
                 tz != null ? tz.toZoneId() : TimeZone.getTimeZone("UTC").toZoneId());
+    }
+
+    public static String readString(InputStream input) throws IOException {
+        int len =  readVarInt(input);
+        if ( len == 0 ) {
+            return "";
+        }
+        return new String(readNBytes(input, len), StandardCharsets.UTF_8);
     }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/QueryResponse.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/QueryResponse.java
@@ -9,6 +9,7 @@ import com.clickhouse.client.api.metrics.ServerMetrics;
 import com.clickhouse.data.ClickHouseFormat;
 import com.clickhouse.data.ClickHouseInputStream;
 
+import java.io.InputStream;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -52,7 +53,7 @@ public class QueryResponse implements AutoCloseable {
         this.operationMetrics.operationComplete(clickHouseResponse.getSummary());
     }
 
-    public ClickHouseInputStream getInputStream() {
+    public InputStream getInputStream() {
         try {
             return clickHouseResponse.getInputStream();
         } catch (Exception e) {

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
@@ -116,4 +116,12 @@ public class QuerySettings {
     public String getDatabase() {
         return (String) rawSettings.get("database");
     }
+
+    /**
+     * Requests the server to wait for the and of the query before sending response. Useful for getting accurate summary.
+     */
+    public QuerySettings waitEndOfQuery(Boolean waitEndOfQuery) {
+        rawSettings.put("wait_end_of_query", waitEndOfQuery);
+        return this;
+    }
 }

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -77,6 +77,8 @@ public class QueryTests extends BaseIntegrationTest {
                 .addEndpoint(Protocol.HTTP, node.getHost(), node.getPort(), false)
                 .setUsername("default")
                 .setPassword("")
+                .compressClientRequest(false)
+                .compressServerResponse(false)
                 .build();
 
         delayForProfiler(0);
@@ -799,7 +801,7 @@ public class QueryTests extends BaseIntegrationTest {
 
         final List<Supplier<String>> valueGenerators = Arrays.asList(
                 () -> sq("utf8 string с кириллицей そして他のホイッスル"),
-                () -> sq("ten chars"),
+                () -> sq("7 chars"),
                 () -> "NULL",
                 () -> sq("not null string")
         );
@@ -901,6 +903,7 @@ public class QueryTests extends BaseIntegrationTest {
                 colIndex++;
                 try {
                     verifier.accept(reader);
+                    System.out.println("Verified " + colIndex);
                 } catch (Exception e) {
                     Assert.fail("Failed to verify " + columns.get(colIndex), e);
                 }

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -925,7 +925,9 @@ public class QueryTests extends BaseIntegrationTest {
 
         String uuid = UUID.randomUUID().toString();
         QuerySettings settings = new QuerySettings()
-                .setFormat(ClickHouseFormat.TabSeparated).setQueryId(uuid);
+                .setFormat(ClickHouseFormat.TabSeparated)
+                .waitEndOfQuery(true)
+                .setQueryId(uuid);
 
         QueryResponse response = client.query("SELECT * FROM " + DATASET_TABLE + " LIMIT 3", settings).get();
 


### PR DESCRIPTION
## Summary
Previous implementation was using ClickHouseInputStream and BinaryStreamUtils to read data. 
This PR removes any references for this two classes from client v2 code 

Bonus: 
There is a fix for premature summary. Operations like `queryAll` or `queryRecords` require to have result rows count. However summery doesn't guarantee to have it correct if no `wait_end_of_query=true` is set.  

