### PR TITLE
[client-v2] Attach TimeZone to a QueryResponse & use TimeZone settings in binary readers

### DIFF
--- a/clickhouse-cli-client/src/main/java/com/clickhouse/client/cli/ClickHouseCommandLineResponse.java
+++ b/clickhouse-cli-client/src/main/java/com/clickhouse/client/cli/ClickHouseCommandLineResponse.java
@@ -14,7 +14,7 @@ public class ClickHouseCommandLineResponse extends ClickHouseStreamResponse {
     private final transient ClickHouseCommandLine cli;
 
     protected ClickHouseCommandLineResponse(ClickHouseConfig config, ClickHouseCommandLine cli) throws IOException {
-        super(config, cli.getInputStream(), null, null, ClickHouseResponseSummary.EMPTY);
+        super(config, cli.getInputStream(), null, null, ClickHouseResponseSummary.EMPTY, null);
         this.cli = cli;
 
         if (processor.getInputStream().available() < 1) {

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseResponse.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseResponse.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Spliterator;
 import java.util.Spliterators;
+import java.util.TimeZone;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
@@ -39,7 +40,7 @@ public interface ClickHouseResponse extends AutoCloseable, Serializable {
     /**
      * Empty response that can never be closed.
      */
-    static final ClickHouseResponse EMPTY = new ClickHouseResponse() {
+    ClickHouseResponse EMPTY = new ClickHouseResponse() {
         @Override
         public List<ClickHouseColumn> getColumns() {
             return Collections.emptyList();
@@ -75,6 +76,11 @@ public interface ClickHouseResponse extends AutoCloseable, Serializable {
             // ensure the instance is "stateless"
             return false;
         }
+
+        @Override
+        public TimeZone getTimeZone() {
+            return null;
+        }
     };
 
     /**
@@ -101,6 +107,15 @@ public interface ClickHouseResponse extends AutoCloseable, Serializable {
      * @return non-null input stream for getting raw data returned from server
      */
     ClickHouseInputStream getInputStream();
+
+    /**
+     * Returns a server timezone if it is returned by server in a header {@code X-ClickHouse-Timezone } or
+     * other way. If not, it returns null
+     * @return server timezone from server response or null
+     */
+    default TimeZone getTimeZone() {
+        return null;
+    }
 
     /**
      * Gets the first record only. Please use {@link #records()} instead if you need

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseSimpleResponse.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseSimpleResponse.java
@@ -1,12 +1,5 @@
 package com.clickhouse.client;
 
-import java.sql.Time;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.TimeZone;
-
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseInputStream;
 import com.clickhouse.data.ClickHouseRecord;
@@ -14,6 +7,12 @@ import com.clickhouse.data.ClickHouseRecordMapper;
 import com.clickhouse.data.ClickHouseRecordTransformer;
 import com.clickhouse.data.ClickHouseSimpleRecord;
 import com.clickhouse.data.ClickHouseValue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.TimeZone;
 
 /**
  * A simple response built on top of two lists: columns and records.
@@ -31,7 +30,7 @@ public class ClickHouseSimpleResponse implements ClickHouseResponse {
      * @return response object
      */
     public static ClickHouseResponse of(ClickHouseConfig config, List<ClickHouseColumn> columns, Object[][] values) {
-        return of(config, columns, values, null);
+        return of(config, columns, values, null, null);
     }
 
     /**
@@ -136,6 +135,7 @@ public class ClickHouseSimpleResponse implements ClickHouseResponse {
         this.columns = columns;
         this.records = Collections.unmodifiableList(records);
         this.summary = summary != null ? summary : ClickHouseResponseSummary.EMPTY;
+        this.timeZone = timeZone;
     }
 
     protected ClickHouseSimpleResponse(List<ClickHouseColumn> columns, ClickHouseValue[][] values,
@@ -151,6 +151,7 @@ public class ClickHouseSimpleResponse implements ClickHouseResponse {
         this.records = Collections.unmodifiableList(list);
 
         this.summary = summary != null ? summary : ClickHouseResponseSummary.EMPTY;
+        this.timeZone = timeZone;
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseSimpleResponse.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseSimpleResponse.java
@@ -1,9 +1,11 @@
 package com.clickhouse.client;
 
+import java.sql.Time;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.TimeZone;
 
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseInputStream;
@@ -19,6 +21,7 @@ import com.clickhouse.data.ClickHouseValue;
 public class ClickHouseSimpleResponse implements ClickHouseResponse {
     private static final long serialVersionUID = 6883452584393840649L;
 
+    private final TimeZone timeZone;
     /**
      * Creates a response object using columns definition and raw values.
      *
@@ -41,7 +44,7 @@ public class ClickHouseSimpleResponse implements ClickHouseResponse {
      * @return response object
      */
     public static ClickHouseResponse of(ClickHouseConfig config, List<ClickHouseColumn> columns, Object[][] values,
-            ClickHouseResponseSummary summary) {
+            ClickHouseResponseSummary summary, TimeZone timeZone) {
         if (columns == null) {
             columns = Collections.emptyList();
         }
@@ -69,7 +72,7 @@ public class ClickHouseSimpleResponse implements ClickHouseResponse {
             }
         }
 
-        return new ClickHouseSimpleResponse(columns, wrappedValues, summary);
+        return new ClickHouseSimpleResponse(columns, wrappedValues, summary, timeZone);
     }
 
     /**
@@ -118,7 +121,7 @@ public class ClickHouseSimpleResponse implements ClickHouseResponse {
             records.add(rec);
         }
 
-        return new ClickHouseSimpleResponse(response.getColumns(), records, response.getSummary());
+        return new ClickHouseSimpleResponse(response.getColumns(), records, response.getSummary(), response.getTimeZone());
     }
 
     private final List<ClickHouseColumn> columns;
@@ -129,14 +132,14 @@ public class ClickHouseSimpleResponse implements ClickHouseResponse {
     private volatile boolean closed;
 
     protected ClickHouseSimpleResponse(List<ClickHouseColumn> columns, List<ClickHouseRecord> records,
-            ClickHouseResponseSummary summary) {
+                                       ClickHouseResponseSummary summary, TimeZone timeZone) {
         this.columns = columns;
         this.records = Collections.unmodifiableList(records);
         this.summary = summary != null ? summary : ClickHouseResponseSummary.EMPTY;
     }
 
     protected ClickHouseSimpleResponse(List<ClickHouseColumn> columns, ClickHouseValue[][] values,
-            ClickHouseResponseSummary summary) {
+            ClickHouseResponseSummary summary, TimeZone timeZone) {
         this.columns = columns;
 
         int len = values.length;
@@ -163,6 +166,11 @@ public class ClickHouseSimpleResponse implements ClickHouseResponse {
     @Override
     public ClickHouseInputStream getInputStream() {
         throw new UnsupportedOperationException("An in-memory response does not have input stream");
+    }
+
+    @Override
+    public TimeZone getTimeZone() {
+        return timeZone;
     }
 
     @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseStreamResponse.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseStreamResponse.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
 
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseDataProcessor;
@@ -23,32 +24,35 @@ public class ClickHouseStreamResponse implements ClickHouseResponse {
 
     private static final long serialVersionUID = 2271296998310082447L;
 
+    private final TimeZone timeZone;
+
     protected static final List<ClickHouseColumn> defaultTypes = Collections
             .singletonList(ClickHouseColumn.of("results", "Nullable(String)"));
-
-    public static ClickHouseResponse of(ClickHouseConfig config, ClickHouseInputStream input) throws IOException {
-        return of(config, input, null, null, null);
-    }
-
+//
+//    public static ClickHouseResponse of(ClickHouseConfig config, ClickHouseInputStream input) throws IOException {
+//        return of(config, input, null, null, null);
+//    }
+//
+//    public static ClickHouseResponse of(ClickHouseConfig config, ClickHouseInputStream input,
+//            Map<String, Serializable> settings) throws IOException {
+//        return of(config, input, settings, null, null);
+//    }
+//
+//    public static ClickHouseResponse of(ClickHouseConfig config, ClickHouseInputStream input,
+//            List<ClickHouseColumn> columns) throws IOException {
+//        return of(config, input, null, columns, null);
+//    }
+//
+//    public static ClickHouseResponse of(ClickHouseConfig config, ClickHouseInputStream input,
+//            Map<String, Serializable> settings, List<ClickHouseColumn> columns) throws IOException {
+//        return of(config, input, settings, columns, null);
+//    }
+//
     public static ClickHouseResponse of(ClickHouseConfig config, ClickHouseInputStream input,
-            Map<String, Serializable> settings) throws IOException {
-        return of(config, input, settings, null, null);
-    }
-
-    public static ClickHouseResponse of(ClickHouseConfig config, ClickHouseInputStream input,
-            List<ClickHouseColumn> columns) throws IOException {
-        return of(config, input, null, columns, null);
-    }
-
-    public static ClickHouseResponse of(ClickHouseConfig config, ClickHouseInputStream input,
-            Map<String, Serializable> settings, List<ClickHouseColumn> columns) throws IOException {
-        return of(config, input, settings, columns, null);
-    }
-
-    public static ClickHouseResponse of(ClickHouseConfig config, ClickHouseInputStream input,
-            Map<String, Serializable> settings, List<ClickHouseColumn> columns, ClickHouseResponseSummary summary)
+                                        Map<String, Serializable> settings, List<ClickHouseColumn> columns,
+                                        ClickHouseResponseSummary summary, TimeZone timeZone)
             throws IOException {
-        return new ClickHouseStreamResponse(config, input, settings, columns, summary);
+        return new ClickHouseStreamResponse(config, input, settings, columns, summary, timeZone);
     }
 
     protected final ClickHouseConfig config;
@@ -58,9 +62,11 @@ public class ClickHouseStreamResponse implements ClickHouseResponse {
     private volatile boolean closed;
 
     protected ClickHouseStreamResponse(ClickHouseConfig config, ClickHouseInputStream input,
-            Map<String, Serializable> settings, List<ClickHouseColumn> columns, ClickHouseResponseSummary summary)
+            Map<String, Serializable> settings, List<ClickHouseColumn> columns, ClickHouseResponseSummary summary,
+                                       TimeZone timeZone)
             throws IOException {
 
+        this.timeZone = timeZone;
         boolean hasError = true;
         try {
             this.processor = ClickHouseDataStreamFactory.getInstance().getProcessor(config, input, null, settings,
@@ -142,6 +148,11 @@ public class ClickHouseStreamResponse implements ClickHouseResponse {
                     "No data processor available for deserialization, please consider to use getInputStream instead");
         }
         return processor.records();
+    }
+
+    @Override
+    public TimeZone getTimeZone() {
+        return timeZone;
     }
 
     @Override

--- a/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcResponse.java
+++ b/clickhouse-grpc-client/src/main/java/com/clickhouse/client/grpc/ClickHouseGrpcResponse.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
 import java.util.Map;
+import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 
 import com.clickhouse.client.ClickHouseConfig;
@@ -28,7 +29,7 @@ public class ClickHouseGrpcResponse extends ClickHouseStreamResponse {
 
     protected ClickHouseGrpcResponse(ClickHouseConfig config, Map<String, Serializable> settings,
             ClickHouseStreamObserver observer) throws IOException {
-        super(config, observer.getInputStream(), settings, null, observer.getSummary());
+        super(config, observer.getInputStream(), settings, null, observer.getSummary(), null);
 
         this.observer = observer;
     }
@@ -42,7 +43,8 @@ public class ClickHouseGrpcResponse extends ClickHouseStreamResponse {
                         : ClickHouseGrpcClientImpl.getInput(config, result.getOutput().newInput(),
                                 () -> checkError(result)),
                 settings, null,
-                new ClickHouseResponseSummary(null, null));
+                new ClickHouseResponseSummary(null, null),
+                TimeZone.getTimeZone(result.getTimeZone()));
 
         this.observer = null;
         if (result.hasProgress()) {

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
@@ -128,8 +128,8 @@ public class ApacheHttpConnectionImpl extends ClickHouseHttpConnection {
                 format = ClickHouseFormat.valueOf(value);
                 hasQueryResult = true;
             }
-            value = getResponseHeader(response, ClickHouseHttpProto.HEADER_TIMEZONE, "");
-            timeZone = !ClickHouseChecker.isNullOrEmpty(value) ? TimeZone.getTimeZone(value)
+            String tzValue = getResponseHeader(response, ClickHouseHttpProto.HEADER_TIMEZONE, "");
+            timeZone = !ClickHouseChecker.isNullOrEmpty(tzValue) ? TimeZone.getTimeZone(tzValue)
                     : timeZone;
         }
 

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpClient.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpClient.java
@@ -212,7 +212,7 @@ public class ClickHouseHttpClient extends AbstractClient<ClickHouseHttpConnectio
 
 
         return ClickHouseStreamResponse.of(httpResponse.getConfig(sealedRequest), httpResponse.getInputStream(),
-                sealedRequest.getSettings(), null, httpResponse.summary);
+                sealedRequest.getSettings(), null, httpResponse.summary, httpResponse.getTimeZone());
     }
 
     @Override

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpResponse.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpResponse.java
@@ -81,4 +81,8 @@ public class ClickHouseHttpResponse {
     public ClickHouseInputStream getInputStream() {
         return input;
     }
+
+    public TimeZone getTimeZone() {
+        return timeZone;
+    }
 }

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseStatementImpl.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseStatementImpl.java
@@ -55,6 +55,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.TimeZone;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
@@ -222,8 +223,10 @@ public class ClickHouseStatementImpl extends JdbcWrapper
 
                 f = getFile(f, stmt);
                 final ClickHouseResponseSummary summary = new ClickHouseResponseSummary(null, null);
+                TimeZone responseTimeZone = null;
                 try (ClickHouseResponse response = request.query(stmt.getSQL()).output(f).executeAndWait()) {
                     summary.add(response.getSummary());
+                    responseTimeZone = response.getTimeZone();
                 } catch (ClickHouseException e) {
                     throw SqlExceptionUtils.handle(e);
                 }
@@ -236,7 +239,8 @@ public class ClickHouseStatementImpl extends JdbcWrapper
                         new Object[][] { { file, f.getFormat().name(),
                                 f.hasCompression() ? f.getCompressionAlgorithm().encoding() : "none",
                                 f.getCompressionLevel(), f.getFile().length() } },
-                        summary);
+                        summary,
+                        responseTimeZone);
             } else if (stmt.getStatementType() == StatementType.INSERT) {
                 final Mutation m = request.write().query(stmt.getSQL());
                 final ClickHouseResponseSummary summary = new ClickHouseResponseSummary(null, null);
@@ -267,7 +271,7 @@ public class ClickHouseStatementImpl extends JdbcWrapper
                 } catch (IOException e) {
                     throw SqlExceptionUtils.handle(e);
                 }
-                return ClickHouseSimpleResponse.of(null, null, new Object[0][], summary);
+                return ClickHouseSimpleResponse.of(null, null, new Object[0][], summary, null);
             }
         }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -1137,7 +1137,7 @@ public class Client implements AutoCloseable {
                         metrics.setQueryId(queryId);
                         metrics.operationComplete();
 
-                        return new QueryResponse(httpResponse, finalSettings.getFormat(), metrics);
+                        return new QueryResponse(httpResponse, finalSettings.getFormat(), finalSettings, metrics);
                     } catch (ClientException e) {
                         throw e;
                     } catch (Exception e) {
@@ -1169,7 +1169,7 @@ public class Client implements AutoCloseable {
                         clickHouseResponse = request.execute().get();
                     }
 
-                    return new QueryResponse(clickHouseResponse, format, clientStats);
+                    return new QueryResponse(clickHouseResponse, format, clientStats, finalSettings);
                 } catch (ClientException e) {
                     throw e;
                 } catch (Exception e) {

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryWithNamesAndTypesFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryWithNamesAndTypesFormatReader.java
@@ -17,10 +17,6 @@ import java.util.Map;
 
 public class RowBinaryWithNamesAndTypesFormatReader extends AbstractBinaryFormatReader implements Iterator<Map<String, Object>> {
 
-    public RowBinaryWithNamesAndTypesFormatReader(InputStream inputStream) {
-        this(inputStream, null);
-    }
-
     public RowBinaryWithNamesAndTypesFormatReader(InputStream inputStream, QuerySettings querySettings) {
         super(inputStream, querySettings, null);
         readSchema();

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
@@ -61,7 +61,7 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
         TimeZone timeZone = useServerTimeZone ? querySettings.getServerTimeZone() :
                 (TimeZone) this.settings.get(ClickHouseClientOption.USE_TIME_ZONE.getKey());
         if (timeZone == null) {
-            throw new ClientException("Time zone is not set");
+            throw new ClientException("Time zone is not set. (useServerTimezone:" + useServerTimeZone + ")");
         }
         this.binaryStreamReader = new BinaryStreamReader(inputStream, timeZone, LOG);
         setSchema(schema);

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
@@ -566,8 +566,8 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
     @Override
     public LocalDate getLocalDate(String colName) {
         Object value = readValue(colName);
-        if (value instanceof LocalDateTime) {
-            return ((LocalDateTime) value).toLocalDate();
+        if (value instanceof ZonedDateTime) {
+            return ((ZonedDateTime) value).toLocalDate();
         }
         return (LocalDate) value;
 
@@ -576,8 +576,8 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
     @Override
     public LocalDate getLocalDate(int index) {
         Object value = readValue(index);
-        if (value instanceof LocalDateTime) {
-            return ((LocalDateTime) value).toLocalDate();
+        if (value instanceof ZonedDateTime) {
+            return ((ZonedDateTime) value).toLocalDate();
         }
         return (LocalDate) value;
     }
@@ -585,14 +585,18 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
     @Override
     public LocalDateTime getLocalDateTime(String colName) {
         Object value = readValue(colName);
-        if (value instanceof LocalDate) {
-            return ((LocalDate) value).atStartOfDay();
+        if (value instanceof ZonedDateTime) {
+            return ((ZonedDateTime) value).toLocalDateTime();
         }
         return (LocalDateTime) value;
     }
 
     @Override
     public LocalDateTime getLocalDateTime(int index) {
-        return readValue(index);
+        Object value = readValue(index);
+        if (value instanceof ZonedDateTime) {
+            return ((ZonedDateTime) value).toLocalDateTime();
+        }
+        return (LocalDateTime) value;
     }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
@@ -56,8 +56,7 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
     protected AbstractBinaryFormatReader(InputStream inputStream, QuerySettings querySettings, TableSchema schema) {
         this.input = inputStream;
         this.settings = querySettings == null ? Collections.emptyMap() : new HashMap<>(querySettings.getAllSettings());
-        boolean useServerTimeZone = (boolean) this.settings.getOrDefault(ClickHouseClientOption.USE_SERVER_TIME_ZONE.getKey(),
-                 false);
+        boolean useServerTimeZone = (boolean) this.settings.get(ClickHouseClientOption.USE_SERVER_TIME_ZONE.getKey());
         TimeZone timeZone = useServerTimeZone ? querySettings.getServerTimeZone() :
                 (TimeZone) this.settings.get(ClickHouseClientOption.USE_TIME_ZONE.getKey());
         if (timeZone == null) {

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -31,8 +31,11 @@ public class BinaryStreamReader {
 
     private final Logger log;
 
-    BinaryStreamReader(InputStream input, Logger log) {
+    private final TimeZone timeZone;
+
+    BinaryStreamReader(InputStream input, TimeZone timeZone, Logger log) {
         this.log = log == null ? NOPLogger.NOP_LOGGER : log;
+        this.timeZone = timeZone;
         this.input = input;
     }
 
@@ -114,13 +117,17 @@ public class BinaryStreamReader {
                 case Enum16:
                     return (T) Short.valueOf((short) readUnsignedShortLE(input));
                 case Date:
-                    return (T) readDate(input, column.getTimeZone());
+                    return (T) readDate(input, column.getTimeZone() == null ? timeZone:
+                            column.getTimeZone());
                 case Date32:
-                    return (T) readDate32(input, column.getTimeZone());
+                    return (T) readDate32(input, column.getTimeZone() == null ? timeZone:
+                            column.getTimeZone());
                 case DateTime:
-                    return (T) readDateTime32(input, column.getTimeZone());
+                    return (T) readDateTime32(input, column.getTimeZone() == null ? timeZone:
+                            column.getTimeZone());
                 case DateTime32:
-                    return (T) readDateTime32(input, column.getTimeZone());
+                    return (T) readDateTime32(input, column.getTimeZone() == null ? timeZone:
+                            column.getTimeZone());
                 case DateTime64:
                     return (T) readDateTime64(input, 3, column.getTimeZone());
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -19,6 +19,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -450,34 +451,25 @@ public class BinaryStreamReader {
         return new BigInteger(1, readNBytes(input, 32));
     }
 
-    public static LocalDate readDate(InputStream input, TimeZone tz)
-            throws IOException {
+    public static ZonedDateTime readDate(InputStream input, TimeZone tz) throws IOException {
         LocalDate d = LocalDate.ofEpochDay(readUnsignedShortLE(input));
-        if (tz != null && !tz.toZoneId().equals(ClickHouseValues.SYS_ZONE)) {
-            d = d.atStartOfDay(ClickHouseValues.SYS_ZONE).withZoneSameInstant(tz.toZoneId()).toLocalDate();
-        }
-        return d;
+        return d.atStartOfDay(tz.toZoneId()).withZoneSameInstant(tz.toZoneId());
     }
 
-    public static LocalDate readDate32(InputStream input, TimeZone tz)
+    public static ZonedDateTime readDate32(InputStream input, TimeZone tz)
             throws IOException {
         LocalDate d = LocalDate.ofEpochDay(readIntLE(input));
-        if (tz != null && !tz.toZoneId().equals(ClickHouseValues.SYS_ZONE)) {
-            d = d.atStartOfDay(ClickHouseValues.SYS_ZONE).withZoneSameInstant(tz.toZoneId()).toLocalDate();
-        }
-        return d;
+        return d.atStartOfDay(tz.toZoneId()).withZoneSameInstant(tz.toZoneId());
     }
 
-    public static LocalDateTime readDateTime32(InputStream input, TimeZone tz) throws IOException {
+    public static ZonedDateTime readDateTime32(InputStream input, TimeZone tz) throws IOException {
         long time = readUnsignedIntLE(input);
-
-        return LocalDateTime.ofInstant(Instant.ofEpochSecond(Math.max(time, 0L)),
-                tz != null ? tz.toZoneId() : ClickHouseValues.UTC_ZONE);
+        return LocalDateTime.ofInstant(Instant.ofEpochSecond(Math.max(time, 0L)), tz.toZoneId()).atZone(tz.toZoneId());
     }
     private static final int[] BASES = new int[] { 1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000,
             1000000000 };
 
-    public static LocalDateTime readDateTime64(InputStream input, int scale, TimeZone tz) throws IOException {
+    public static ZonedDateTime readDateTime64(InputStream input, int scale, TimeZone tz) throws IOException {
         long value = readLongLE(input);
         int nanoSeconds = 0;
         if (scale > 0) {
@@ -493,8 +485,8 @@ public class BinaryStreamReader {
             }
         }
 
-        return LocalDateTime.ofInstant(Instant.ofEpochSecond(value, nanoSeconds),
-                tz != null ? tz.toZoneId() : TimeZone.getTimeZone("UTC").toZoneId());
+        return LocalDateTime.ofInstant(Instant.ofEpochSecond(value, nanoSeconds), tz.toZoneId())
+                .atZone(tz.toZoneId());
     }
 
     public static String readString(InputStream input) throws IOException {

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/MapUtils.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/MapUtils.java
@@ -29,4 +29,35 @@ public class MapUtils {
             }
         }
     }
+
+    public static boolean getFlag(Map<String, String> map, String key) {
+        String val = map.get(key);
+        if (val == null) {
+            throw new NullPointerException("Missing value for the key '" + key + "'");
+        }
+        if (val.equalsIgnoreCase("true")) {
+            return true;
+        } else if (val.equalsIgnoreCase("false")) {
+            return false;
+        }
+
+        throw new IllegalArgumentException("Invalid non-boolean value for the key '" + key + "': '" + val + "'");
+    }
+
+    public static boolean getFlag(Map<String, String> p1, Map<String, String> p2, String key) {
+        String val = p1.get(key);
+        if (val == null) {
+            val = p2.get(key);
+        }
+        if (val == null) {
+            throw new NullPointerException("Missing value for the key '" + key + "'");
+        }
+        if (val.equalsIgnoreCase("true")) {
+            return true;
+        } else if (val.equalsIgnoreCase("false")) {
+            return false;
+        }
+
+        throw new IllegalArgumentException("Invalid non-boolean value for the key '" + key + "': '" + val + "'");
+    }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/SettingsConverter.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/SettingsConverter.java
@@ -153,6 +153,7 @@ public class SettingsConverter {
                         ClickHouseClientOption.USE_OBJECTS_IN_ARRAYS,
                         ClickHouseClientOption.USE_SERVER_TIME_ZONE,
                         ClickHouseClientOption.USE_SERVER_TIME_ZONE_FOR_DATES,
+                        ClickHouseClientOption.SERVER_TIME_ZONE,
                         ClickHouseClientOption.USE_TIME_ZONE)
                 .forEach(option -> map.put(option.getKey(), option));
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/QueryResponse.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/QueryResponse.java
@@ -64,7 +64,13 @@ public class QueryResponse implements AutoCloseable {
         this.operationMetrics = operationMetrics;
 
         Header tzHeader = response.getFirstHeader(ClickHouseHttpProto.HEADER_TIMEZONE);
-        settings.setOption("server_timezone", tzHeader);
+        if (tzHeader != null) {
+            try {
+                settings.setOption("server_timezone", TimeZone.getTimeZone(tzHeader.getValue()));
+            } catch (Exception e) {
+                throw new ClientException("Failed to parse server timezone", e);
+            }
+        }
     }
 
     public InputStream getInputStream() {

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/QueryResponse.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/QueryResponse.java
@@ -190,4 +190,8 @@ public class QueryResponse implements AutoCloseable {
                 ? null
                 : (TimeZone) settings.getOption("server_timezone");
     }
+
+    public QuerySettings getSettings() {
+        return settings;
+    }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
@@ -1,11 +1,14 @@
 package com.clickhouse.client.api.query;
 
 
+import com.clickhouse.client.ClickHouseNode;
 import com.clickhouse.client.api.internal.ValidationUtils;
+import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.data.ClickHouseFormat;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.TimeZone;
 
 /**
  * <p>Query settings class represents a set of settings that can be used to customize query execution.</p>
@@ -123,5 +126,31 @@ public class QuerySettings {
     public QuerySettings waitEndOfQuery(Boolean waitEndOfQuery) {
         rawSettings.put("wait_end_of_query", waitEndOfQuery);
         return this;
+    }
+
+    public QuerySettings setUseServerTimeZone(Boolean useServerTimeZone) {
+        if (rawSettings.containsKey(ClickHouseClientOption.USE_TIME_ZONE.getKey())) {
+            throw new ValidationUtils.SettingsValidationException("use_server_timezone",
+                    "Cannot set both use_time_zone and use_server_time_zone");
+        }
+        rawSettings.put("use_server_time_zone", useServerTimeZone);
+        return this;
+    }
+
+    public Boolean getUseServerTimeZone() {
+        return (Boolean) rawSettings.get("use_server_time_zone");
+    }
+
+    public QuerySettings setUseTimeZone(String timeZone) {
+        if (rawSettings.containsKey(ClickHouseClientOption.USE_SERVER_TIME_ZONE.getKey())) {
+            throw new ValidationUtils.SettingsValidationException("use_time_zone",
+                    "Cannot set both use_time_zone and use_server_time_zone");
+        }
+        rawSettings.put("use_time_zone", timeZone);
+        return this;
+    }
+
+    public TimeZone getServerTimeZone() {
+        return (TimeZone) rawSettings.get("server_timezone");
     }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
@@ -151,6 +151,6 @@ public class QuerySettings {
     }
 
     public TimeZone getServerTimeZone() {
-        return (TimeZone) rawSettings.get("server_timezone");
+        return (TimeZone) rawSettings.get(ClickHouseClientOption.SERVER_TIME_ZONE.getKey());
     }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/Records.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/Records.java
@@ -28,7 +28,7 @@ public class Records implements Iterable<GenericRecord>, AutoCloseable {
             throw new ClientException("Unsupported format: " + finalSettings.getFormat());
         }
 
-        this.reader = new RowBinaryWithNamesAndTypesFormatReader(response.getInputStream());
+        this.reader = new RowBinaryWithNamesAndTypesFormatReader(response.getInputStream(), finalSettings);
         this.empty = !reader.hasNext();
     }
 

--- a/client-v2/src/test/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReaderTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReaderTests.java
@@ -22,7 +22,7 @@ public class BinaryStreamReaderTests {
         BinaryStreamUtils.writeDate(out, inValue);
 
         ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
-        LocalDate outValue = new BinaryStreamReader(ClickHouseInputStream.of(in), null)
+        LocalDate outValue = new BinaryStreamReader(ClickHouseInputStream.of(in), TimeZone.getDefault(), null)
                 .readValue(ClickHouseColumn.of("updated", "DateTime"));
         Assert.assertEquals(outValue, inValue);
     }

--- a/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
@@ -152,6 +152,7 @@ public class InsertTests extends BaseIntegrationTest {
         byte[] requestBody = ("INSERT INTO table01 FORMAT " +
                 ClickHouseFormat.TSV.name() + " \n1\t2\t3\n").getBytes();
 
+        // First request gets no response
         faultyServer.addStubMapping(WireMock.post(WireMock.anyUrl())
                         .withRequestBody(WireMock.binaryEqualTo(requestBody))
                 .inScenario("Retry")
@@ -159,6 +160,7 @@ public class InsertTests extends BaseIntegrationTest {
                 .willSetStateTo("Failed")
                 .willReturn(WireMock.aResponse().withFault(Fault.EMPTY_RESPONSE)).build());
 
+        // Second request gets a response (retry)
         faultyServer.addStubMapping(WireMock.post(WireMock.anyUrl())
                         .withRequestBody(WireMock.binaryEqualTo(requestBody))
                 .inScenario("Retry")
@@ -177,19 +179,7 @@ public class InsertTests extends BaseIntegrationTest {
                 .compressClientRequest(false)
                 .setOption(ClickHouseClientOption.RETRY.getKey(), "2")
                 .build();
-        Runnable powerBlink = () -> {
-            try {
-                Thread.sleep(100);
-                faultyServer.stop();
-                Thread.sleep(50);
-                faultyServer.start();
-            } catch (InterruptedException e) {
-                Assert.fail("Unexpected exception", e);
-            }
-        };
         try {
-            new Thread(powerBlink).start();
-            Thread.sleep(200);
             InsertResponse insertResponse = mockServerClient.insert("table01",
                     new ByteArrayInputStream("1\t2\t3\n".getBytes()), ClickHouseFormat.TSV, settings).get(30, TimeUnit.SECONDS);
             insertResponse.close();

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -89,7 +89,7 @@ public class QueryTests extends BaseIntegrationTest {
                 .setPassword("")
                 .compressClientRequest(false)
                 .compressServerResponse(false)
-                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "true").equals("true"))
+                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "false").equals("true"))
                 .build();
 
         delayForProfiler(0);

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -52,6 +52,9 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1165,5 +1168,82 @@ public class QueryTests extends BaseIntegrationTest {
             }
 
         }
+    }
+
+    @Test(groups = {"integration"})
+    public void testServerTimeZoneFromHeader() {
+
+        final String requestTimeZone = "America/Los_Angeles";
+        try (QueryResponse response =
+                     client.query("SELECT now() as t, toDateTime(now(), 'UTC') as utc_time " +
+                             "SETTINGS session_timezone = '" + requestTimeZone + "'").get(1, TimeUnit.SECONDS)) {
+
+            ClickHouseBinaryFormatReader reader =
+                    new RowBinaryWithNamesAndTypesFormatReader(response.getInputStream(), response.getSettings());
+
+            reader.next();
+
+            LocalDateTime serverTime = reader.getLocalDateTime(1);
+            System.out.println("Server time: " + serverTime);
+            LocalDateTime serverUtcTime = reader.getLocalDateTime(2);
+            System.out.println("Server UTC time: " + serverUtcTime);
+
+            ZonedDateTime serverTimeZ = serverTime.atZone(ZoneId.of(requestTimeZone));
+            ZonedDateTime serverUtcTimeZ = serverUtcTime.atZone(ZoneId.of("UTC"));
+
+            Assert.assertEquals(serverTimeZ.withZoneSameInstant(ZoneId.of("UTC")), serverUtcTimeZ);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail("Failed to get server time zone from header", e);
+        }
+    }
+
+
+    @Test(groups = {"integration"})
+    public void testClientUseOwnTimeZone() {
+
+        final String overrideTz = "America/Los_Angeles";
+        try (Client client = newClient().useTimeZone(overrideTz).useServerTimeZone(false).build()) {
+            final String requestTimeZone = "Europe/Berlin";
+            try (QueryResponse response =
+                         client.query("SELECT now() as t, toDateTime(now(), 'UTC') as utc_time, " +
+                                 "toDateTime(now(), 'Europe/Lisbon')" +
+                                 "SETTINGS session_timezone = '" + requestTimeZone + "'").get(1, TimeUnit.SECONDS)) {
+
+                ClickHouseBinaryFormatReader reader =
+                        new RowBinaryWithNamesAndTypesFormatReader(response.getInputStream(), response.getSettings());
+
+                reader.next();
+
+                LocalDateTime serverTime = reader.getLocalDateTime(1); // in "America/Los_Angeles"
+                System.out.println("Server time: " + serverTime);
+                LocalDateTime serverUtcTime = reader.getLocalDateTime(2);
+                System.out.println("Server UTC time: " + serverUtcTime);
+                ZonedDateTime serverLisbonTime = reader.getZonedDateTime(3);  // in "Europe/Lisbon"
+                System.out.println("Server Lisbon time: " + serverLisbonTime);
+
+                ZonedDateTime serverTimeZ = serverTime.atZone(ZoneId.of("America/Los_Angeles"));
+                ZonedDateTime serverUtcTimeZ = serverUtcTime.atZone(ZoneId.of("UTC"));
+
+                Assert.assertEquals(serverTimeZ.withZoneSameInstant(ZoneId.of("UTC")), serverUtcTimeZ);
+                Assert.assertEquals(serverLisbonTime.withZoneSameInstant(ZoneId.of("UTC")), serverTimeZ);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            Assert.fail("Failed to get server time zone from header", e);
+        }
+    }
+
+    private Client.Builder newClient() {
+        ClickHouseNode node = getServer(ClickHouseProtocol.HTTP);
+        return new Client.Builder()
+                .addEndpoint(Protocol.HTTP, node.getHost(), node.getPort(), false)
+                .setUsername("default")
+                .setPassword("")
+                .compressClientRequest(false)
+                .compressServerResponse(false)
+                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "true").equals("true"))
+                ;
     }
 }

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -1227,7 +1227,7 @@ public class QueryTests extends BaseIntegrationTest {
                 ZonedDateTime serverUtcTimeZ = serverUtcTime.atZone(ZoneId.of("UTC"));
 
                 Assert.assertEquals(serverTimeZ.withZoneSameInstant(ZoneId.of("UTC")), serverUtcTimeZ);
-                Assert.assertEquals(serverLisbonTime.withZoneSameInstant(ZoneId.of("UTC")), serverTimeZ);
+                Assert.assertEquals(serverLisbonTime.withZoneSameInstant(ZoneId.of("UTC")), serverUtcTimeZ);
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/SimpleReader.java
+++ b/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/SimpleReader.java
@@ -59,7 +59,8 @@ public class SimpleReader {
         try (QueryResponse response = client.query(sql).get(3, TimeUnit.SECONDS);) {
 
             // Create a reader to access the data in a convenient way
-            ClickHouseBinaryFormatReader reader = new RowBinaryWithNamesAndTypesFormatReader(response.getInputStream());
+            ClickHouseBinaryFormatReader reader = new RowBinaryWithNamesAndTypesFormatReader(response.getInputStream(),
+                    response.getSettings());
 
             while (reader.hasNext()) {
                 reader.next(); // Read the next record from stream and parse it


### PR DESCRIPTION
## Summary
There are two options for the timezone for parsing DateTime values:
- use server timezone (pre-fetch or header) 
- use user specified timezone 

This PR implement these options when old or new implementation are used. 

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
