### PR TITLE
[client-v2] Compression Support

### DIFF
--- a/client-v2/pom.xml
+++ b/client-v2/pom.xml
@@ -47,6 +47,11 @@
             <artifactId>lz4-pure-java</artifactId>
             <optional>true</optional>
         </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>org.apache.commons.compress</artifactId>
+            <version>${repackaged.version}</version>
+        </dependency>
         <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>

--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -40,6 +40,8 @@ import com.clickhouse.data.ClickHouseDataStreamFactory;
 import com.clickhouse.data.ClickHouseFormat;
 import com.clickhouse.data.ClickHousePipedOutputStream;
 import com.clickhouse.data.format.BinaryStreamUtils;
+import org.apache.commons.compress.compressors.lz4.BlockLZ4CompressorOutputStream;
+import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorOutputStream;
 import org.apache.hc.core5.concurrent.DefaultThreadFactory;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.HttpStatus;
@@ -758,6 +760,7 @@ public class Client implements AutoCloseable {
                                                 }
                                             }
                                         }
+                                        out.close();
                                     })) {
 
 
@@ -876,7 +879,7 @@ public class Client implements AutoCloseable {
                                              while ((bytesRead = data.read(buffer)) != -1) {
                                                  out.write(buffer, 0, bytesRead);
                                              }
-                                             out.flush();
+                                             out.close();
                                          })) {
 
 
@@ -1038,7 +1041,7 @@ public class Client implements AutoCloseable {
                         ClassicHttpResponse httpResponse =
                                 httpClientHelper.executeRequest(selectedNode, finalSettings.getAllSettings(), output -> {
                                     output.write(sqlQuery.getBytes(StandardCharsets.UTF_8));
-                                    output.flush();
+                                    output.close();
                                 });
 
                         // Check response

--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -34,6 +34,7 @@ import com.clickhouse.client.api.query.Records;
 import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.client.config.ClickHouseDefaults;
 import com.clickhouse.client.http.ClickHouseHttpProto;
+import com.clickhouse.client.http.config.ClickHouseHttpOption;
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseDataStreamFactory;
 import com.clickhouse.data.ClickHouseFormat;
@@ -404,6 +405,11 @@ public class Client implements AutoCloseable {
          */
         public Builder compressClientRequest(boolean enabled) {
             this.configuration.put(ClickHouseClientOption.DECOMPRESS.getKey(), String.valueOf(enabled));
+            return this;
+        }
+
+        public Builder useHttpCompression(boolean enabled) {
+            this.configuration.put("client.use_http_compression", String.valueOf(enabled));
             return this;
         }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/ClickHouseLZ4InputStream.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/ClickHouseLZ4InputStream.java
@@ -11,7 +11,6 @@ import org.slf4j.LoggerFactory;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.StreamCorruptedException;
 import java.nio.ByteBuffer;
 
 public class ClickHouseLZ4InputStream extends InputStream {
@@ -26,11 +25,11 @@ public class ClickHouseLZ4InputStream extends InputStream {
     private byte[] tmpBuffer = new byte[1];
 
 
-    public ClickHouseLZ4InputStream(InputStream in, LZ4FastDecompressor decompressor) {
+    public ClickHouseLZ4InputStream(InputStream in, LZ4FastDecompressor decompressor, int bufferSize) {
         super();
         this.decompressor = decompressor;
         this.in = in;
-        this.buffer = ByteBuffer.allocate(8192);
+        this.buffer = ByteBuffer.allocate(bufferSize);
         this.buffer.limit(0);
     }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/ClickHouseLZ4InputStream.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/ClickHouseLZ4InputStream.java
@@ -1,0 +1,155 @@
+package com.clickhouse.client.api.internal;
+
+import com.clickhouse.client.api.ClientException;
+import com.clickhouse.data.ClickHouseByteUtils;
+import com.clickhouse.data.ClickHouseCityHash;
+import net.jpountz.lz4.LZ4FastDecompressor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+
+public class ClickHouseLZ4InputStream extends InputStream {
+
+    private static Logger LOG = LoggerFactory.getLogger(ClickHouseLZ4InputStream.class);
+    private final LZ4FastDecompressor decompressor;
+
+    private final InputStream in;
+
+    private ByteBuffer buffer;
+
+    private byte[] tmpBuffer = new byte[1];
+
+
+    public ClickHouseLZ4InputStream(InputStream in, LZ4FastDecompressor decompressor) {
+        super();
+        this.decompressor = decompressor;
+        this.in = in;
+        this.buffer = ByteBuffer.allocate(8192);
+        this.buffer.limit(0);
+    }
+
+    @Override
+    public int read() throws IOException {
+        int n = read(tmpBuffer, 0, 1);
+        return n == -1 ? -1 : tmpBuffer[0] & 0xFF;
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (b == null) {
+            throw new NullPointerException("b is null");
+        } else if (off < 0) {
+            throw new IndexOutOfBoundsException("off is negative");
+        } else if (len < 0) {
+            throw new IndexOutOfBoundsException("len is negative");
+        } else if (off + len > b.length) {
+            throw new IndexOutOfBoundsException("off + len is greater than b.length");
+        } else if (len == 0) {
+            return 0;
+        }
+
+        int readBytes = 0;
+        do {
+            int remaining = Math.min(len - readBytes, buffer.remaining());
+            buffer.get(b, off + readBytes, remaining);
+            readBytes += remaining;
+        } while (readBytes < len && refill() != -1);
+
+        return readBytes == 0 ? -1 : readBytes;
+    }
+
+
+    static final byte MAGIC = (byte) 0x82;
+    static final int HEADER_LENGTH = 25;
+
+    static final byte[] headerBuff = new byte[HEADER_LENGTH];
+
+    private int refill() throws IOException {
+
+        // read header
+        int readBytes = in.read(headerBuff, 0, HEADER_LENGTH);
+        if (readBytes == -1) {
+            return -1;
+        } else  if (readBytes < HEADER_LENGTH) {
+            throw new IOException("Unexpected end of stream");
+        }
+
+        if (headerBuff[16] != MAGIC) {
+            // 1 byte - 0x82 (shows this is LZ4)
+            throw new ClientException("Invalid LZ4 magic byte: '" + headerBuff[16] + "'");
+        }
+
+        // 4 bytes - size of the compressed data including 9 bytes of the header
+        int compressedSizeWithHeader = getInt32(headerBuff, 17);
+        // 4 bytes - size of uncompressed data
+        int uncompressedSize = getInt32(headerBuff, 21);
+
+        int offset = 9;
+        final byte[] block =  new byte[compressedSizeWithHeader];
+        block[0] = MAGIC;
+        setInt32(block, 1, compressedSizeWithHeader);
+        setInt32(block, 5, uncompressedSize);
+        // compressed data: compressed_size - 9 bytes
+        int remaining = compressedSizeWithHeader - offset;
+        readBytes = in.read(block, offset, remaining);
+        if (readBytes == -1) {
+            throw new EOFException("Unexpected end of stream");
+        } else if (readBytes < remaining) {
+            throw new ClientException("Read bytes: " + readBytes + " but expected: " + remaining);
+        }
+
+        long[] real = ClickHouseCityHash.cityHash128(block, 0, compressedSizeWithHeader);
+        if (real[0] != getInt64(headerBuff, 0) || real[1] != ClickHouseByteUtils.getInt64(headerBuff, 8)) {
+            throw new ClientException("Corrupted stream: checksum mismatch");
+        }
+
+        if (buffer.capacity() < uncompressedSize) {
+            buffer = ByteBuffer.allocate(uncompressedSize);
+            LOG.warn("Buffer size is too small, reallocate buffer with size: " + uncompressedSize);
+        }
+        decompressor.decompress(ByteBuffer.wrap(block), offset,  buffer, 0, uncompressedSize);
+        buffer.position(0);
+        buffer.limit(uncompressedSize);
+        return uncompressedSize;
+    }
+
+    /**
+     * Read int32 Little Endian
+     * @param bytes
+     * @param offset
+     * @return
+     */
+    private int getInt32(byte[] bytes, int offset) {
+        return (0xFF & bytes[offset]) | ((0xFF & bytes[offset + 1]) << 8) | ((0xFF & bytes[offset + 2]) << 16)
+                | ((0xFF & bytes[offset + 3]) << 24);
+    }
+
+    /**
+     * Read int64 Little Endian
+     * @param bytes
+     * @param offset
+     * @return
+     */
+    public long getInt64(byte[] bytes, int offset) {
+        return (0xFFL & bytes[offset]) | ((0xFFL & bytes[offset + 1]) << 8) | ((0xFFL & bytes[offset + 2]) << 16)
+                | ((0xFFL & bytes[offset + 3]) << 24) | ((0xFFL & bytes[offset + 4]) << 32)
+                | ((0xFFL & bytes[offset + 5]) << 40) | ((0xFFL & bytes[offset + 6]) << 48)
+                | ((0xFFL & bytes[offset + 7]) << 56);
+    }
+
+    public void setInt32(byte[] bytes, int offset, int value) {
+        bytes[offset] = (byte) (0xFF & value);
+        bytes[offset + 1] = (byte) (0xFF & (value >> 8));
+        bytes[offset + 2] = (byte) (0xFF & (value >> 16));
+        bytes[offset + 3] = (byte) (0xFF & (value >> 24));
+    }
+
+    @Override
+    public void close() throws IOException {
+        super.close();
+    }
+}

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/ClickHouseLZ4OutputStream.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/ClickHouseLZ4OutputStream.java
@@ -1,17 +1,15 @@
 package com.clickhouse.client.api.internal;
 
-import com.clickhouse.data.ClickHouseByteUtils;
 import com.clickhouse.data.ClickHouseCityHash;
-import com.clickhouse.data.stream.Lz4InputStream;
 import net.jpountz.lz4.LZ4Compressor;
-import net.jpountz.lz4.LZ4FastDecompressor;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.nio.MappedByteBuffer;
 
 public class ClickHouseLZ4OutputStream extends OutputStream {
+
+    public static final int UNCOMPRESSED_BUFF_SIZE = 8192;
 
     private final ByteBuffer buffer;
 
@@ -26,9 +24,9 @@ public class ClickHouseLZ4OutputStream extends OutputStream {
     private static int HEADER_LEN = 15; // 9 bytes for header, 6 bytes for checksum
 
 
-    public ClickHouseLZ4OutputStream(OutputStream out, LZ4Compressor compressor) {
+    public ClickHouseLZ4OutputStream(OutputStream out, LZ4Compressor compressor, int bufferSize) {
         super();
-        this.buffer = ByteBuffer.allocate(8192);
+        this.buffer = ByteBuffer.allocate(bufferSize);
         this.out = out;
         this.compressor = compressor;
         this.compressedBuffer = ByteBuffer.allocate(compressor.maxCompressedLength(buffer.capacity()) + HEADER_LEN);

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/ClickHouseLZ4OutputStream.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/ClickHouseLZ4OutputStream.java
@@ -1,0 +1,103 @@
+package com.clickhouse.client.api.internal;
+
+import com.clickhouse.data.ClickHouseByteUtils;
+import com.clickhouse.data.ClickHouseCityHash;
+import com.clickhouse.data.stream.Lz4InputStream;
+import net.jpountz.lz4.LZ4Compressor;
+import net.jpountz.lz4.LZ4FastDecompressor;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.MappedByteBuffer;
+
+public class ClickHouseLZ4OutputStream extends OutputStream {
+
+    private final ByteBuffer buffer;
+
+    private final OutputStream out;
+
+    private final LZ4Compressor compressor;
+
+    private byte tmpBuffer[] = new byte[1];
+
+    private final ByteBuffer compressedBuffer;
+
+    private static int HEADER_LEN = 15; // 9 bytes for header, 6 bytes for checksum
+
+
+    public ClickHouseLZ4OutputStream(OutputStream out, LZ4Compressor compressor) {
+        super();
+        this.buffer = ByteBuffer.allocate(8192);
+        this.out = out;
+        this.compressor = compressor;
+        this.compressedBuffer = ByteBuffer.allocate(compressor.maxCompressedLength(buffer.capacity()) + HEADER_LEN);
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        tmpBuffer[0] = (byte) b;
+        write(tmpBuffer, 0, 1);
+    }
+
+    @Override
+    public void write( byte[] b, int off, int len) throws IOException {
+        if (b == null) {
+            throw new NullPointerException("b is null");
+        } else if (off < 0) {
+            throw new IndexOutOfBoundsException("off is negative");
+        } else if (len < 0) {
+            throw new IndexOutOfBoundsException("len is negative");
+        } else if (off + len > b.length) {
+            throw new IndexOutOfBoundsException("off + len is greater than b.length");
+        } else if (len == 0) {
+            return;
+        }
+
+        int writtenBytes = 0;
+        do {
+            int remaining = Math.min(len - writtenBytes, buffer.remaining());
+            buffer.put(b, off + writtenBytes, remaining);
+            writtenBytes += remaining;
+            if (buffer.remaining() == 0) {
+                flush();
+            }
+        } while (writtenBytes < len);
+    }
+
+    @Override
+    public void flush() throws IOException {
+        compressedBuffer.clear();
+        compressedBuffer.put(16, ClickHouseLZ4InputStream.MAGIC);
+        int uncompressedLen = buffer.position();
+        buffer.flip();
+        int compressed = compressor.compress(buffer, 0, uncompressedLen, compressedBuffer, 25,
+                compressedBuffer.remaining() - 25);
+        int compressedSizeWithHeader = compressed + 9;
+        ClickHouseLZ4InputStream.setInt32(compressedBuffer.array(), 17, compressedSizeWithHeader); // compressed size with header
+        ClickHouseLZ4InputStream.setInt32(compressedBuffer.array(), 21, uncompressedLen); // uncompressed size
+        long[] hash = ClickHouseCityHash.cityHash128(compressedBuffer.array(), 16, compressedSizeWithHeader);
+        setInt64(compressedBuffer.array(), 0, hash[0]);
+        setInt64(compressedBuffer.array(), 8, hash[1]);
+        compressedBuffer.flip();
+        out.write(compressedBuffer.array(), 0, compressed + 25);
+        buffer.clear();
+    }
+
+
+    static void setInt64(byte[] bytes, int offset, long value) {
+        bytes[offset] = (byte) (0xFF & value);
+        bytes[offset + 1] = (byte) (0xFF & (value >> 8));
+        bytes[offset + 2] = (byte) (0xFF & (value >> 16));
+        bytes[offset + 3] = (byte) (0xFF & (value >> 24));
+        bytes[offset + 4] = (byte) (0xFF & (value >> 32));
+        bytes[offset + 5] = (byte) (0xFF & (value >> 40));
+        bytes[offset + 6] = (byte) (0xFF & (value >> 48));
+        bytes[offset + 7] = (byte) (0xFF & (value >> 56));
+    }
+    @Override
+    public void close() throws IOException {
+        flush();
+        out.close();
+    }
+}

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
@@ -329,7 +329,8 @@ public class HttpAPIClientHelper {
         boolean clientCompression = chConfiguration.getOrDefault(ClickHouseClientOption.DECOMPRESS.getKey(), "false").equalsIgnoreCase("true");
         boolean useHttpCompression = chConfiguration.getOrDefault("client.use_http_compression", "false").equalsIgnoreCase("true");
         if (serverCompression || clientCompression) {
-            return new LZ4Entity(httpEntity, useHttpCompression, serverCompression, clientCompression);
+            return new LZ4Entity(httpEntity, useHttpCompression, serverCompression, clientCompression,
+                    MapUtils.getInt(chConfiguration, "compression.lz4.uncompressed_buffer_size"));
         } else {
             return httpEntity;
         }

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
@@ -278,13 +278,11 @@ public class HttpAPIClientHelper {
         boolean clientCompression = chConfiguration.getOrDefault(ClickHouseClientOption.DECOMPRESS.getKey(), "false").equalsIgnoreCase("true");
         boolean useHttpCompression = chConfiguration.getOrDefault("client.use_http_compression", "false").equalsIgnoreCase("true");
 
-        if (serverCompression) {
-            if (useHttpCompression) {
+        if (useHttpCompression) {
+            if (serverCompression) {
                 req.addHeader(HttpHeaders.ACCEPT_ENCODING, "lz4");
             }
-        }
-        if (clientCompression) {
-            if (useHttpCompression) {
+            if (clientCompression) {
                 req.addHeader(HttpHeaders.CONTENT_ENCODING, "lz4");
             }
         }
@@ -310,19 +308,20 @@ public class HttpAPIClientHelper {
         boolean clientCompression = chConfiguration.getOrDefault(ClickHouseClientOption.DECOMPRESS.getKey(), "false").equalsIgnoreCase("true");
         boolean useHttpCompression = chConfiguration.getOrDefault("client.use_http_compression", "false").equalsIgnoreCase("true");
 
-        if (serverCompression) {
-            if (useHttpCompression) {
-                req.addParameter("enable_http_compression", "1");
-            } else {
+
+        if (useHttpCompression) {
+            // enable_http_compression make server react on http header
+            // for client side compression Content-Encoding should be set
+            // for server side compression Accept-Encoding should be set
+            req.addParameter("enable_http_compression", "1");
+        } else {
+            if (serverCompression) {
                 req.addParameter("compress", "1");
             }
-        }
-        if (clientCompression) {
-            if (useHttpCompression) {
-                req.addParameter("enable_http_compression", "1");
-            } else {
+            if (clientCompression) {
                 req.addParameter("decompress", "1");
-            }        }
+            }
+        }
     }
 
     private HttpEntity wrapEntity(HttpEntity httpEntity) {

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/LZ4Entity.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/LZ4Entity.java
@@ -1,0 +1,93 @@
+package com.clickhouse.client.api.internal;
+
+import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorInputStream;
+import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorOutputStream;
+import org.apache.hc.core5.function.Supplier;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpEntity;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Set;
+
+class LZ4Entity implements HttpEntity {
+
+    private HttpEntity httpEntity;
+    
+    private boolean useHttpCompression;
+    private boolean serverCompression; 
+    private boolean clientCompression;
+    
+    
+    LZ4Entity(HttpEntity httpEntity, boolean useHttpCompression, boolean serverCompression, boolean clientCompression) {
+        this.httpEntity = httpEntity;
+        this.useHttpCompression = useHttpCompression;
+        this.serverCompression = serverCompression;
+        this.clientCompression = clientCompression;
+    }
+    
+    @Override
+    public boolean isRepeatable() {
+        return httpEntity.isRepeatable();
+    }
+
+    @Override
+    public InputStream getContent() throws IOException, UnsupportedOperationException {
+        if (serverCompression && useHttpCompression) {
+            return new FramedLZ4CompressorInputStream(httpEntity.getContent());
+        } else {
+            return httpEntity.getContent();
+        }
+    }
+
+    @Override
+    public void writeTo(OutputStream outStream) throws IOException {
+        if (clientCompression && useHttpCompression) {
+            httpEntity.writeTo(new FramedLZ4CompressorOutputStream(outStream));
+        } else {
+            httpEntity.writeTo(outStream);
+        }
+    }
+
+    @Override
+    public boolean isStreaming() {
+        return httpEntity.isStreaming();
+    }
+
+    @Override
+    public Supplier<List<? extends Header>> getTrailers() {
+        return httpEntity.getTrailers();
+    }
+
+    @Override
+    public void close() throws IOException {
+        httpEntity.close();
+    }
+
+    @Override
+    public long getContentLength() {
+        return httpEntity.getContentLength();
+    }
+
+    @Override
+    public String getContentType() {
+        return httpEntity.getContentType();
+    }
+
+    @Override
+    public String getContentEncoding() {
+        return httpEntity.getContentEncoding();
+    }
+
+    @Override
+    public boolean isChunked() {
+        return httpEntity.isChunked();
+    }
+
+    @Override
+    public Set<String> getTrailerNames() {
+        return httpEntity.getTrailerNames();
+    }
+}

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/LZ4Entity.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/LZ4Entity.java
@@ -36,7 +36,16 @@ class LZ4Entity implements HttpEntity {
     @Override
     public InputStream getContent() throws IOException, UnsupportedOperationException {
         if (serverCompression && useHttpCompression) {
-            return new FramedLZ4CompressorInputStream(httpEntity.getContent());
+            InputStream content = httpEntity.getContent();
+            try {
+                return new FramedLZ4CompressorInputStream(content);
+            } catch (IOException e) {
+                // This is the easiest way to handle empty content because
+                // - streams at this point wrapped with something else and we can't check content length
+                // - exception is thrown with no details
+                // So we just return original content and if there is a real data in it we will get error later
+                return content;
+            }
         } else {
             return httpEntity.getContent();
         }

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/LZ4Entity.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/LZ4Entity.java
@@ -1,5 +1,6 @@
 package com.clickhouse.client.api.internal;
 
+import net.jpountz.lz4.LZ4Factory;
 import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorInputStream;
 import org.apache.commons.compress.compressors.lz4.FramedLZ4CompressorOutputStream;
 import org.apache.hc.core5.function.Supplier;
@@ -46,6 +47,8 @@ class LZ4Entity implements HttpEntity {
                 // So we just return original content and if there is a real data in it we will get error later
                 return content;
             }
+        } else if (serverCompression && !useHttpCompression) {
+            return new ClickHouseLZ4InputStream(httpEntity.getContent(), LZ4Factory.fastestInstance().fastDecompressor());
         } else {
             return httpEntity.getContent();
         }

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/LZ4Entity.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/LZ4Entity.java
@@ -47,7 +47,7 @@ class LZ4Entity implements HttpEntity {
                 // So we just return original content and if there is a real data in it we will get error later
                 return content;
             }
-        } else if (serverCompression && !useHttpCompression) {
+        } else if (serverCompression) {
             return new ClickHouseLZ4InputStream(httpEntity.getContent(), LZ4Factory.fastestInstance().fastDecompressor());
         } else {
             return httpEntity.getContent();
@@ -58,6 +58,8 @@ class LZ4Entity implements HttpEntity {
     public void writeTo(OutputStream outStream) throws IOException {
         if (clientCompression && useHttpCompression) {
             httpEntity.writeTo(new FramedLZ4CompressorOutputStream(outStream));
+        } else if (clientCompression) {
+            httpEntity.writeTo(new ClickHouseLZ4OutputStream(outStream, LZ4Factory.fastestInstance().fastCompressor()));
         } else {
             httpEntity.writeTo(outStream);
         }

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/MapUtils.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/MapUtils.java
@@ -29,4 +29,16 @@ public class MapUtils {
             }
         }
     }
+
+    public static int getInt(Map<String, String> map, String key) {
+        String val = map.get(key);
+        if (val != null) {
+            try {
+                return Integer.parseInt(val);
+            } catch (NumberFormatException e) {
+                throw new RuntimeException("Invalid value for key " + key + ": " + val, e);
+            }
+        }
+        return 0;
+    }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/TableSchemaParser.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/TableSchemaParser.java
@@ -6,6 +6,7 @@ import com.clickhouse.client.api.metadata.TableSchema;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.StringReader;
 import java.util.Properties;
 
@@ -37,12 +38,15 @@ public class TableSchemaParser {
         schema.setTableName(table);
         schema.setDatabaseName(database);
         Properties p = new Properties();
-        try (BufferedReader r = new BufferedReader(new java.io.InputStreamReader(content))) {
+        try (BufferedReader r = new BufferedReader(new InputStreamReader(content))) {
             String line;
             while ((line = r.readLine()) != null) {
                 p.clear();
-                p.load(new StringReader(line.replaceAll("\t", "\n")));
-                schema.addColumn(p.getProperty("name"), p.getProperty("type"), p.getProperty("default_type"));
+                int lineLength = line.length();
+                if (!line.trim().isEmpty()) {
+                    p.load(new StringReader(line.replaceAll("\t", "\n")));
+                    schema.addColumn(p.getProperty("name"), p.getProperty("type"), p.getProperty("default_type"));
+                }
             }
         } catch (IOException e) {
             throw new RuntimeException("Failed to parse table schema", e);

--- a/client-v2/src/test/java/com/clickhouse/client/ClientTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/ClientTests.java
@@ -18,9 +18,9 @@ import java.util.concurrent.TimeUnit;
 
 public class ClientTests extends BaseIntegrationTest {
 
-    static {
-        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "DEBUG");
-    }
+//    static {
+//        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "DEBUG");
+//    }
 
     @Test(dataProvider = "clientProvider")
     public void testAddSecureEndpoint(Client client) {
@@ -117,29 +117,4 @@ public class ClientTests extends BaseIntegrationTest {
             client.close();
         }
     }
-
-    @Test
-    public void testServerCompression() {
-        ClickHouseNode node = getServer(ClickHouseProtocol.HTTP);
-        Client client = new Client.Builder()
-                .addEndpoint(node.toUri().toString())
-                .setUsername("default")
-                .setPassword("")
-                .compressServerResponse(true)
-                .useHttpCompression(true)
-                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "true").equals("true"))
-                .build();
-
-        try (Records response = client.queryRecords("SELECT number FROM system.numbers LIMIT 10").get()) {
-            response.forEach(record -> {
-                System.out.println(record);
-            });
-        } catch (Exception e) {
-            e.printStackTrace();
-            Assert.fail(e.getMessage());
-        } finally {
-            client.close();
-        }
-    }
-
 }

--- a/client-v2/src/test/java/com/clickhouse/client/ClientTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/ClientTests.java
@@ -18,6 +18,9 @@ import java.util.concurrent.TimeUnit;
 
 public class ClientTests extends BaseIntegrationTest {
 
+    static {
+        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "DEBUG");
+    }
 
     @Test(dataProvider = "clientProvider")
     public void testAddSecureEndpoint(Client client) {
@@ -115,5 +118,28 @@ public class ClientTests extends BaseIntegrationTest {
         }
     }
 
+    @Test
+    public void testServerCompression() {
+        ClickHouseNode node = getServer(ClickHouseProtocol.HTTP);
+        Client client = new Client.Builder()
+                .addEndpoint(node.toUri().toString())
+                .setUsername("default")
+                .setPassword("")
+                .compressServerResponse(true)
+                .useHttpCompression(true)
+                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "true").equals("true"))
+                .build();
+
+        try (Records response = client.queryRecords("SELECT number FROM system.numbers LIMIT 10").get()) {
+            response.forEach(record -> {
+                System.out.println(record);
+            });
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail(e.getMessage());
+        } finally {
+            client.close();
+        }
+    }
 
 }

--- a/client-v2/src/test/java/com/clickhouse/client/insert/InsertClientContentCompressionTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/insert/InsertClientContentCompressionTests.java
@@ -1,0 +1,12 @@
+package com.clickhouse.client.insert;
+
+public class InsertClientContentCompressionTests extends InsertTests {
+
+    static {
+        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "DEBUG");
+    }
+
+    public InsertClientContentCompressionTests() {
+        super(true, false);
+    }
+}

--- a/client-v2/src/test/java/com/clickhouse/client/insert/InsertClientHttpCompressionTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/insert/InsertClientHttpCompressionTests.java
@@ -1,0 +1,12 @@
+package com.clickhouse.client.insert;
+
+public class InsertClientHttpCompressionTests extends InsertTests {
+
+    static {
+        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "DEBUG");
+    }
+
+    public InsertClientHttpCompressionTests() {
+        super(true, true);
+    }
+}

--- a/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
@@ -75,9 +75,8 @@ public class InsertTests extends BaseIntegrationTest {
                 .addEndpoint(Protocol.HTTP, node.getHost(), node.getPort(), false)
                 .setUsername("default")
                 .setPassword("")
-                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "true").equals("true"))
+                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "false").equals("true"))
                 .compressClientRequest(useClientCompression)
-                .compressServerResponse(useHttpCompression)
                 .useHttpCompression(useHttpCompression)
                 .build();
         settings = new InsertSettings()

--- a/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
@@ -56,6 +56,18 @@ public class InsertTests extends BaseIntegrationTest {
     private Client client;
     private InsertSettings settings;
 
+    private boolean useClientCompression = false;
+
+    private boolean useHttpCompression = false;
+
+    InsertTests() {
+    }
+
+    InsertTests(boolean useClientCompression, boolean useHttpCompression) {
+        this.useClientCompression = useClientCompression;
+        this.useHttpCompression = useHttpCompression;
+    }
+
     @BeforeMethod(groups = { "integration" })
     public void setUp() throws IOException {
         ClickHouseNode node = getServer(ClickHouseProtocol.HTTP);
@@ -63,8 +75,10 @@ public class InsertTests extends BaseIntegrationTest {
                 .addEndpoint(Protocol.HTTP, node.getHost(), node.getPort(), false)
                 .setUsername("default")
                 .setPassword("")
-                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "false").equals("true"))
-                .compressClientRequest(false)
+                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "true").equals("true"))
+                .compressClientRequest(useClientCompression)
+                .compressServerResponse(useHttpCompression)
+                .useHttpCompression(useHttpCompression)
                 .build();
         settings = new InsertSettings()
                 .setDeduplicationToken(RandomStringUtils.randomAlphabetic(36))

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryServerContentCompressionTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryServerContentCompressionTests.java
@@ -1,0 +1,10 @@
+package com.clickhouse.client.query;
+
+public class QueryServerContentCompressionTests extends QueryTests {
+    static {
+        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "DEBUG");
+    }
+    QueryServerContentCompressionTests() {
+        super(true, false);
+    }
+}

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryServerHttpCompressionTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryServerHttpCompressionTests.java
@@ -1,0 +1,10 @@
+package com.clickhouse.client.query;
+
+public class QueryServerHttpCompressionTests extends QueryTests {
+    static {
+        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "DEBUG");
+    }
+    QueryServerHttpCompressionTests() {
+        super(true, true);
+    }
+}

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -99,7 +99,7 @@ public class QueryTests extends BaseIntegrationTest {
                 .compressClientRequest(false)
                 .compressServerResponse(useServerCompression)
                 .useHttpCompression(useHttpCompression)
-                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "true").equals("true"))
+                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "false").equals("true"))
                 .build();
 
         delayForProfiler(0);

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -99,7 +99,7 @@ public class QueryTests extends BaseIntegrationTest {
                 .compressClientRequest(false)
                 .compressServerResponse(useServerCompression)
                 .useHttpCompression(useHttpCompression)
-                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "false").equals("true"))
+                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "true").equals("true"))
                 .build();
 
         delayForProfiler(0);

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -77,6 +77,18 @@ public class QueryTests extends BaseIntegrationTest {
 
     private Client client;
 
+    private boolean useServerCompression = false;
+
+    private boolean useHttpCompression = false;
+
+    QueryTests(){
+    }
+
+    QueryTests(boolean useServerCompression, boolean useHttpCompression) {
+        this.useServerCompression = useServerCompression;
+        this.useHttpCompression = useHttpCompression;
+    }
+
     @BeforeMethod(groups = {"integration"})
     public void setUp() {
         ClickHouseNode node = getServer(ClickHouseProtocol.HTTP);
@@ -85,8 +97,9 @@ public class QueryTests extends BaseIntegrationTest {
                 .setUsername("default")
                 .setPassword("")
                 .compressClientRequest(false)
-                .compressServerResponse(false)
-                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "true").equals("true"))
+                .compressServerResponse(useServerCompression)
+                .useHttpCompression(useHttpCompression)
+                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "false").equals("true"))
                 .build();
 
         delayForProfiler(0);


### PR DESCRIPTION
## Summary

Implements support for next compression scenarios:
- whole http response from a server is compressed with LZ4
    - enabled when server &  http compression is enabled 
- response body from a server is compressed with LZ4
- http request is compressed with LZ4 
- request body is compressed with LZ4  

Closes https://github.com/ClickHouse/clickhouse-java/issues/1717