### PR TITLE
Including support for bitmap serialization

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/SerializerUtils.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/SerializerUtils.java
@@ -2,8 +2,11 @@ package com.clickhouse.client.api.internal;
 
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ClientFaultCause;
+import com.clickhouse.data.ClickHouseAggregateFunction;
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.format.BinaryStreamUtils;
+import com.clickhouse.data.value.ClickHouseBitmap;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -42,6 +45,9 @@ public class SerializerUtils {
                 break;
             case Map:
                 serializeMapData(stream, value, column);
+                break;
+            case AggregateFunction:
+                serializeAggregateFunction(stream, value, column);
                 break;
             default:
                 serializePrimitiveData(stream, value, column);
@@ -177,6 +183,13 @@ public class SerializerUtils {
         }
     }
 
+    private static void serializeAggregateFunction(OutputStream stream, Object value, ClickHouseColumn column) throws IOException {
+        if (column.getAggregateFunction() == ClickHouseAggregateFunction.groupBitmap) {
+            BinaryStreamUtils.writeBitmap(stream, (ClickHouseBitmap) value);
+        } else {
+            throw new UnsupportedOperationException("Unsupported aggregate function: " + column.getAggregateFunction());
+        }
+    }
 
     public static Integer convertToInteger(Object value) {
         if (value instanceof Integer) {


### PR DESCRIPTION
## Summary
I have a table structure which has a few aggregate function columns (groupBitmap) and I was unable to directly insert into it as the ClickhouseBitmapColumn was throwing an unsupported data type when serializing.

Checking the code I saw there was a `writeBitmap` function implemented in the BinaryStreamUtils but it was not being used in the SerializerUtils. Not sure if there was any reason behind it or if there are any other aggregate functions that could be serialized as well. 

- I did not add any unit tests as this class did not have them yet (there is no much logic in it but a wrapper to serialize)  but let me know fi that is a requirement and I'll add unit tests to cover the changes.
