### PR TITLE
[client-v2] Fix reading binary streams

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -392,7 +392,7 @@ public class Client implements AutoCloseable {
          * @param enabled - indicates if server response compression is enabled
          */
         public Builder compressServerResponse(boolean enabled) {
-            this.configuration.put("compress", String.valueOf(enabled));
+            this.configuration.put(ClickHouseClientOption.COMPRESS.getKey(), String.valueOf(enabled));
             return this;
         }
 
@@ -403,7 +403,7 @@ public class Client implements AutoCloseable {
          * @param enabled - indicates if client request compression is enabled
          */
         public Builder compressClientRequest(boolean enabled) {
-            this.configuration.put("decompress", String.valueOf(enabled));
+            this.configuration.put(ClickHouseClientOption.DECOMPRESS.getKey(), String.valueOf(enabled));
             return this;
         }
 
@@ -1149,8 +1149,9 @@ public class Client implements AutoCloseable {
                 List<GenericRecord> records = new ArrayList<>();
                 if (response.getResultRows() > 0) {
                     ClickHouseBinaryFormatReader reader = new RowBinaryWithNamesAndTypesFormatReader(response.getInputStream());
-                    while (reader.hasNext()) {
-                        records.add(new MapBackedRecord(reader.next(), reader.getSchema()));
+                    Map<String, Object> record;
+                    while ((record = reader.next()) != null) {
+                        records.add(new MapBackedRecord(record, reader.getSchema()));
                     }
                 }
                 return records;

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/ClickHouseBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/ClickHouseBinaryFormatReader.java
@@ -52,7 +52,7 @@ public interface ClickHouseBinaryFormatReader {
     /**
      * Moves cursor to the next row. Must be called before reading the first row.
      *
-     * @return true if there are more rows to read, false otherwise
+     * @return map filled with column values or null if no more records are available
      */
     Map<String, Object> next();
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryWithNamesAndTypesFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryWithNamesAndTypesFormatReader.java
@@ -30,7 +30,13 @@ public class RowBinaryWithNamesAndTypesFormatReader extends AbstractBinaryFormat
         try {
             TableSchema headerSchema = new TableSchema();
             List<String> columns = new ArrayList<>();
-            int nCol = BinaryStreamReader.readVarInt(input);
+            int nCol;
+            try {
+                nCol = BinaryStreamReader.readVarInt(input);
+            } catch (EOFException e) {
+                endReached();
+                return;
+            }
             for (int i = 0; i < nCol; i++) {
                 columns.add(BinaryStreamReader.readString(input));
             }
@@ -42,23 +48,6 @@ public class RowBinaryWithNamesAndTypesFormatReader extends AbstractBinaryFormat
             setSchema(headerSchema);
         } catch (IOException e) {
             throw new ClientException("Failed to read header", e);
-        }
-    }
-
-    /**
-     * Reads a row to a map using column definitions from the schema.
-     * If column type mismatch and cannot be converted, an exception will be thrown.
-     *
-     * @param record data destination
-     * @throws IOException
-     */
-    @Override
-    public void readRecord(Map<String, Object> record) throws IOException {
-        for (ClickHouseColumn column : getSchema().getColumns()) {
-            Object val = binaryStreamReader.readValue(column);
-            if (val != null) {
-                record.put(column.getColumnName(),val);
-            }
         }
     }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -7,7 +7,6 @@ import com.clickhouse.data.ClickHouseValues;
 import org.slf4j.Logger;
 import org.slf4j.helpers.NOPLogger;
 
-import java.io.DataInputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -34,7 +33,7 @@ public class BinaryStreamReader {
 
     BinaryStreamReader(InputStream input, Logger log) {
         this.log = log == null ? NOPLogger.NOP_LOGGER : log;
-        this.input = new DataInputStream(input); // wrap input stream
+        this.input = input;
     }
 
     public <T> T readValue(ClickHouseColumn column) throws IOException {
@@ -43,8 +42,8 @@ public class BinaryStreamReader {
 
     private <T> T readValueImpl(ClickHouseColumn column) throws IOException {
         if (column.isNullable()) {
-
-            if (input.read() == 1) { // is Null?
+            int isNull = readByteOrEOF(input);
+            if (isNull == 1) { // is Null?
                 return (T) null;
             }
         }
@@ -64,14 +63,14 @@ public class BinaryStreamReader {
                     return (T) new String(bytes, 0, end, StandardCharsets.UTF_8);
                 }
                 case String: {
-                    int len =  readVarInt(input);
-                    if ( len == 0 ) {
+                    int len = readVarInt(input);
+                    if (len == 0) {
                         return (T) "";
                     }
                     return (T) new String(readNBytes(input, len), StandardCharsets.UTF_8);
                 }
                 case Int8:
-                    return (T) Byte.valueOf((byte) input.read());
+                    return (T) Byte.valueOf((byte) readByteOrEOF(input));
                 case UInt8:
                     return (T) Short.valueOf(readUnsignedByte(input));
                 case Int16:
@@ -109,7 +108,7 @@ public class BinaryStreamReader {
                 case Float64:
                     return (T) Double.valueOf(readDoubleLE(input));
                 case Bool:
-                    return (T) Boolean.valueOf(input.read() == 1);
+                    return (T) Boolean.valueOf(readByteOrEOF(input) == 1);
                 case Enum8:
                     return (T) Byte.valueOf((byte) readUnsignedByte(input));
                 case Enum16:
@@ -168,6 +167,8 @@ public class BinaryStreamReader {
                 default:
                     throw new IllegalArgumentException("Unsupported data type: " + column.getDataType());
             }
+        } catch (EOFException e) {
+            throw e;
         } catch (Exception e) {
             throw new ClientException("Failed to read value for column " + column.getColumnName(), e);
         }
@@ -175,30 +176,30 @@ public class BinaryStreamReader {
 
     public static short readShortLE(InputStream input) throws IOException {
         short v = 0;
-        v |= (short) input.read();
-        v |= (short) (input.read() << 8);
+        v |= (short) readByteOrEOF(input);
+        v |= (short) (readByteOrEOF(input) << 8);
         return v;
     }
 
     public static int readIntLE(InputStream input) throws IOException {
         int v = 0;
-        v |= input.read();
-        v |= input.read() << 8;
-        v |= input.read() << 16;
-        v |= input.read() << 24;
+        v |= readByteOrEOF(input);
+        v |= readByteOrEOF(input) << 8;
+        v |= readByteOrEOF(input) << 16;
+        v |= readByteOrEOF(input) << 24;
         return v;
     }
 
     public static long readLongLE(InputStream input) throws IOException {
         long v = 0;
-        v |= input.read();
-        v |= (0xFFL & input.read()) << 8;
-        v |= (0xFFL & input.read()) << 16;
-        v |= (0xFFL & input.read()) << 24;
-        v |= (0xFFL & input.read()) << 32;
-        v |= (0xFFL & input.read()) << 40;
-        v |= (0xFFL & input.read()) << 48;
-        v |= (0xFFL & input.read()) << 56;
+        v |= readByteOrEOF(input);
+        v |= (0xFFL & readByteOrEOF(input)) << 8;
+        v |= (0xFFL & readByteOrEOF(input)) << 16;
+        v |= (0xFFL & readByteOrEOF(input)) << 24;
+        v |= (0xFFL & readByteOrEOF(input)) << 32;
+        v |= (0xFFL & readByteOrEOF(input)) << 40;
+        v |= (0xFFL & readByteOrEOF(input)) << 48;
+        v |= (0xFFL & readByteOrEOF(input)) << 56;
 
         return v;
     }
@@ -407,7 +408,7 @@ public class BinaryStreamReader {
         int value = 0;
 
         for (int i = 0 ; i < 10 ; i++) {
-            byte b = (byte) input.read();
+            byte b = (byte) readByteOrEOF(input);
             value |= (b & 0x7F) << (7 * i);
 
             if ((b & 0x80) == 0) {
@@ -419,7 +420,7 @@ public class BinaryStreamReader {
     }
 
     public static short readUnsignedByte(InputStream input) throws IOException {
-        return (short) (input.read() & 0xFF);
+        return (short) (readByteOrEOF(input) & 0xFF);
     }
 
     public static int readUnsignedShortLE(InputStream input) throws IOException {
@@ -495,5 +496,13 @@ public class BinaryStreamReader {
             return "";
         }
         return new String(readNBytes(input, len), StandardCharsets.UTF_8);
+    }
+
+    private static int readByteOrEOF(InputStream input) throws IOException {
+        int b = input.read();
+        if (b < 0) {
+            throw new EOFException("End of stream reached before reading all data");
+        }
+        return b;
     }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/MapBackedRecord.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/MapBackedRecord.java
@@ -22,6 +22,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -33,7 +34,7 @@ public class MapBackedRecord implements GenericRecord {
     private TableSchema schema;
 
     public MapBackedRecord(Map<String, Object> record, TableSchema schema) {
-        this.record = record;
+        this.record = new HashMap<>(record);
         this.schema = schema;
     }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/Records.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/Records.java
@@ -27,6 +27,7 @@ public class Records implements Iterable<GenericRecord>, AutoCloseable {
         if (!response.getFormat().equals(ClickHouseFormat.RowBinaryWithNamesAndTypes)) {
             throw new ClientException("Unsupported format: " + finalSettings.getFormat());
         }
+
         this.reader = new RowBinaryWithNamesAndTypesFormatReader(response.getInputStream());
         this.empty = !reader.hasNext();
     }

--- a/client-v2/src/test/java/com/clickhouse/client/ClientTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/ClientTests.java
@@ -52,11 +52,13 @@ public class ClientTests extends BaseIntegrationTest {
                         .addEndpoint("https://" + node.getHost() + ":" + node.getPort())
                         .setUsername("default")
                         .setPassword("")
+                        .setRootCertificate("containers/clickhouse-server/certs/localhost.crt")
                         .build(),
                 new Client.Builder()
                         .addEndpoint(Protocol.HTTP, node.getHost(), node.getPort(), true)
                         .setUsername("default")
                         .setPassword("")
+                        .setRootCertificate("containers/clickhouse-server/certs/localhost.crt")
                         .build()
         };
     }

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -215,7 +215,7 @@ public class QueryTests extends BaseIntegrationTest {
     @Test(groups = {"integration"}, dataProvider = "rowBinaryFormats")
     public void testRowBinaryQueries(ClickHouseFormat format)
             throws ExecutionException, InterruptedException {
-        final int rows = 1;
+        final int rows = 3;
         // TODO: replace with dataset with all primitive types of data
         // TODO: reusing same table name may lead to a conflict in tests?
 
@@ -229,11 +229,15 @@ public class QueryTests extends BaseIntegrationTest {
         ClickHouseBinaryFormatReader reader = createBinaryFormatReader(queryResponse, settings, tableSchema);
 
         Iterator<Map<String, Object>> dataIterator = data.iterator();
+        int rowsCount = 0;
         while (dataIterator.hasNext()) {
             Map<String, Object> expectedRecord = dataIterator.next();
             Map<String, Object> actualRecord = reader.next();
             Assert.assertEquals(actualRecord, expectedRecord);
+            rowsCount++;
         }
+
+        Assert.assertEquals(rowsCount, rows);
     }
 
     private static ClickHouseBinaryFormatReader createBinaryFormatReader(QueryResponse response, QuerySettings settings,
@@ -272,6 +276,7 @@ public class QueryTests extends BaseIntegrationTest {
         schema.addColumn("col3", "String");
         schema.addColumn("host", "String");
         ClickHouseBinaryFormatReader reader = createBinaryFormatReader(queryResponse, settings, schema);
+        int rowsCount = 0;
         while (reader.next() != null) {
             String hostName = reader.readValue("host");
             Long col1 = reader.readValue("col1");
@@ -282,8 +287,9 @@ public class QueryTests extends BaseIntegrationTest {
             Assert.assertEquals(reader.readValue(1), col1);
             Assert.assertEquals(reader.readValue(2), col3);
             Assert.assertEquals(reader.readValue(3), hostName);
+            rowsCount++;
         }
-
+        Assert.assertEquals(rowsCount, 10);
         Assert.assertFalse(reader.hasNext());
         Assert.assertNull(reader.next());
     }

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -86,7 +86,7 @@ public class QueryTests extends BaseIntegrationTest {
                 .setPassword("")
                 .compressClientRequest(false)
                 .compressServerResponse(false)
-                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "false").equals("true"))
+                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "true").equals("true"))
                 .build();
 
         delayForProfiler(0);
@@ -272,8 +272,7 @@ public class QueryTests extends BaseIntegrationTest {
         schema.addColumn("col3", "String");
         schema.addColumn("host", "String");
         ClickHouseBinaryFormatReader reader = createBinaryFormatReader(queryResponse, settings, schema);
-        while (reader.hasNext()) {
-            Assert.assertNotNull(reader.next());
+        while (reader.next() != null) {
             String hostName = reader.readValue("host");
             Long col1 = reader.readValue("col1");
             String col3 = reader.readValue("col3");
@@ -285,7 +284,8 @@ public class QueryTests extends BaseIntegrationTest {
             Assert.assertEquals(reader.readValue(3), hostName);
         }
 
-        Assert.expectThrows(NoSuchElementException.class, reader::next);
+        Assert.assertFalse(reader.hasNext());
+        Assert.assertNull(reader.next());
     }
 
     @Test(groups = {"integration"})


### PR DESCRIPTION
## Summary

### Problem 1
Some streams return `0` when `available()` called even when data is available. Some streams may throw EOFException while read some may not. So only check for number of read bytes or result of `read()` really works. 

### Problem 2 
If we want to wrap a stream of data into collection we must properly implement `hasNext()`. Because of problem#1 we can not do it easily


### Solution 
- Check `read()` result and throw EOFException 
- Read data up-front. It will give some overhead, but it is simplest solution 
- Logic is based on EOFException what is bad, but can be fixed in future with passing error handler to each read or returning tuples (what will be a memory overhead) 
    - If EOFException is throw before reading next record - it assumes that if we at the start of row reaching end of stream indicates that no row is sent by server. 




## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
