### PR TITLE
Remove Java9 Targets

### DIFF
--- a/clickhouse-client/src/main/java11/module-info.java
+++ b/clickhouse-client/src/main/java11/module-info.java
@@ -1,0 +1,15 @@
+/**
+ * Declares com.clickhouse.client module.
+ */
+module com.clickhouse.client {
+    exports com.clickhouse.client;
+    exports com.clickhouse.client.config;
+
+    requires static org.dnsjava;
+
+    requires transitive com.clickhouse.data;
+
+    uses com.clickhouse.client.ClickHouseClient;
+    uses com.clickhouse.client.ClickHouseDnsResolver;
+    uses com.clickhouse.client.ClickHouseSslContextProvider;
+}

--- a/clickhouse-data/src/main/java11/com/clickhouse/data/ByteUtils.java
+++ b/clickhouse-data/src/main/java11/com/clickhouse/data/ByteUtils.java
@@ -1,0 +1,76 @@
+package com.clickhouse.data;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.VarHandle;
+import java.nio.ByteOrder;
+import java.util.Arrays;
+
+public final class ByteUtils {
+    public boolean equals(byte[] a, int aFromIndex, int aToIndex, byte[] b, int bFromIndex, int bToIndex) {
+        return Arrays.equals(a, aFromIndex, aToIndex, b, bFromIndex, bToIndex);
+    }
+
+    public byte getInt8(byte[] bytes, int offset) {
+        return (byte) byteHandle.get(bytes, offset);
+    }
+
+    public void setInt8(byte[] bytes, int offset, byte value) {
+        byteHandle.set(bytes, offset, value);
+    }
+
+    public short getInt16(byte[] bytes, int offset) {
+        return (short) shortHandle.get(bytes, offset);
+    }
+
+    public void setInt16(byte[] bytes, int offset, short value) {
+        shortHandle.set(bytes, offset, value);
+    }
+
+    public int getInt32(byte[] bytes, int offset) {
+        return (int) intHandle.get(bytes, offset);
+    }
+
+    public void setInt32(byte[] bytes, int offset, int value) {
+        intHandle.set(bytes, offset, value);
+    }
+
+    public long getInt64(byte[] bytes, int offset) {
+        return (long) longHandle.get(bytes, offset);
+    }
+
+    public void setInt64(byte[] bytes, int offset, long value) {
+        longHandle.set(bytes, offset, value);
+    }
+
+    public float getFloat32(byte[] bytes, int offset) {
+        return (float) floatHandle.get(bytes, offset);
+    }
+
+    public void setFloat32(byte[] bytes, int offset, float value) {
+        floatHandle.set(bytes, offset, value);
+    }
+
+    public double getFloat64(byte[] bytes, int offset) {
+        return (double) doubleHandle.get(bytes, offset);
+    }
+
+    public void setFloat64(byte[] bytes, int offset, double value) {
+        doubleHandle.set(bytes, offset, value);
+    }
+
+    private final VarHandle byteHandle;
+    private final VarHandle shortHandle;
+    private final VarHandle intHandle;
+    private final VarHandle longHandle;
+    private final VarHandle floatHandle;
+    private final VarHandle doubleHandle;
+
+    ByteUtils(ByteOrder byteOrder) {
+        byteHandle = MethodHandles.arrayElementVarHandle(byte[].class);
+        shortHandle = MethodHandles.byteArrayViewVarHandle(short[].class, byteOrder);
+        intHandle = MethodHandles.byteArrayViewVarHandle(int[].class, byteOrder);
+        longHandle = MethodHandles.byteArrayViewVarHandle(long[].class, byteOrder);
+        floatHandle = MethodHandles.byteArrayViewVarHandle(float[].class, byteOrder);
+        doubleHandle = MethodHandles.byteArrayViewVarHandle(double[].class, byteOrder);
+    }
+}

--- a/clickhouse-data/src/main/java11/module-info.java
+++ b/clickhouse-data/src/main/java11/module-info.java
@@ -1,0 +1,23 @@
+/**
+ * Declares com.clickhouse.data module.
+ */
+module com.clickhouse.data {
+    exports com.clickhouse.config;
+    exports com.clickhouse.data;
+    // exports com.clickhouse.data.cache;
+    // exports com.clickhouse.data.format;
+    // exports com.clickhouse.data.mapper;
+    // exports com.clickhouse.data.stream;
+    exports com.clickhouse.data.value;
+    exports com.clickhouse.logging;
+
+    requires static java.logging;
+    requires static com.google.gson;
+    requires static com.github.benmanes.caffeine;
+    requires static org.lz4.java;
+    requires static org.slf4j;
+    requires static org.roaringbitmap;
+
+    uses com.clickhouse.data.ClickHouseDataStreamFactory;
+    uses com.clickhouse.logging.LoggerFactory;
+}

--- a/clickhouse-jdbc/src/main/java11/module-info.java
+++ b/clickhouse-jdbc/src/main/java11/module-info.java
@@ -1,0 +1,18 @@
+/**
+ * Declares com.clickhouse module.
+ */
+module com.clickhouse.jdbc {
+    exports com.clickhouse.jdbc;
+
+    requires java.sql;
+
+    requires transitive com.clickhouse.client;
+    // requires transitive com.google.gson;
+    // requires transitive org.lz4.java;
+
+    uses com.clickhouse.client.ClickHouseClient;
+    uses com.clickhouse.client.ClickHouseDnsResolver;
+    uses com.clickhouse.client.ClickHouseSslContextProvider;
+    uses com.clickhouse.data.ClickHouseDataStreamFactory;
+    uses com.clickhouse.logging.LoggerFactory;
+}

--- a/clickhouse-r2dbc/src/main/java11/module-info.java
+++ b/clickhouse-r2dbc/src/main/java11/module-info.java
@@ -1,0 +1,17 @@
+/**
+ * Declares com.clickhouse.r2dbc module.
+ */
+module com.clickhouse.r2dbc {
+    exports com.clickhouse.r2dbc;
+
+    requires transitive com.clickhouse.client;
+    requires transitive r2dbc.spi;
+    requires transitive reactor.core;
+    requires transitive org.lz4.java;
+
+    uses com.clickhouse.client.ClickHouseClient;
+    uses com.clickhouse.client.ClickHouseDnsResolver;
+    uses com.clickhouse.client.ClickHouseSslContextProvider;
+    uses com.clickhouse.data.ClickHouseDataStreamFactory;
+    uses com.clickhouse.logging.LoggerFactory;
+}

--- a/pom.xml
+++ b/pom.xml
@@ -650,23 +650,6 @@
                 </configuration>
                 <executions>
                     <execution>
-                        <id>java9</id>
-                        <phase>none</phase>
-                        <goals>
-                            <goal>compile</goal>
-                        </goals>
-                        <configuration>
-                            <release>9</release>
-                            <jdkToolchain>
-                                <version>9</version>
-                            </jdkToolchain>
-                            <compileSourceRoots>
-                                <compileSourceRoot>${project.basedir}/src/main/java9</compileSourceRoot>
-                            </compileSourceRoots>
-                            <multiReleaseOutput>true</multiReleaseOutput>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>java11</id>
                         <phase>none</phase>
                         <goals>
@@ -876,29 +859,6 @@
             </properties>
         </profile>
         <profile>
-            <id>compile-java9</id>
-            <activation>
-                <jdk>[9,)</jdk>
-                <property>
-                    <name>!j8</name>
-                </property>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <executions>
-                            <execution>
-                                <id>java9</id>
-                                <phase>compile</phase>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <id>compile-java11</id>
             <activation>
                 <jdk>[11,)</jdk>
@@ -961,9 +921,6 @@
                         <configuration>
                             <toolchains>
                                 <jdk>
-                                    <version>9</version>
-                                </jdk>
-                                <jdk>
                                     <version>11</version>
                                 </jdk>
                                 <jdk>
@@ -976,10 +933,6 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <executions>
-                            <execution>
-                                <id>java9</id>
-                                <phase>compile</phase>
-                            </execution>
                             <execution>
                                 <id>java11</id>
                                 <phase>compile</phase>
@@ -1159,7 +1112,7 @@
             </build>
         </profile>
         <profile>
-            <id>build9</id>
+            <id>build11</id>
             <activation>
                 <property>
                     <name>!j8</name>
@@ -1180,9 +1133,6 @@
                         <configuration>
                             <toolchains>
                                 <jdk>
-                                    <version>9</version>
-                                </jdk>
-                                <jdk>
                                     <version>11</version>
                                 </jdk>
                                 <jdk>
@@ -1195,10 +1145,6 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <executions>
-                            <execution>
-                                <id>java9</id>
-                                <phase>compile</phase>
-                            </execution>
                             <execution>
                                 <id>java11</id>
                                 <phase>compile</phase>


### PR DESCRIPTION
## Summary
- Remove building, testing, releasing for Java 9
-

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
