### PR TITLE
[client-v2] reader buffer optimization

### DIFF
--- a/.github/workflows/analysis.yml
+++ b/.github/workflows/analysis.yml
@@ -95,6 +95,6 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: |
-          mvn --batch-mode -DclickhouseVersion=$PREFERRED_LTS_VERSION \
+          mvn --batch-mode -DclickhouseVersion=$PREFERRED_LTS_VERSION -Dclient.tests.useNewImplementation=true \
             -Panalysis verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
         continue-on-error: true

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/ClickHouseBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/ClickHouseBinaryFormatReader.java
@@ -19,7 +19,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-public interface ClickHouseBinaryFormatReader {
+public interface ClickHouseBinaryFormatReader extends AutoCloseable {
 
     /**
      * Reads a single value from the stream.

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/NativeFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/NativeFormatReader.java
@@ -2,6 +2,7 @@ package com.clickhouse.client.api.data_formats;
 
 import com.clickhouse.client.api.data_formats.internal.AbstractBinaryFormatReader;
 import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
+import com.clickhouse.client.api.internal.BasicObjectsPool;
 import com.clickhouse.client.api.query.QuerySettings;
 import com.clickhouse.data.ClickHouseColumn;
 
@@ -23,12 +24,9 @@ public class NativeFormatReader extends AbstractBinaryFormatReader {
 
     private int blockRowIndex;
 
-    public NativeFormatReader(InputStream inputStream) {
-        this(inputStream, null);
-    }
-
-    public NativeFormatReader(InputStream inputStream, QuerySettings settings) {
-        super(inputStream, settings, null);
+    public NativeFormatReader(InputStream inputStream, QuerySettings settings,
+                              BasicObjectsPool<BinaryStreamReader.ByteBufferAllocator> byteBufferPool) {
+        super(inputStream, settings, null, byteBufferPool);
         readNextRecord();
     }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/NativeFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/NativeFormatReader.java
@@ -2,7 +2,6 @@ package com.clickhouse.client.api.data_formats;
 
 import com.clickhouse.client.api.data_formats.internal.AbstractBinaryFormatReader;
 import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
-import com.clickhouse.client.api.internal.BasicObjectsPool;
 import com.clickhouse.client.api.query.QuerySettings;
 import com.clickhouse.data.ClickHouseColumn;
 
@@ -25,8 +24,8 @@ public class NativeFormatReader extends AbstractBinaryFormatReader {
     private int blockRowIndex;
 
     public NativeFormatReader(InputStream inputStream, QuerySettings settings,
-                              BasicObjectsPool<BinaryStreamReader.ByteBufferAllocator> byteBufferPool) {
-        super(inputStream, settings, null, byteBufferPool);
+                              BinaryStreamReader.ByteBufferAllocator byteBufferAllocator) {
+        super(inputStream, settings, null, byteBufferAllocator);
         readNextRecord();
     }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryFormatReader.java
@@ -1,6 +1,8 @@
 package com.clickhouse.client.api.data_formats;
 
 import com.clickhouse.client.api.data_formats.internal.AbstractBinaryFormatReader;
+import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
+import com.clickhouse.client.api.internal.BasicObjectsPool;
 import com.clickhouse.client.api.metadata.TableSchema;
 import com.clickhouse.client.api.query.QuerySettings;
 import com.clickhouse.data.ClickHouseColumn;
@@ -12,12 +14,9 @@ import java.util.Map;
 
 public class RowBinaryFormatReader extends AbstractBinaryFormatReader {
 
-    public RowBinaryFormatReader(InputStream inputStream, TableSchema schema) {
-        this(inputStream, null, schema);
-    }
-
-    public RowBinaryFormatReader(InputStream inputStream, QuerySettings querySettings, TableSchema schema) {
-        super(inputStream, querySettings, schema);
+    public RowBinaryFormatReader(InputStream inputStream, QuerySettings querySettings, TableSchema schema,
+                                 BasicObjectsPool<BinaryStreamReader.ByteBufferAllocator> byteBufferPool) {
+        super(inputStream, querySettings, schema, byteBufferPool);
         readNextRecord();
     }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryFormatReader.java
@@ -2,7 +2,6 @@ package com.clickhouse.client.api.data_formats;
 
 import com.clickhouse.client.api.data_formats.internal.AbstractBinaryFormatReader;
 import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
-import com.clickhouse.client.api.internal.BasicObjectsPool;
 import com.clickhouse.client.api.metadata.TableSchema;
 import com.clickhouse.client.api.query.QuerySettings;
 import com.clickhouse.data.ClickHouseColumn;
@@ -15,8 +14,8 @@ import java.util.Map;
 public class RowBinaryFormatReader extends AbstractBinaryFormatReader {
 
     public RowBinaryFormatReader(InputStream inputStream, QuerySettings querySettings, TableSchema schema,
-                                 BasicObjectsPool<BinaryStreamReader.ByteBufferAllocator> byteBufferPool) {
-        super(inputStream, querySettings, schema, byteBufferPool);
+                                 BinaryStreamReader.ByteBufferAllocator byteBufferAllocator) {
+        super(inputStream, querySettings, schema, byteBufferAllocator);
         readNextRecord();
     }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryWithNamesAndTypesFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryWithNamesAndTypesFormatReader.java
@@ -3,6 +3,7 @@ package com.clickhouse.client.api.data_formats;
 import com.clickhouse.client.api.ClientException;
 import com.clickhouse.client.api.data_formats.internal.AbstractBinaryFormatReader;
 import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
+import com.clickhouse.client.api.internal.BasicObjectsPool;
 import com.clickhouse.client.api.metadata.TableSchema;
 import com.clickhouse.client.api.query.QuerySettings;
 import com.clickhouse.data.ClickHouseColumn;
@@ -17,8 +18,9 @@ import java.util.Map;
 
 public class RowBinaryWithNamesAndTypesFormatReader extends AbstractBinaryFormatReader implements Iterator<Map<String, Object>> {
 
-    public RowBinaryWithNamesAndTypesFormatReader(InputStream inputStream, QuerySettings querySettings) {
-        super(inputStream, querySettings, null);
+    public RowBinaryWithNamesAndTypesFormatReader(InputStream inputStream, QuerySettings querySettings,
+                                                  BasicObjectsPool<BinaryStreamReader.ByteBufferAllocator> byteBufferPool) {
+        super(inputStream, querySettings, null, byteBufferPool);
         readSchema();
     }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryWithNamesAndTypesFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryWithNamesAndTypesFormatReader.java
@@ -3,10 +3,8 @@ package com.clickhouse.client.api.data_formats;
 import com.clickhouse.client.api.ClientException;
 import com.clickhouse.client.api.data_formats.internal.AbstractBinaryFormatReader;
 import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
-import com.clickhouse.client.api.internal.BasicObjectsPool;
 import com.clickhouse.client.api.metadata.TableSchema;
 import com.clickhouse.client.api.query.QuerySettings;
-import com.clickhouse.data.ClickHouseColumn;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -19,8 +17,8 @@ import java.util.Map;
 public class RowBinaryWithNamesAndTypesFormatReader extends AbstractBinaryFormatReader implements Iterator<Map<String, Object>> {
 
     public RowBinaryWithNamesAndTypesFormatReader(InputStream inputStream, QuerySettings querySettings,
-                                                  BasicObjectsPool<BinaryStreamReader.ByteBufferAllocator> byteBufferPool) {
-        super(inputStream, querySettings, null, byteBufferPool);
+                                                  BinaryStreamReader.ByteBufferAllocator byteBufferAllocator) {
+        super(inputStream, querySettings, null, byteBufferAllocator);
         readSchema();
     }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryWithNamesFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryWithNamesFormatReader.java
@@ -2,7 +2,6 @@ package com.clickhouse.client.api.data_formats;
 
 import com.clickhouse.client.api.data_formats.internal.AbstractBinaryFormatReader;
 import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
-import com.clickhouse.client.api.internal.BasicObjectsPool;
 import com.clickhouse.client.api.metadata.TableSchema;
 import com.clickhouse.client.api.query.QuerySettings;
 
@@ -18,8 +17,8 @@ public class RowBinaryWithNamesFormatReader extends AbstractBinaryFormatReader {
     private List<String> columns = null;
 
     public RowBinaryWithNamesFormatReader(InputStream inputStream, QuerySettings querySettings, TableSchema schema,
-                                          BasicObjectsPool<BinaryStreamReader.ByteBufferAllocator> byteBufferPool) {
-        super(inputStream, querySettings, schema, byteBufferPool);
+                                          BinaryStreamReader.ByteBufferAllocator byteBufferAllocator) {
+        super(inputStream, querySettings, schema, byteBufferAllocator);
         int nCol = 0;
         try {
             nCol = BinaryStreamReader.readVarInt(input);

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryWithNamesFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryWithNamesFormatReader.java
@@ -2,9 +2,9 @@ package com.clickhouse.client.api.data_formats;
 
 import com.clickhouse.client.api.data_formats.internal.AbstractBinaryFormatReader;
 import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
+import com.clickhouse.client.api.internal.BasicObjectsPool;
 import com.clickhouse.client.api.metadata.TableSchema;
 import com.clickhouse.client.api.query.QuerySettings;
-import com.clickhouse.data.ClickHouseColumn;
 
 import java.io.EOFException;
 import java.io.IOException;
@@ -12,19 +12,14 @@ import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 public class RowBinaryWithNamesFormatReader extends AbstractBinaryFormatReader {
 
     private List<String> columns = null;
 
-    public RowBinaryWithNamesFormatReader(InputStream inputStream, TableSchema schema) {
-        this(inputStream, null, schema);
-        readNextRecord();
-    }
-
-    public RowBinaryWithNamesFormatReader(InputStream inputStream, QuerySettings querySettings, TableSchema schema) {
-        super(inputStream, querySettings, schema);
+    public RowBinaryWithNamesFormatReader(InputStream inputStream, QuerySettings querySettings, TableSchema schema,
+                                          BasicObjectsPool<BinaryStreamReader.ByteBufferAllocator> byteBufferPool) {
+        super(inputStream, querySettings, schema, byteBufferPool);
         int nCol = 0;
         try {
             nCol = BinaryStreamReader.readVarInt(input);

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
@@ -2,6 +2,7 @@ package com.clickhouse.client.api.data_formats.internal;
 
 import com.clickhouse.client.api.ClientException;
 import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatReader;
+import com.clickhouse.client.api.internal.BasicObjectsPool;
 import com.clickhouse.client.api.internal.MapUtils;
 import com.clickhouse.client.api.metadata.TableSchema;
 import com.clickhouse.client.api.query.NullValueException;
@@ -41,6 +42,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryFormatReader {
 
@@ -58,7 +60,12 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
 
     private volatile boolean hasNext = true;
 
-    protected AbstractBinaryFormatReader(InputStream inputStream, QuerySettings querySettings, TableSchema schema) {
+    BasicObjectsPool<BinaryStreamReader.ByteBufferAllocator> byteBufferPool;
+
+    BinaryStreamReader.ByteBufferAllocator byteBufferAllocator;
+
+    protected AbstractBinaryFormatReader(InputStream inputStream, QuerySettings querySettings, TableSchema schema,
+                                         BasicObjectsPool<BinaryStreamReader.ByteBufferAllocator> byteBufferPool) {
         this.input = inputStream;
         this.settings = querySettings == null ? Collections.emptyMap() : new HashMap<>(querySettings.getAllSettings());
         boolean useServerTimeZone = (boolean) this.settings.get(ClickHouseClientOption.USE_SERVER_TIME_ZONE.getKey());
@@ -67,7 +74,9 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
         if (timeZone == null) {
             throw new ClientException("Time zone is not set. (useServerTimezone:" + useServerTimeZone + ")");
         }
-        this.binaryStreamReader = new BinaryStreamReader(inputStream, timeZone, LOG);
+        this. byteBufferPool = byteBufferPool;
+        this.byteBufferAllocator = byteBufferPool.lease();
+        this.binaryStreamReader = new BinaryStreamReader(inputStream, timeZone, LOG, byteBufferAllocator);
         setSchema(schema);
     }
 
@@ -133,12 +142,12 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
         try {
             nextRecordEmpty.set(true);
             if (!readRecord(nextRecord)) {
-                hasNext = false;
+                endReached();
             } else {
                 nextRecordEmpty.compareAndSet(true, false);
             }
         } catch (IOException e) {
-            hasNext = false;
+            endReached();
             throw new ClientException("Failed to read next row", e);
         }
     }
@@ -165,7 +174,7 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
                     return null;
                 }
             } catch (IOException e) {
-                hasNext = false;
+                endReached();
                 throw new ClientException("Failed to read row", e);
             }
         }
@@ -173,6 +182,9 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
 
     protected void endReached() {
         hasNext = false;
+        BinaryStreamReader.ByteBufferAllocator allocator = this.byteBufferAllocator;
+        this.byteBufferAllocator = null;
+        byteBufferPool.release(allocator);
     }
 
     protected void setSchema(TableSchema schema) {
@@ -620,5 +632,14 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
             return ((ZonedDateTime) value).toLocalDateTime();
         }
         return (LocalDateTime) value;
+    }
+
+    @Override
+    public void close() throws Exception {
+        if (byteBufferAllocator != null) {
+            byteBufferPool.release(byteBufferAllocator);
+            byteBufferAllocator = null;
+        }
+        input.close();
     }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/BasicObjectsPool.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/BasicObjectsPool.java
@@ -1,0 +1,31 @@
+package com.clickhouse.client.api.internal;
+
+import java.util.Deque;
+
+public abstract class BasicObjectsPool<T> {
+
+
+    private Deque<T> objects;
+
+    BasicObjectsPool(Deque<T> objects) {
+        this(objects, 0);
+    }
+
+    public BasicObjectsPool(Deque<T> objects, int size) {
+        this.objects = objects;
+        for (int i = 0; i < size; i++) {
+            this.objects.add(create());
+        }
+    }
+
+    public T lease() {
+        T obj = objects.poll();
+        return obj != null ? obj : create();
+    }
+
+    public void release(T obj) {
+        objects.addFirst(obj);
+    }
+
+    protected abstract T create();
+}

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/BasicObjectsPool.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/BasicObjectsPool.java
@@ -2,15 +2,31 @@ package com.clickhouse.client.api.internal;
 
 import java.util.Deque;
 
-public abstract class BasicObjectsPool<T> {
 
+/**
+ * Objects pool.
+ * Can be used to reuse object to reduce GC pressure.
+ * Thread-safety is not guaranteed. Depends on deque implementation that is
+ * passed to the constructor.
+ * @param <T> - type of stored objects
+ */
+public abstract class BasicObjectsPool<T> {
 
     private Deque<T> objects;
 
+    /**
+     * Creates an empty pool.
+     * @param objects object queue
+     */
     BasicObjectsPool(Deque<T> objects) {
         this(objects, 0);
     }
 
+    /**
+     * Creates a pool and pre-populates it with a number of objects equal to the size parameter.
+     * @param objects object queue
+     * @param size initial size of the object queue
+     */
     public BasicObjectsPool(Deque<T> objects, int size) {
         this.objects = objects;
         for (int i = 0; i < size; i++) {

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/CachingObjectsSupplier.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/CachingObjectsSupplier.java
@@ -1,0 +1,44 @@
+package com.clickhouse.client.api.internal;
+
+import java.util.Deque;
+import java.util.Iterator;
+import java.util.function.Supplier;
+
+public abstract class CachingObjectsSupplier<T> implements Supplier<T> {
+
+    private Iterator<T> iterator;
+    private Deque<T> cache;;
+
+    /**
+     * Constructs caching object supplier that uses Deque as cache. Deque may be a thread safe implementation.
+     * It will be filled with {@code preallocate} number of objects.
+     *
+     * @param cache
+     * @param preallocate
+     */
+    public CachingObjectsSupplier(Deque<T> cache, int preallocate) {
+        this.cache = cache;
+    }
+
+    @Override
+    public T get() {
+        T obj;
+        if (iterator.hasNext()) {
+            obj = iterator.next();
+        } else {
+            obj = create();
+            cache.addFirst(obj);
+        }
+
+        return obj;
+    }
+
+    /**
+     * Resets internal iterator to begin with the first object in the cache.
+     */
+    public void reset() {
+        iterator = cache.iterator();
+    }
+
+    public abstract T create();
+}

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/Records.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/Records.java
@@ -1,14 +1,9 @@
 package com.clickhouse.client.api.query;
 
-import com.clickhouse.client.api.ClientException;
 import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatReader;
-import com.clickhouse.client.api.data_formats.RowBinaryWithNamesAndTypesFormatReader;
 import com.clickhouse.client.api.data_formats.internal.BinaryReaderBackedRecord;
-import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
-import com.clickhouse.client.api.internal.BasicObjectsPool;
 import com.clickhouse.client.api.metrics.OperationMetrics;
 import com.clickhouse.client.api.metrics.ServerMetrics;
-import com.clickhouse.data.ClickHouseFormat;
 
 import java.util.Iterator;
 import java.util.Spliterator;
@@ -24,13 +19,9 @@ public class Records implements Iterable<GenericRecord>, AutoCloseable {
     private boolean empty;
     private Iterator<GenericRecord> iterator;
 
-    public Records(QueryResponse response, QuerySettings finalSettings, BasicObjectsPool<BinaryStreamReader.ByteBufferAllocator> byteBufferPool) {
+    public Records(QueryResponse response, ClickHouseBinaryFormatReader reader) {
         this.response = response;
-        if (!response.getFormat().equals(ClickHouseFormat.RowBinaryWithNamesAndTypes)) {
-            throw new ClientException("Unsupported format: " + finalSettings.getFormat());
-        }
-
-        this.reader = new RowBinaryWithNamesAndTypesFormatReader(response.getInputStream(), finalSettings, byteBufferPool);
+        this.reader = reader;
         this.empty = !reader.hasNext();
     }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/Records.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/Records.java
@@ -4,6 +4,8 @@ import com.clickhouse.client.api.ClientException;
 import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatReader;
 import com.clickhouse.client.api.data_formats.RowBinaryWithNamesAndTypesFormatReader;
 import com.clickhouse.client.api.data_formats.internal.BinaryReaderBackedRecord;
+import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
+import com.clickhouse.client.api.internal.BasicObjectsPool;
 import com.clickhouse.client.api.metrics.OperationMetrics;
 import com.clickhouse.client.api.metrics.ServerMetrics;
 import com.clickhouse.data.ClickHouseFormat;
@@ -22,13 +24,13 @@ public class Records implements Iterable<GenericRecord>, AutoCloseable {
     private boolean empty;
     private Iterator<GenericRecord> iterator;
 
-    public Records(QueryResponse response, QuerySettings finalSettings) {
+    public Records(QueryResponse response, QuerySettings finalSettings, BasicObjectsPool<BinaryStreamReader.ByteBufferAllocator> byteBufferPool) {
         this.response = response;
         if (!response.getFormat().equals(ClickHouseFormat.RowBinaryWithNamesAndTypes)) {
             throw new ClientException("Unsupported format: " + finalSettings.getFormat());
         }
 
-        this.reader = new RowBinaryWithNamesAndTypesFormatReader(response.getInputStream(), finalSettings);
+        this.reader = new RowBinaryWithNamesAndTypesFormatReader(response.getInputStream(), finalSettings, byteBufferPool);
         this.empty = !reader.hasNext();
     }
 

--- a/client-v2/src/test/java/com/clickhouse/client/query/BinaryReadyReusesBuffersTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/BinaryReadyReusesBuffersTests.java
@@ -1,0 +1,8 @@
+package com.clickhouse.client.query;
+
+public class BinaryReadyReusesBuffersTests extends QueryTests  {
+
+    public BinaryReadyReusesBuffersTests() {
+        super(false, false, true);
+    }
+}

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -86,12 +86,19 @@ public class QueryTests extends BaseIntegrationTest {
 
     private boolean useHttpCompression = false;
 
+    private boolean usePreallocatedBuffers = false;
+
     QueryTests(){
     }
 
     public QueryTests(boolean useServerCompression, boolean useHttpCompression) {
+        this(useServerCompression, useHttpCompression, false);
+    }
+
+    public QueryTests(boolean useServerCompression, boolean useHttpCompression, boolean usePreallocatedBuffers) {
         this.useServerCompression = useServerCompression;
         this.useHttpCompression = useHttpCompression;
+        this.usePreallocatedBuffers = usePreallocatedBuffers;
     }
 
     @BeforeMethod(groups = {"integration"})
@@ -1455,6 +1462,7 @@ public class QueryTests extends BaseIntegrationTest {
                 .compressClientRequest(false)
                 .compressServerResponse(true)
                 .useHttpCompression(useHttpCompression)
+                .setOption("client_use_caching_buffer_allocator", Boolean.valueOf(usePreallocatedBuffers).toString())
                 .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "true").equals("true"));
     }
 }

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -15,10 +15,6 @@ import com.clickhouse.client.api.ClientException;
 import com.clickhouse.client.api.DataTypeUtils;
 import com.clickhouse.client.api.ServerException;
 import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatReader;
-import com.clickhouse.client.api.data_formats.NativeFormatReader;
-import com.clickhouse.client.api.data_formats.RowBinaryFormatReader;
-import com.clickhouse.client.api.data_formats.RowBinaryWithNamesAndTypesFormatReader;
-import com.clickhouse.client.api.data_formats.RowBinaryWithNamesFormatReader;
 import com.clickhouse.client.api.enums.Protocol;
 import com.clickhouse.client.api.insert.InsertSettings;
 import com.clickhouse.client.api.metadata.TableSchema;
@@ -53,7 +49,6 @@ import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
-import java.net.UnknownHostException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
@@ -78,8 +73,8 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import java.util.stream.BaseStream;
-import java.util.stream.IntStream;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 public class QueryTests extends BaseIntegrationTest {
 
@@ -366,7 +361,7 @@ public class QueryTests extends BaseIntegrationTest {
         QueryResponse queryResponse = response.get();
 
         TableSchema tableSchema = client.getTableSchema(DATASET_TABLE + "_" + format.name());
-        ClickHouseBinaryFormatReader reader = createBinaryFormatReader(queryResponse, settings, tableSchema);
+        ClickHouseBinaryFormatReader reader = client.newBinaryFormatReader(queryResponse, tableSchema);
 
         Iterator<Map<String, Object>> dataIterator = data.iterator();
         int rowsCount = 0;
@@ -378,28 +373,6 @@ public class QueryTests extends BaseIntegrationTest {
         }
 
         Assert.assertEquals(rowsCount, rows);
-    }
-
-    private static ClickHouseBinaryFormatReader createBinaryFormatReader(QueryResponse response, QuerySettings settings,
-                                                                         TableSchema schema) {
-        ClickHouseBinaryFormatReader reader = null;
-        switch (response.getFormat()) {
-            case Native:
-                reader = new NativeFormatReader(response.getInputStream(), settings);
-                break;
-            case RowBinaryWithNamesAndTypes:
-                reader = new RowBinaryWithNamesAndTypesFormatReader(response.getInputStream(), settings);
-                break;
-            case RowBinaryWithNames:
-                reader = new RowBinaryWithNamesFormatReader(response.getInputStream(), settings, schema);
-                break;
-            case RowBinary:
-                reader = new RowBinaryFormatReader(response.getInputStream(), settings, schema);
-                break;
-            default:
-                Assert.fail("unsupported format: " + response.getFormat().name());
-        }
-        return reader;
     }
 
     @Test(groups = {"integration"})
@@ -415,7 +388,7 @@ public class QueryTests extends BaseIntegrationTest {
         schema.addColumn("col1", "UInt32");
         schema.addColumn("col3", "String");
         schema.addColumn("host", "String");
-        ClickHouseBinaryFormatReader reader = createBinaryFormatReader(queryResponse, settings, schema);
+        ClickHouseBinaryFormatReader reader = client.newBinaryFormatReader(queryResponse, schema);
         int rowsCount = 0;
         while (reader.next() != null) {
             String hostName = reader.readValue("host");
@@ -447,7 +420,7 @@ public class QueryTests extends BaseIntegrationTest {
         schema.addColumn("col1", "UInt32");
         schema.addColumn("col3", "String");
         schema.addColumn("host", "String");
-        ClickHouseBinaryFormatReader reader = new RowBinaryWithNamesAndTypesFormatReader(queryResponse.getInputStream(), settings);
+        ClickHouseBinaryFormatReader reader = client.newBinaryFormatReader(queryResponse);
 
         Map<String, Object> record;
         for (int i = 0; i < rows; i++) {
@@ -486,8 +459,7 @@ public class QueryTests extends BaseIntegrationTest {
         TableSchema schema = client.getTableSchema(table);
 
         QueryResponse queryResponse = response.get();
-        ClickHouseBinaryFormatReader reader = createBinaryFormatReader(queryResponse, settings, schema);
-
+        ClickHouseBinaryFormatReader reader = client.newBinaryFormatReader(queryResponse, schema);
 
         Map<String, Object> record = reader.next();
         Assert.assertNotNull(record);
@@ -535,7 +507,7 @@ public class QueryTests extends BaseIntegrationTest {
         TableSchema schema = client.getTableSchema(table);
 
         QueryResponse queryResponse = response.get();
-        ClickHouseBinaryFormatReader reader = createBinaryFormatReader(queryResponse, settings, schema);
+        ClickHouseBinaryFormatReader reader = client.newBinaryFormatReader(queryResponse, schema);
 
         Map<String, Object> record = reader.next();
         Assert.assertNotNull(record);
@@ -586,7 +558,7 @@ public class QueryTests extends BaseIntegrationTest {
         TableSchema schema = client.getTableSchema(table);
 
         QueryResponse queryResponse = response.get();
-        ClickHouseBinaryFormatReader reader = createBinaryFormatReader(queryResponse, settings, schema);
+        ClickHouseBinaryFormatReader reader = client.newBinaryFormatReader(queryResponse, schema);
 
         Map<String, Object> record = reader.next();
         Assert.assertNotNull(record);
@@ -1123,7 +1095,7 @@ public class QueryTests extends BaseIntegrationTest {
 
         try {
             QueryResponse queryResponse = response.get();
-            ClickHouseBinaryFormatReader reader = createBinaryFormatReader(queryResponse, settings, schema);
+            ClickHouseBinaryFormatReader reader = client.newBinaryFormatReader(queryResponse, schema);
             Assert.assertNotNull(reader.next());
             Assert.assertEquals(verifiers.size(), columns.size(), "Number of verifiers should match number of columns");
             int colIndex = 0;
@@ -1376,8 +1348,7 @@ public class QueryTests extends BaseIntegrationTest {
                      client.query("SELECT now() as t, toDateTime(now(), 'UTC') as utc_time " +
                              "SETTINGS session_timezone = '" + requestTimeZone + "'").get(1, TimeUnit.SECONDS)) {
 
-            ClickHouseBinaryFormatReader reader =
-                    new RowBinaryWithNamesAndTypesFormatReader(response.getInputStream(), response.getSettings());
+            ClickHouseBinaryFormatReader reader = client.newBinaryFormatReader(response);
 
             reader.next();
 
@@ -1407,8 +1378,7 @@ public class QueryTests extends BaseIntegrationTest {
                                  "toDateTime(now(), 'Europe/Lisbon')" +
                                  "SETTINGS session_timezone = '" + requestTimeZone + "'").get(1, TimeUnit.SECONDS)) {
 
-                ClickHouseBinaryFormatReader reader =
-                        new RowBinaryWithNamesAndTypesFormatReader(response.getInputStream(), response.getSettings());
+                ClickHouseBinaryFormatReader reader = client.newBinaryFormatReader(response);
 
                 reader.next();
 
@@ -1440,8 +1410,7 @@ public class QueryTests extends BaseIntegrationTest {
     protected void simpleRequest(Client client) throws Exception {
         try (QueryResponse response =
                      client.query("SELECT number FROM system.numbers LIMIT 1000_000").get(1, TimeUnit.SECONDS)) {
-            ClickHouseBinaryFormatReader reader =
-                    new RowBinaryWithNamesAndTypesFormatReader(response.getInputStream(), response.getSettings());
+            ClickHouseBinaryFormatReader reader = client.newBinaryFormatReader(response);
 
             int count = 0;
             while (reader.hasNext()) {

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -1462,7 +1462,7 @@ public class QueryTests extends BaseIntegrationTest {
                 .compressClientRequest(false)
                 .compressServerResponse(true)
                 .useHttpCompression(useHttpCompression)
-                .setOption("client_use_caching_buffer_allocator", Boolean.valueOf(usePreallocatedBuffers).toString())
+                .allowBinaryReaderToReuseBuffers(usePreallocatedBuffers)
                 .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "true").equals("true"));
     }
 }

--- a/client-v2/src/test/java/com/clickhouse/client/query/UsingPreallocatefReadBuffers.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/UsingPreallocatefReadBuffers.java
@@ -1,8 +1,0 @@
-package com.clickhouse.client.query;
-
-public class UsingPreallocatefReadBuffers extends QueryTests  {
-
-    public UsingPreallocatefReadBuffers() {
-        super(false, false);
-    }
-}

--- a/client-v2/src/test/java/com/clickhouse/client/query/UsingPreallocatefReadBuffers.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/UsingPreallocatefReadBuffers.java
@@ -1,0 +1,8 @@
+package com.clickhouse.client.query;
+
+public class UsingPreallocatefReadBuffers extends QueryTests  {
+
+    public UsingPreallocatefReadBuffers() {
+        super(false, false);
+    }
+}

--- a/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/BigDatasetExamples.java
+++ b/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/BigDatasetExamples.java
@@ -102,7 +102,7 @@ public class BigDatasetExamples {
             ArrayList<com.clickhouse.demo_service.data.NumbersRecord> result = new ArrayList<>();
 
             // iterable approach is more efficient for large datasets because it doesn't load all records into memory
-            ClickHouseBinaryFormatReader reader = Client.newBinaryFormatReader(response);
+            ClickHouseBinaryFormatReader reader = client.newBinaryFormatReader(response);
 
             long start = System.nanoTime();
             while (reader.next() != null) {

--- a/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/SimpleReader.java
+++ b/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/SimpleReader.java
@@ -59,8 +59,7 @@ public class SimpleReader {
         try (QueryResponse response = client.query(sql).get(3, TimeUnit.SECONDS);) {
 
             // Create a reader to access the data in a convenient way
-            ClickHouseBinaryFormatReader reader = new RowBinaryWithNamesAndTypesFormatReader(response.getInputStream(),
-                    response.getSettings());
+            ClickHouseBinaryFormatReader reader = client.newBinaryFormatReader(response);
 
             while (reader.hasNext()) {
                 reader.next(); // Read the next record from stream and parse it

--- a/examples/demo-service/src/main/java/com/clickhouse/demo_service/DatasetController.java
+++ b/examples/demo-service/src/main/java/com/clickhouse/demo_service/DatasetController.java
@@ -68,7 +68,7 @@ public class DatasetController {
             ArrayList<VirtualDatasetRecord> result = new ArrayList<>();
 
             // iterable approach is more efficient for large datasets because it doesn't load all records into memory
-            ClickHouseBinaryFormatReader reader = Client.newBinaryFormatReader(response);
+            ClickHouseBinaryFormatReader reader = chDirectClient.newBinaryFormatReader(response);
 
             long start = System.nanoTime();
             while (reader.next() != null) {


### PR DESCRIPTION
## Summary
A lot small buffers may be allocated while reading numeric information. 
This PR implements a reusing buffers withing a reader. It is not a default behavior. 
Introduced `Client.Builder#allowBinaryReaderToReuseBuffers` to control the behavior 

Note: 
- implementation is not thread-safe 
- reader should be called by one thread at a time
- small buffers will 64 bytes are pre-allocated 


## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
