### PR TITLE
Use debug logging for internal connection details

### DIFF
--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
@@ -95,7 +95,7 @@ public class ApacheHttpConnectionImpl extends ClickHouseHttpConnection {
         }
 
         long connectionTTL = config.getLongOption(ClickHouseClientOption.CONNECTION_TTL);
-        log.info("Connection TTL: %d ms", connectionTTL);
+        log.debug("Connection TTL: %d ms", connectionTTL);
         String poolReuseStrategy = c.getStrOption(ClickHouseHttpOption.CONNECTION_REUSE_STRATEGY);
         PoolReusePolicy poolReusePolicy = PoolReusePolicy.LIFO;
         if (poolReuseStrategy != null && !poolReuseStrategy.isEmpty()) {
@@ -105,7 +105,7 @@ public class ApacheHttpConnectionImpl extends ClickHouseHttpConnection {
                 throw new IllegalArgumentException("Invalid connection reuse strategy: " + poolReuseStrategy);
             }
         }
-        log.info("Connection reuse strategy: %s", poolReusePolicy.name());
+        log.debug("Connection reuse strategy: %s", poolReusePolicy.name());
         HttpConnectionManager connManager = new HttpConnectionManager(r.build(), c, PoolConcurrencyPolicy.LAX,
                 poolReusePolicy, TimeValue.ofMilliseconds(connectionTTL));
         int maxConnection = config.getIntOption(ClickHouseHttpOption.MAX_OPEN_CONNECTIONS);


### PR DESCRIPTION
## Summary
Currently, connection TTL & queue strategy are logged at INFO level for every request. This can result in a lot of noise in logs:

![Screenshot 2024-09-03 at 11 00 56 AM](https://github.com/user-attachments/assets/89d18028-2ff7-4671-b658-51f401d9181c)

This PR switches them to DEBUG log levels.

## Checklist
Delete items not relevant to your PR:
- [ ] A human-readable description of the changes was provided to include in CHANGELOG