### PR TITLE
[client-v2] Fixed reusing map without creating new nodes

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
@@ -39,6 +39,7 @@ import java.util.NoSuchElementException;
 import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 
 public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryFormatReader {
@@ -71,6 +72,7 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
     protected Map<String, Object> currentRecord = new ConcurrentHashMap<>();
     protected Map<String, Object> nextRecord = new ConcurrentHashMap<>();
 
+    protected AtomicBoolean nextRecordEmpty = new AtomicBoolean(true);
 
     /**
      * It is still internal method and should be used with care.
@@ -89,7 +91,9 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
             try {
                 Object val = binaryStreamReader.readValue(column);
                 if (val != null) {
-                    record.put(column.getColumnName(),val);
+                    record.put(column.getColumnName(), val);
+                } else {
+                    record.remove(column.getColumnName());
                 }
                 firstColumn = false;
             } catch (EOFException e) {
@@ -119,15 +123,17 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
 
     @Override
     public boolean hasNext() {
-         return hasNext;
+        return hasNext;
     }
 
 
     protected void readNextRecord() {
         try {
-            nextRecord.clear();
+            nextRecordEmpty.set(true);
             if (!readRecord(nextRecord)) {
                 hasNext = false;
+            } else {
+                nextRecordEmpty.compareAndSet(true, false);
             }
         } catch (IOException e) {
             hasNext = false;
@@ -141,7 +147,7 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
             return null;
         }
 
-        if (!nextRecord.isEmpty()) {
+        if (!nextRecordEmpty.get()) {
             Map<String, Object> tmp = currentRecord;
             currentRecord = nextRecord;
             nextRecord = tmp;
@@ -149,7 +155,6 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
             return currentRecord;
         } else {
             try {
-                currentRecord.clear();
                 if (readRecord(currentRecord)) {
                     readNextRecord();
                     return currentRecord;

--- a/examples/demo-service/src/main/java/com/clickhouse/demo_service/DbConfiguration.java
+++ b/examples/demo-service/src/main/java/com/clickhouse/demo_service/DbConfiguration.java
@@ -18,10 +18,8 @@ public class DbConfiguration {
                 .setUsername(dbUser)
                 .setPassword(dbPassword)
                 .useNewImplementation(true) // using new transport layer implementation
-
-                // sets the maximum number of connections to the server at a time
-                // this is important for services handling many concurrent requests to ClickHouse
-                .setOption(ClickHouseHttpOption.MAX_OPEN_CONNECTIONS.getKey(), "2000")
+                .setLZ4UncompressedBufferSize(1050000) // increase a LZ4 buffer size
+                .setMaxConnections(50)
                 .build();
     }
 }


### PR DESCRIPTION
## Summary
Internally data is read into a map that represents a record. `clear()` was called each time before reading data to protect from stale data from a previous records. However it is not needed because it is always same number of columns are read. Only case with null should be handled correctly to clean up non-null values.

This single change reduces number of Map$Node object by magnitude. 

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
