### PR TITLE
[client-v2] Fix: null TimeZone Exception

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -130,7 +130,8 @@ public class BinaryStreamReader {
                     return (T) readDateTime32(input, column.getTimeZone() == null ? timeZone:
                             column.getTimeZone());
                 case DateTime64:
-                    return (T) readDateTime64(input, 3, column.getTimeZone());
+                    return (T) readDateTime64(input, 3, column.getTimeZone() == null ? timeZone:
+                            column.getTimeZone());
 
                 case IntervalYear:
                 case IntervalQuarter:


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Possible fix for https://github.com/ClickHouse/clickhouse-java/issues/1780
As I understand it, this field will not be null if you have explicitly specified time zone in the database.
To fix this, i just repeated the code that was above, because I don’t think that the functionality in the JVM can depend on the bit depth of DateTime
Maybe it's just a typo?

Closes https://github.com/ClickHouse/clickhouse-java/issues/1780

## Checklist
Delete items not relevant to your PR:
