### PR TITLE
[client-v2] primitive reading into pojo

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
@@ -73,17 +73,27 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
 
     protected AtomicBoolean nextRecordEmpty = new AtomicBoolean(true);
 
+    /**
+     * Reads next record into POJO object using set of serializers.
+     * There should be a serializer for each column in the record, otherwise it will silently skip a field
+     * It is done in such a way because it is not the reader concern. Calling code should validate this.
+     *
+     * Note: internal API
+     * @param deserializers
+     * @param obj
+     * @return
+     * @throws IOException
+     */
     public boolean readToPOJO(Map<String, POJOSetter> deserializers, Object obj ) throws IOException {
         boolean firstColumn = true;
 
         for (ClickHouseColumn column : columns) {
             try {
-                Object val = binaryStreamReader.readValue(column);
-                if (val != null) {
-                    POJOSetter deserializer = deserializers.get(column.getColumnName());
-                    if (deserializer != null) {
-                        deserializer.setValue(obj, val);
-                    }
+                POJOSetter deserializer = deserializers.get(column.getColumnName());
+                if (deserializer != null) {
+                    deserializer.setValue(obj, binaryStreamReader, column);
+                } else {
+                    binaryStreamReader.skipValue(column);
                 }
                 firstColumn = false;
             } catch (EOFException e) {

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -20,6 +20,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -68,11 +69,28 @@ public class BinaryStreamReader {
         this.bufferAllocator = bufferAllocator;
     }
 
+    /**
+     * Reads a value from the internal input stream.
+     * @param column - column information
+     * @return value
+     * @param <T> - target type of the value
+     * @throws IOException when IO error occurs
+     */
     public <T> T readValue(ClickHouseColumn column) throws IOException {
-        return readValueImpl(column);
+        return readValue(column, null);
     }
 
-    private <T> T readValueImpl(ClickHouseColumn column) throws IOException {
+    /**
+     * Reads a value from the internal input stream. Method will use type hint to do smarter conversion if possible.
+     * For example, all datetime values are of {@link ZonedDateTime}; if a type hint is {@link LocalDateTime} then
+     * {@link ZonedDateTime#toLocalDateTime()} .
+     * @param column - column information
+     * @param typeHint - type hint
+     * @return value
+     * @param <T> - target type of the value
+     * @throws IOException when IO error occurs
+     */
+    public <T> T readValue(ClickHouseColumn column, Class<?> typeHint) throws IOException {
         if (column.isNullable()) {
             int isNull = readByteOrEOF(input);
             if (isNull == 1) { // is Null?
@@ -95,64 +113,64 @@ public class BinaryStreamReader {
                     return (T) new String(readNBytes(input, len), StandardCharsets.UTF_8);
                 }
                 case Int8:
-                    return (T) Byte.valueOf((byte) readByteOrEOF(input));
+                    return (T) Byte.valueOf(readByte());
                 case UInt8:
-                    return (T) Short.valueOf(readUnsignedByte(input));
+                    return (T) Short.valueOf(readUnsignedByte());
                 case Int16:
-                    return (T) Short.valueOf(readShortLE(input));
+                    return (T) Short.valueOf(readShortLE());
                 case UInt16:
-                    return (T) Integer.valueOf(readUnsignedShortLE(input));
+                    return (T) Integer.valueOf(readUnsignedShortLE());
                 case Int32:
-                    return (T) Integer.valueOf(readIntLE(input));
+                    return (T) Integer.valueOf(readIntLE());
                 case UInt32:
-                    return (T) Long.valueOf(readUnsignedIntLE(input));
+                    return (T) Long.valueOf(readUnsignedIntLE());
                 case Int64:
-                    return (T) Long.valueOf(readLongLE(input));
+                    return (T) Long.valueOf(readLongLE());
                 case UInt64:
-                    return (T) readBigIntegerLE(input, INT64_SIZE, true);
+                    return (T) readBigIntegerLE(INT64_SIZE, true);
                 case Int128:
-                    return (T) readBigIntegerLE(input, INT128_SIZE, false);
+                    return (T) readBigIntegerLE(INT128_SIZE, false);
                 case UInt128:
-                    return (T) readBigIntegerLE(input, INT128_SIZE, true);
+                    return (T) readBigIntegerLE(INT128_SIZE, true);
                 case Int256:
-                    return (T) readBigIntegerLE(input, INT256_SIZE, false);
+                    return (T) readBigIntegerLE(INT256_SIZE, false);
                 case UInt256:
-                    return (T) readBigIntegerLE(input, INT256_SIZE, true);
+                    return (T) readBigIntegerLE(INT256_SIZE, true);
                 case Decimal:
-                    return (T) readDecimal(input, column.getPrecision(), column.getScale());
+                    return (T) readDecimal(column.getPrecision(), column.getScale());
                 case Decimal32:
-                    return (T) readDecimal(input, ClickHouseDataType.Decimal32.getMaxPrecision(), column.getScale());
+                    return (T) readDecimal(ClickHouseDataType.Decimal32.getMaxPrecision(), column.getScale());
                 case Decimal64:
-                    return (T) readDecimal(input, ClickHouseDataType.Decimal64.getMaxPrecision(), column.getScale());
+                    return (T) readDecimal(ClickHouseDataType.Decimal64.getMaxPrecision(), column.getScale());
                 case Decimal128:
-                    return (T) readDecimal(input, ClickHouseDataType.Decimal128.getMaxPrecision(), column.getScale());
+                    return (T) readDecimal(ClickHouseDataType.Decimal128.getMaxPrecision(), column.getScale());
                 case Decimal256:
-                    return (T) readDecimal(input, ClickHouseDataType.Decimal256.getMaxPrecision(), column.getScale());
+                    return (T) readDecimal(ClickHouseDataType.Decimal256.getMaxPrecision(), column.getScale());
                 case Float32:
-                    return (T) Float.valueOf(readFloatLE(input));
+                    return (T) Float.valueOf(readFloatLE());
                 case Float64:
-                    return (T) Double.valueOf(readDoubleLE(input));
+                    return (T) Double.valueOf(readDoubleLE());
                 case Bool:
                     return (T) Boolean.valueOf(readByteOrEOF(input) == 1);
                 case Enum8:
-                    return (T) Byte.valueOf((byte) readUnsignedByte(input));
+                    return (T) Byte.valueOf((byte) readUnsignedByte());
                 case Enum16:
-                    return (T) Short.valueOf((short) readUnsignedShortLE(input));
+                    return (T) Short.valueOf((short) readUnsignedShortLE());
                 case Date:
-                    return (T) readDate(input, column.getTimeZone() == null ? timeZone :
-                            column.getTimeZone());
+                    return convertDateTime(readDate(column.getTimeZone() == null ? timeZone :
+                            column.getTimeZone()), typeHint);
                 case Date32:
-                    return (T) readDate32(input, column.getTimeZone() == null ? timeZone :
-                            column.getTimeZone());
+                    return convertDateTime(readDate32(column.getTimeZone() == null ? timeZone :
+                            column.getTimeZone()), typeHint);
                 case DateTime:
-                    return (T) readDateTime32(input, column.getTimeZone() == null ? timeZone :
-                            column.getTimeZone());
+                    return convertDateTime(readDateTime32(column.getTimeZone() == null ? timeZone :
+                            column.getTimeZone()), typeHint);
                 case DateTime32:
-                    return (T) readDateTime32(input, column.getTimeZone() == null ? timeZone :
-                            column.getTimeZone());
+                    return convertDateTime(readDateTime32(column.getTimeZone() == null ? timeZone :
+                            column.getTimeZone()), typeHint);
                 case DateTime64:
-                    return (T) readDateTime64(input, 3, column.getTimeZone() == null ? timeZone :
-                            column.getTimeZone());
+                    return convertDateTime(readDateTime64(3, column.getTimeZone() == null ? timeZone :
+                            column.getTimeZone()), typeHint);
 
                 case IntervalYear:
                 case IntervalQuarter:
@@ -165,7 +183,7 @@ public class BinaryStreamReader {
                 case IntervalMicrosecond:
                 case IntervalMillisecond:
                 case IntervalNanosecond:
-                    return (T) readBigIntegerLE(input, 8, true);
+                    return (T) readBigIntegerLE(8, true);
                 case IPv4:
                     // https://clickhouse.com/docs/en/sql-reference/data-types/ipv4
                     return (T) Inet4Address.getByAddress(readNBytesLE(input, 4));
@@ -173,20 +191,20 @@ public class BinaryStreamReader {
                     // https://clickhouse.com/docs/en/sql-reference/data-types/ipv6
                     return (T) Inet6Address.getByAddress(readNBytes(input, 16));
                 case UUID:
-                    return (T) new UUID(readLongLE(input), readLongLE(input));
+                    return (T) new UUID(readLongLE(), readLongLE());
                 case Point:
-                    return (T) readGeoPoint(input);
+                    return (T) readGeoPoint();
                 case Polygon:
-                    return (T) readGeoPolygon(input);
+                    return (T) readGeoPolygon();
                 case MultiPolygon:
-                    return (T) readGeoMultiPolygon(input);
+                    return (T) readGeoMultiPolygon();
                 case Ring:
-                    return (T) readGeoRing(input);
+                    return (T) readGeoRing();
 
 //                case JSON: // obsolete https://clickhouse.com/docs/en/sql-reference/data-types/json#displaying-json-column
 //                case Object:
                 case Array:
-                    return (T) readArray(column);
+                    return convertArray(readArray(column), typeHint);
                 case Map:
                     return (T) readMap(column);
 //                case Nested:
@@ -206,7 +224,37 @@ public class BinaryStreamReader {
         }
     }
 
-    private short readShortLE(InputStream input) throws IOException {
+    private static <T> T convertDateTime(ZonedDateTime value, Class<?> typeHint) {
+        if (typeHint == null) {
+            return (T) value;
+        }
+        if (typeHint.isAssignableFrom(LocalDateTime.class)) {
+            return (T) value.toLocalDateTime();
+        } else if (typeHint.isAssignableFrom(LocalDate.class)) {
+            return (T) value.toLocalDate();
+        }
+
+        return (T) value;
+    }
+
+    private static <T> T convertArray(ArrayValue value, Class<?> typeHint) {
+        if (typeHint == null) {
+            return (T) value;
+        }
+        if (typeHint.isAssignableFrom(List.class)) {
+            return (T) value.asList();
+        }
+
+        return (T) value;
+    }
+
+    /**
+     * Read a short value in little-endian from the internal input stream.
+     *
+     * @return short value
+     * @throws IOException when IO error occurs
+     */
+    public short readShortLE() throws IOException {
         return readShortLE(input, bufferAllocator.allocate(INT16_SIZE));
     }
 
@@ -216,14 +264,19 @@ public class BinaryStreamReader {
      * @param input - source of bytes
      * @param buff  - buffer to store data
      * @return short value
-     * @throws IOException
+     * @throws IOException when IO error occurs
      */
     public static short readShortLE(InputStream input, byte[] buff) throws IOException {
         readNBytes(input, buff, 0, 2);
         return (short) (buff[0] & 0xFF | (buff[1] & 0xFF) << 8);
     }
 
-    private int readIntLE(InputStream input) throws IOException {
+    /**
+     * Reads an int value in little-endian from the internal input stream.
+     * @return int value
+     * @throws IOException when IO error occurs
+     */
+    public int readIntLE() throws IOException {
         return readIntLE(input, bufferAllocator.allocate(INT32_SIZE));
     }
 
@@ -233,14 +286,20 @@ public class BinaryStreamReader {
      * @param input - source of bytes
      * @param buff  - buffer to store data
      * @return - int value
-     * @throws IOException
+     * @throws IOException when IO error occurs
      */
     public static int readIntLE(InputStream input, byte[] buff) throws IOException {
         readNBytes(input, buff, 0, 4);
         return (buff[0] & 0xFF) | (buff[1] & 0xFF) << 8 | (buff[2] & 0xFF) << 16 | (buff[3] & 0xFF) << 24;
     }
 
-    private long readLongLE(InputStream input) throws IOException {
+    /**
+     * Reads a long value in little-endian from the internal input stream.
+     *
+     * @return long value
+     * @throws IOException when IO error occurs
+     */
+    public long readLongLE() throws IOException {
         return readLongLE(input, bufferAllocator.allocate(INT64_SIZE));
     }
 
@@ -250,7 +309,7 @@ public class BinaryStreamReader {
      * @param input - source of bytes
      * @param buff  - buffer to store data
      * @return - long value
-     * @throws IOException
+     * @throws IOException when IO error occurs
      */
     public static long readLongLE(InputStream input, byte[] buff) throws IOException {
         readNBytes(input, buff, 0, 8);
@@ -259,11 +318,30 @@ public class BinaryStreamReader {
                 | (long) (buff[6] & 0xFF) << 48 | (long) (buff[7] & 0xFF) << 56;
     }
 
-    public short readUnsignedByte(InputStream input) throws IOException {
+    /**
+     * Read byte from the internal input stream.
+     * @return byte value
+     * @throws IOException when IO error occurs
+     */
+    public byte readByte() throws IOException {
+        return (byte) readByteOrEOF(input);
+    }
+
+    /**
+     * Reads an unsigned byte value from the internal input stream.
+     * @return unsigned byte value
+     * @throws IOException when IO error occurs
+     */
+    public short readUnsignedByte() throws IOException {
         return (short) (readByteOrEOF(input) & 0xFF);
     }
 
-    private int readUnsignedShortLE(InputStream input) throws IOException {
+    /**
+     * Reads an unsigned short value from the internal input stream.
+     * @return unsigned short value
+     * @throws IOException when IO error occurs
+     */
+    public int readUnsignedShortLE() throws IOException {
         return readUnsignedShortLE(input, bufferAllocator.allocate(INT16_SIZE));
     }
 
@@ -279,8 +357,14 @@ public class BinaryStreamReader {
         return readShortLE(input, buff) & 0xFFFF;
     }
 
-    private long readUnsignedIntLE(InputStream input) throws IOException {
-        return readIntLE(input) & 0xFFFFFFFFL;
+    /**
+     * Reads an unsigned int value in little-endian from the internal input stream.
+     *
+     * @return unsigned int value
+     * @throws IOException when IO error occurs
+     */
+    public long readUnsignedIntLE() throws IOException {
+        return readIntLE() & 0xFFFFFFFFL;
     }
 
     /**
@@ -288,14 +372,21 @@ public class BinaryStreamReader {
      *
      * @param input - source of bytes
      * @param buff - buffer to store data
-     * @return
-     * @throws IOException
+     * @return - unsigned int value
+     * @throws IOException when IO error occurs
      */
     public static long readUnsignedIntLE(InputStream input, byte[] buff) throws IOException {
         return readIntLE(input, buff) & 0xFFFFFFFFL;
     }
 
-    private BigInteger readBigIntegerLE(InputStream input, int len, boolean unsigned) throws IOException {
+    /**
+     * Reads a big integer value in little-endian from the internal input stream.
+     * @param len - number of bytes to read
+     * @param unsigned - whether the value is unsigned
+     * @return big integer value
+     * @throws IOException when IO error occurs
+     */
+    public BigInteger readBigIntegerLE(int len, boolean unsigned) throws IOException {
         return readBigIntegerLE(input, bufferAllocator.allocate(len), len, unsigned);
     }
 
@@ -323,25 +414,43 @@ public class BinaryStreamReader {
         return unsigned ? new BigInteger(1, bytes) : new BigInteger(bytes);
     }
 
-    public float readFloatLE(InputStream input) throws IOException {
-        return Float.intBitsToFloat(readIntLE(input));
+
+    /**
+     * Reads a decimal value from the internal input stream.
+     * @return decimal value
+     * @throws IOException when IO error occurs
+     */
+    public float readFloatLE() throws IOException {
+        return Float.intBitsToFloat(readIntLE());
     }
 
-    public double readDoubleLE(InputStream input) throws IOException {
-        return Double.longBitsToDouble(readLongLE(input));
+    /**
+     * Reads a double value from the internal input stream.
+     * @return double value
+     * @throws IOException when IO error occurs
+     */
+    public double readDoubleLE() throws IOException {
+        return Double.longBitsToDouble(readLongLE());
     }
 
-    private BigDecimal readDecimal(InputStream input, int precision, int scale) throws IOException {
+    /**
+     * Reads a decimal value from the internal input stream.
+     * @param precision - precision of the decimal value
+     * @param scale - scale of the decimal value
+     * @return decimal value
+     * @throws IOException when IO error occurs
+     */
+    public BigDecimal readDecimal(int precision, int scale) throws IOException {
         BigDecimal v;
 
         if (precision <= ClickHouseDataType.Decimal32.getMaxScale()) {
-            return BigDecimal.valueOf(readIntLE(input), scale);
+            return BigDecimal.valueOf(readIntLE(), scale);
         } else if (precision <= ClickHouseDataType.Decimal64.getMaxScale()) {
-            v = BigDecimal.valueOf(readLongLE(input), scale);
+            v = BigDecimal.valueOf(readLongLE(), scale);
         } else if (precision <= ClickHouseDataType.Decimal128.getMaxScale()) {
-            v = new BigDecimal(readBigIntegerLE(input, INT128_SIZE, false), scale);
+            v = new BigDecimal(readBigIntegerLE(INT128_SIZE, false), scale);
         } else {
-            v = new BigDecimal(readBigIntegerLE(input, INT256_SIZE, false), scale);
+            v = new BigDecimal(readBigIntegerLE(INT256_SIZE, false), scale);
         }
 
         return v;
@@ -403,8 +512,13 @@ public class BinaryStreamReader {
         return bytes;
     }
 
-
-    private ArrayValue readArray(ClickHouseColumn column) throws IOException {
+    /**
+     * Reads a array into an ArrayValue object.
+     * @param column - column information
+     * @return array value
+     * @throws IOException when IO error occurs
+     */
+    public ArrayValue readArray(ClickHouseColumn column) throws IOException {
         Class<?> itemType = column.getArrayBaseColumn().getDataType().getWiderPrimitiveClass();
         int len = readVarInt(input);
         ArrayValue array = new ArrayValue(column.getArrayNestedLevel() > 1 ? ArrayValue.class : itemType, len);
@@ -414,10 +528,14 @@ public class BinaryStreamReader {
         }
 
         for (int i = 0; i < len; i++) {
-            array.set(i, readValueImpl(column.getNestedColumns().get(0)));
+            array.set(i, readValue(column.getNestedColumns().get(0)));
         }
 
         return array;
+    }
+
+    public void skipValue(ClickHouseColumn column) throws IOException {
+        readValue(column, null);
     }
 
     public static class ArrayValue {
@@ -479,7 +597,13 @@ public class BinaryStreamReader {
         }
     }
 
-    private Map<?, ?> readMap(ClickHouseColumn column) throws IOException {
+    /**
+     * Reads a map.
+     * @param column - column information
+     * @return a map
+     * @throws IOException when IO error occurs
+     */
+    public Map<?, ?> readMap(ClickHouseColumn column) throws IOException {
         int len = readVarInt(input);
         if (len == 0) {
             return Collections.emptyMap();
@@ -489,51 +613,77 @@ public class BinaryStreamReader {
         ClickHouseColumn valueType = column.getValueInfo();
         LinkedHashMap<Object, Object> map = new LinkedHashMap<>(len);
         for (int i = 0; i < len; i++) {
-            Object key = readValueImpl(keyType);
-            Object value = readValueImpl(valueType);
+            Object key = readValue(keyType);
+            Object value = readValue(valueType);
             map.put(key, value);
         }
         return map;
     }
 
-    private Object[] readTuple(ClickHouseColumn column) throws IOException {
+    /**
+     * Reads a tuple.
+     * @param column - column information
+     * @return a tuple
+     * @throws IOException when IO error occurs
+     */
+    public Object[] readTuple(ClickHouseColumn column) throws IOException {
         int len = column.getNestedColumns().size();
         Object[] tuple = new Object[len];
         for (int i = 0; i < len; i++) {
-            tuple[i] = readValueImpl(column.getNestedColumns().get(i));
+            tuple[i] = readValue(column.getNestedColumns().get(i));
         }
 
         return tuple;
     }
 
-    private double[] readGeoPoint(InputStream input) throws IOException {
-        return new double[]{readDoubleLE(input), readDoubleLE(input)};
+    /**
+     * Reads a GEO point as an array of two doubles what represents coordinates (X, Y).
+     * @return X, Y coordinates
+     * @throws IOException when IO error occurs
+     */
+    public double[] readGeoPoint() throws IOException {
+        return new double[]{readDoubleLE(), readDoubleLE()};
     }
 
-    private double[][] readGeoRing(InputStream input) throws IOException {
+    /**
+     * Reads a GEO ring as an array of points.
+     * @return array of points
+     * @throws IOException when IO error occurs
+     */
+    public double[][] readGeoRing() throws IOException {
         int count = readVarInt(input);
         double[][] value = new double[count][2];
         for (int i = 0; i < count; i++) {
-            value[i] = readGeoPoint(input);
+            value[i] = readGeoPoint();
         }
         return value;
     }
 
 
-    private double[][][] readGeoPolygon(InputStream input) throws IOException {
+    /**
+     * Reads a GEO polygon as an array of rings.
+     * @return polygon
+     * @throws IOException when IO error occurs
+     */
+    public double[][][] readGeoPolygon() throws IOException {
         int count = readVarInt(input);
         double[][][] value = new double[count][][];
         for (int i = 0; i < count; i++) {
-            value[i] = readGeoRing(input);
+            value[i] = readGeoRing();
         }
         return value;
     }
 
-    private double[][][][] readGeoMultiPolygon(InputStream input) throws IOException {
+    /**
+     * Reads a GEO multipolygon as an array of polygons.
+     * @return multipolygon
+     * @throws IOException when IO error occurs
+     */
+    private double[][][][] readGeoMultiPolygon() throws IOException {
         int count = readVarInt(input);
         double[][][][] value = new double[count][][][];
         for (int i = 0; i < count; i++) {
-            value[i] = readGeoPolygon(input);
+            value[i] = readGeoPolygon();
         }
         return value;
     }
@@ -560,7 +710,13 @@ public class BinaryStreamReader {
         return value;
     }
 
-    private ZonedDateTime readDate(InputStream input, TimeZone tz) throws IOException {
+    /**
+     * Reads a Date value from internal input stream.
+     * @param tz - timezone
+     * @return ZonedDateTime
+     * @throws IOException when IO error occurs
+     */
+    private ZonedDateTime readDate(TimeZone tz) throws IOException {
         return readDate(input, bufferAllocator.allocate(INT16_SIZE), tz);
     }
 
@@ -569,15 +725,21 @@ public class BinaryStreamReader {
      * @param input - source of bytes
      * @param buff - for reading short value. Should be 2 bytes.
      * @param tz - timezone
-     * @return
-     * @throws IOException
+     * @return ZonedDateTime
+     * @throws IOException when IO error occurs
      */
     public static ZonedDateTime readDate(InputStream input, byte[] buff, TimeZone tz) throws IOException {
         LocalDate d = LocalDate.ofEpochDay(readUnsignedShortLE(input, buff));
         return d.atStartOfDay(tz.toZoneId()).withZoneSameInstant(tz.toZoneId());
     }
 
-    private ZonedDateTime readDate32(InputStream input, TimeZone tz)
+    /**
+     * Reads a Date32 value from internal input stream.
+     * @param tz - timezone
+     * @return ZonedDateTime
+     * @throws IOException when IO error occurs
+     */
+    public ZonedDateTime readDate32(TimeZone tz)
             throws IOException {
         return readDate32(input, bufferAllocator.allocate(INT32_SIZE), tz);
     }
@@ -588,8 +750,8 @@ public class BinaryStreamReader {
      * @param input - source of bytes
      * @param buff - for reading int value. Should be 4 bytes.
      * @param tz - timezone
-     * @return
-     * @throws IOException
+     * @return ZonedDateTime
+     * @throws IOException when IO error occurs
      */
     public static ZonedDateTime readDate32(InputStream input, byte[] buff, TimeZone tz)
             throws IOException {
@@ -597,7 +759,7 @@ public class BinaryStreamReader {
         return d.atStartOfDay(tz.toZoneId()).withZoneSameInstant(tz.toZoneId());
     }
 
-    private ZonedDateTime readDateTime32(InputStream input, TimeZone tz) throws IOException {
+    private ZonedDateTime readDateTime32(TimeZone tz) throws IOException {
         return readDateTime32(input, bufferAllocator.allocate(INT32_SIZE), tz);
     }
 
@@ -607,17 +769,28 @@ public class BinaryStreamReader {
      * @param buff - for reading int value. Should be 4 bytes.
      * @param tz - timezone
      * @return ZonedDateTime
-     * @throws IOException
+     * @throws IOException when IO error occurs
      */
     public static ZonedDateTime readDateTime32(InputStream input, byte[] buff, TimeZone tz) throws IOException {
         long time = readUnsignedIntLE(input, buff);
         return LocalDateTime.ofInstant(Instant.ofEpochSecond(Math.max(time, 0L)), tz.toZoneId()).atZone(tz.toZoneId());
     }
 
-    private ZonedDateTime readDateTime64(InputStream input, int scale, TimeZone tz) throws IOException {
+    /**
+     * Reads a datetime64 from internal input stream.
+     * @param scale - scale of the datetime64
+     * @param tz - timezone
+     * @return ZonedDateTime
+     * @throws IOException when IO error occurs
+     */
+    public ZonedDateTime readDateTime64(int scale, TimeZone tz) throws IOException {
         return readDateTime64(input, bufferAllocator.allocate(INT64_SIZE), scale, tz);
     }
 
+
+    /**
+     * Bases for datetime64.
+     */
     public static final int[] BASES = new int[]{1, 10, 100, 1000, 10000, 100000, 1000000, 10000000, 100000000,
             1000000000};
 
@@ -651,6 +824,12 @@ public class BinaryStreamReader {
                 .atZone(tz.toZoneId());
     }
 
+    /**
+     * Reads a decimal value from input stream.
+     * @param input - source of bytes
+     * @return String
+     * @throws IOException when IO error occurs
+     */
     public static String readString(InputStream input) throws IOException {
         int len = readVarInt(input);
         if (len == 0) {
@@ -659,7 +838,7 @@ public class BinaryStreamReader {
         return new String(readNBytes(input, len), StandardCharsets.UTF_8);
     }
 
-    private static int readByteOrEOF(InputStream input) throws IOException {
+    public static int readByteOrEOF(InputStream input) throws IOException {
         int b = input.read();
         if (b < 0) {
             throw new EOFException("End of stream reached before reading all data");
@@ -681,6 +860,25 @@ public class BinaryStreamReader {
         }
     }
 
+    public static boolean isReadToPrimitive(ClickHouseDataType dataType) {
+        switch (dataType) {
+            case Int8:
+            case UInt8:
+            case Int16:
+            case UInt16:
+            case Int32:
+            case UInt32:
+            case Int64:
+            case Float32:
+            case Float64:
+            case Bool:
+            case Enum8:
+            case Enum16:
+                return true;
+            default:
+                return false;
+        }
+    }
     /**
      * Byte allocator that caches preallocated byte arrays for small sizes.
      */

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/SerializerUtils.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/SerializerUtils.java
@@ -81,9 +81,18 @@ public class SerializerUtils {
     private static void serializeTupleData(OutputStream stream, Object value, ClickHouseColumn column) throws IOException {
         //Serialize the tuple to the stream
         //The tuple is a list of values
-        List<?> values = (List<?>) value;
-        for (int i = 0; i < values.size(); i++) {
-            serializeData(stream, values.get(i), column.getNestedColumns().get(i));
+        if (value instanceof List) {
+            List<?> values = (List<?>) value;
+            for (int i = 0; i < values.size(); i++) {
+                serializeData(stream, values.get(i), column.getNestedColumns().get(i));
+            }
+        } else if (value instanceof Object[]) {
+            Object[] values = (Object[]) value;
+            for (int i = 0; i < values.length; i++) {
+                serializeData(stream, values[i], column.getNestedColumns().get(i));
+            }
+        } else {
+            throw new IllegalArgumentException("Cannot serialize " + value + " as a tuple");
         }
     }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/POJOSetter.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/POJOSetter.java
@@ -1,6 +1,9 @@
 package com.clickhouse.client.api.query;
 
 
+import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
+import com.clickhouse.data.ClickHouseColumn;
+
 /**
  * Class used to set value for individual fields in a POJO.
  * Implementation will have reference to a specific POJO property.
@@ -9,37 +12,5 @@ package com.clickhouse.client.api.query;
  */
 public interface POJOSetter {
 
-    default void setValue(Object obj, boolean value) {
-        throw new UnsupportedOperationException("Unsupported type: boolean");
-    };
-
-    default  void setValue(Object obj, byte value) {
-        throw new UnsupportedOperationException("Unsupported type: byte");
-    };
-
-    default void setValue(Object obj, char value) {
-        throw new UnsupportedOperationException("Unsupported type: char");
-    };
-
-    default void setValue(Object obj, short value) {
-        throw new UnsupportedOperationException("Unsupported type: short");
-    };
-
-    default void setValue(Object obj, int value) {
-        throw new UnsupportedOperationException("Unsupported type: int");
-    };
-
-    default void setValue(Object obj, long value) {
-        throw new UnsupportedOperationException("Unsupported type: long");
-    };
-
-    default void setValue(Object obj, float value) {
-        throw new UnsupportedOperationException("Unsupported type: float");
-    };
-
-    default void setValue(Object obj, double value) {
-        throw new UnsupportedOperationException("Unsupported type: double");
-    };
-
-    void setValue(Object obj, Object value);
+    void setValue(Object obj, BinaryStreamReader reader, ClickHouseColumn column) throws Exception;
 }

--- a/client-v2/src/test/java/com/clickhouse/client/internal/SerializerUtilsTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/internal/SerializerUtilsTests.java
@@ -1,62 +1,28 @@
 package com.clickhouse.client.internal;
 
-import com.clickhouse.client.api.internal.SerializerUtils;
+import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
 import com.clickhouse.client.api.query.POJOSetter;
-import com.clickhouse.client.query.SamplePOJO;
+import com.clickhouse.client.query.QuerySamplePOJO;
+import com.clickhouse.client.query.SimplePOJO;
 import com.clickhouse.data.ClickHouseColumn;
-import org.testng.Assert;
-import org.testng.annotations.Test;
 
-import java.lang.reflect.Method;
-import java.math.BigInteger;
+import java.io.IOException;
 import java.time.LocalDateTime;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.stream.Collectors;
+import java.time.ZonedDateTime;
 
 public class SerializerUtilsTests {
 
-    @Test(enabled = false)
-    public void testDeserialize() throws Exception {
-
-        Map<String, POJOSetter> pojoSetterList = new HashMap<>();
-        for (Method method : SamplePOJOForSerialization.class.getDeclaredMethods()) {
-            if (method.getName().startsWith("set")) {
-                pojoSetterList.put(method.getName().substring(3).toLowerCase(),
-                        SerializerUtils.compilePOJOSetter(method, ClickHouseColumn.of(method.getName(),
-                                "String")));
-            }
-        }
-
-        SamplePOJOForSerialization pojo = new SamplePOJOForSerialization();
-        pojoSetterList.get("string").setValue(pojo, "John Doe");
-        pojoSetterList.get("int32").setValue(pojo, Integer.valueOf(30));
-        pojoSetterList.get("int16").setValue(pojo, 22);
-
-        Assert.assertEquals(pojo.getString(), "John Doe");
-        Assert.assertEquals(pojo.getInt32(), 30);
-        Assert.assertEquals(pojo.getInt16(), 22);
-    }
 
     public static class SamplePOJOInt256Setter implements POJOSetter {
 
-
-
-
-        /*
-          public void setValue(java.lang.Object, java.lang.Object);
-            Code:
-               0: aload_1
-               1: checkcast     #7                  // class com/clickhouse/client/query/SamplePOJO
-               4: aload_2
-               5: checkcast     #25                 // class java/math/BigInteger
-               8: invokevirtual #27                 // Method com/clickhouse/client/query/SamplePOJO.setInt256:(Ljava/math/BigInteger;)V
-              11: return
-         */
         @Override
-        public void setValue(Object obj, Object value) {
-            Arrays.stream(((Object[]) value)).collect(Collectors.toList());
+        public void setValue(Object obj, BinaryStreamReader reader, ClickHouseColumn column) throws IOException {
+            ((QuerySamplePOJO)obj).setDateTime(((ZonedDateTime)reader.readValue(column)).toLocalDateTime());
+        }
+
+        public void readValue(Object obj, BinaryStreamReader reader, ClickHouseColumn column) throws IOException {
+//            ((SamplePOJO)obj).setDateTime(((ZonedDateTime)reader.readValue(column)).toLocalDateTime());
+            ((SimplePOJO)obj).setId(reader.readIntLE());
         }
     }
 }

--- a/client-v2/src/test/java/com/clickhouse/client/query/QuerySamplePOJO.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QuerySamplePOJO.java
@@ -18,7 +18,7 @@ import java.util.Objects;
 import java.util.Random;
 import java.util.UUID;
 
-public class SamplePOJO {
+public class QuerySamplePOJO {
     private int int8;
     private int int8_default;
     private int int16;
@@ -35,7 +35,7 @@ public class SamplePOJO {
     private int uint8;
     private int uint16;
     private long uint32;
-    private long uint64;
+    private BigInteger uint64;
     private BigInteger uint128;
     private BigInteger uint256;
 
@@ -67,12 +67,12 @@ public class SamplePOJO {
     private Inet6Address ipv6;
 
     private List<String> array;
-    private List<Integer> tuple;
+//    private List<?> tuple;
     private Map<String, Integer> map;
     private List<Integer> nestedInnerInt;
     private List<String> nestedInnerString;
 
-    public SamplePOJO() {
+    public QuerySamplePOJO() {
         final Random random = new Random();
         int8 = random.nextInt(128);
         int16 = random.nextInt(32768);
@@ -90,11 +90,16 @@ public class SamplePOJO {
 
         int256 = upper1.or(upper2).or(lower1).or(lower2);
 
+
         uint8 = random.nextInt(255);
         uint16 = random.nextInt(32768);
         uint32 = (long) (random.nextDouble() * 4294967295L);
-        uint64 = (long) (random.nextDouble() * 18446744073709615L);
 
+        long rndUInt64 = random.nextLong();
+        uint64 = BigInteger.valueOf(rndUInt64);
+        if (rndUInt64 < 0) {
+            uint64 = uint64.add(BigInteger.ONE.shiftLeft(64));
+        }
 
         uint128 = upper.or(lower).abs();
         uint256 = upper1.or(upper2).or(lower1).or(lower2).abs();
@@ -137,7 +142,7 @@ public class SamplePOJO {
         }
 
         array = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z");
-        tuple = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+//        tuple = Arrays.asList(new Object[]{random.nextInt(), random.nextDouble(), "a", "b" });
         map = new HashMap<>();
         for (int i = 0; i < 10; i++) {
             map.put(String.valueOf((char) ('a' + i)), i + 1);
@@ -248,11 +253,11 @@ public class SamplePOJO {
         this.uint32 = uint32;
     }
 
-    public long getUint64() {
+    public BigInteger getUint64() {
         return uint64;
     }
 
-    public void setUint64(long uint64) {
+    public void setUint64(BigInteger uint64) {
         this.uint64 = uint64;
     }
 
@@ -424,13 +429,13 @@ public class SamplePOJO {
         this.array = array;
     }
 
-    public List<Integer> getTuple() {
-        return tuple;
-    }
+//    public List<?> getTuple() {
+//        return tuple;
+//    }
 
-    public void setTuple(List<Integer> tuple) {
-        this.tuple = tuple;
-    }
+//    public void setTuple(List<?> tuple) {
+//        this.tuple = tuple;
+//    }
 
     public Map<String, Integer> getMap() {
         return map;
@@ -460,18 +465,18 @@ public class SamplePOJO {
     public boolean equals(Object o) {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        SamplePOJO that = (SamplePOJO) o;
-        return int8 == that.int8 && int16 == that.int16 && int32 == that.int32 && int64 == that.int64 && uint8 == that.uint8 && uint16 == that.uint16 && uint32 == that.uint32 && uint64 == that.uint64 && Float.compare(float32, that.float32) == 0 && Double.compare(float64, that.float64) == 0 && bool == that.bool && enum8 == that.enum8 && enum16 == that.enum16 && Objects.equals(int128, that.int128) && Objects.equals(int256, that.int256) && Objects.equals(uint128, that.uint128) && Objects.equals(uint256, that.uint256) && Objects.equals(decimal32, that.decimal32) && Objects.equals(decimal64, that.decimal64) && Objects.equals(decimal128, that.decimal128) && Objects.equals(decimal256, that.decimal256) && Objects.equals(string, that.string) && Objects.equals(fixedString, that.fixedString) && Objects.equals(date, that.date) && Objects.equals(date32, that.date32) && Objects.equals(dateTime, that.dateTime) && Objects.equals(dateTime64, that.dateTime64) && Objects.equals(uuid, that.uuid) && Objects.equals(ipv4, that.ipv4) && Objects.equals(ipv6, that.ipv6) && Objects.equals(array, that.array) && Objects.equals(tuple, that.tuple) && Objects.equals(map, that.map) && Objects.equals(nestedInnerInt, that.nestedInnerInt) && Objects.equals(nestedInnerString, that.nestedInnerString);
+        QuerySamplePOJO that = (QuerySamplePOJO) o;
+        return int8 == that.int8 && int8_default == that.int8_default && int16 == that.int16 && int16_default == that.int16_default && int32 == that.int32 && int32_default == that.int32_default && int64 == that.int64 && int64_default == that.int64_default && uint8 == that.uint8 && uint16 == that.uint16 && uint32 == that.uint32 && Float.compare(float32, that.float32) == 0 && Double.compare(float64, that.float64) == 0 && bool == that.bool && enum8 == that.enum8 && enum16 == that.enum16 && Objects.equals(int128, that.int128) && Objects.equals(int128_default, that.int128_default) && Objects.equals(int256, that.int256) && Objects.equals(int256_default, that.int256_default) && Objects.equals(uint64, that.uint64) && Objects.equals(uint128, that.uint128) && Objects.equals(uint256, that.uint256) && Objects.equals(decimal32, that.decimal32) && Objects.equals(decimal64, that.decimal64) && Objects.equals(decimal128, that.decimal128) && Objects.equals(decimal256, that.decimal256) && Objects.equals(string, that.string) && Objects.equals(fixedString, that.fixedString) && Objects.equals(date, that.date) && Objects.equals(date32, that.date32) && Objects.equals(dateTime, that.dateTime) && Objects.equals(dateTime64, that.dateTime64) && Objects.equals(uuid, that.uuid) && Objects.equals(ipv4, that.ipv4) && Objects.equals(ipv6, that.ipv6) && Objects.equals(array, that.array) && Objects.equals(map, that.map) && Objects.equals(nestedInnerInt, that.nestedInnerInt) && Objects.equals(nestedInnerString, that.nestedInnerString);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(int8, int16, int32, int64, int128, int256, uint8, uint16, uint32, uint64, uint128, uint256, float32, float64, decimal32, decimal64, decimal128, decimal256, bool, string, fixedString, date, date32, dateTime, dateTime64, uuid, enum8, enum16, ipv4, ipv6, array, tuple, map, nestedInnerInt, nestedInnerString);
+        return Objects.hash(int8, int8_default, int16, int16_default, int32, int32_default, int64, int64_default, int128, int128_default, int256, int256_default, uint8, uint16, uint32, uint64, uint128, uint256, float32, float64, decimal32, decimal64, decimal128, decimal256, bool, string, fixedString, date, date32, dateTime, dateTime64, uuid, enum8, enum16, ipv4, ipv6, array, map, nestedInnerInt, nestedInnerString);
     }
 
     @Override
     public String toString() {
-        return "SamplePOJO{" +
+        return "QuerySamplePOJO{" +
                 "int8=" + int8 +
                 ", int8_default=" + int8_default +
                 ", int16=" + int16 +
@@ -509,7 +514,6 @@ public class SamplePOJO {
                 ", ipv4=" + ipv4 +
                 ", ipv6=" + ipv6 +
                 ", array=" + array +
-                ", tuple=" + tuple +
                 ", map=" + map +
                 ", nestedInnerInt=" + nestedInnerInt +
                 ", nestedInnerString=" + nestedInnerString +
@@ -555,7 +559,7 @@ public class SamplePOJO {
                 "ipv4 IPv4, " +
                 "ipv6 IPv6, " +
                 "array Array(String), " +
-                "tuple Tuple(Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32), " +
+//                "tuple Tuple(Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32), " +
                 "map Map(String, Int32), " +
                 "nested Nested (innerInt Int32, innerString String)" +
                 ") ENGINE = Memory";

--- a/client-v2/src/test/java/com/clickhouse/client/query/QuerySamplePOJO.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QuerySamplePOJO.java
@@ -68,6 +68,9 @@ public class QuerySamplePOJO {
 
     private List<String> array;
     private List<?> tuple;
+
+    private Object[] tupleArray;
+
     private Map<String, Integer> map;
     private List<Integer> nestedInnerInt;
     private List<String> nestedInnerString;
@@ -143,6 +146,7 @@ public class QuerySamplePOJO {
 
         array = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z");
         tuple = Arrays.asList(random.nextInt(), random.nextDouble(), "a", "b");
+        tupleArray = new Object[] {random.nextInt(), random.nextDouble(), "c", "d" };
         map = new HashMap<>();
         for (int i = 0; i < 10; i++) {
             map.put(String.valueOf((char) ('a' + i)), i + 1);
@@ -437,6 +441,14 @@ public class QuerySamplePOJO {
         this.tuple = tuple;
     }
 
+    public Object[] getTupleArray() {
+        return tupleArray;
+    }
+
+    public void setTupleArray(Object[] tupleArray) {
+        this.tupleArray = tupleArray;
+    }
+
     public Map<String, Integer> getMap() {
         return map;
     }
@@ -560,6 +572,7 @@ public class QuerySamplePOJO {
                 "ipv6 IPv6, " +
                 "array Array(String), " +
                 "tuple Tuple(Int32, Float64, String, String), " +
+                "tupleArray Tuple(Int32, Float64, String, String), " +
                 "map Map(String, Int32), " +
                 "nested Nested (innerInt Int32, innerString String)" +
                 ") ENGINE = Memory";

--- a/client-v2/src/test/java/com/clickhouse/client/query/QuerySamplePOJO.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QuerySamplePOJO.java
@@ -67,7 +67,7 @@ public class QuerySamplePOJO {
     private Inet6Address ipv6;
 
     private List<String> array;
-//    private List<?> tuple;
+    private List<?> tuple;
     private Map<String, Integer> map;
     private List<Integer> nestedInnerInt;
     private List<String> nestedInnerString;
@@ -142,7 +142,7 @@ public class QuerySamplePOJO {
         }
 
         array = Arrays.asList("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z");
-//        tuple = Arrays.asList(new Object[]{random.nextInt(), random.nextDouble(), "a", "b" });
+        tuple = Arrays.asList(random.nextInt(), random.nextDouble(), "a", "b");
         map = new HashMap<>();
         for (int i = 0; i < 10; i++) {
             map.put(String.valueOf((char) ('a' + i)), i + 1);
@@ -429,13 +429,13 @@ public class QuerySamplePOJO {
         this.array = array;
     }
 
-//    public List<?> getTuple() {
-//        return tuple;
-//    }
+    public List<?> getTuple() {
+        return tuple;
+    }
 
-//    public void setTuple(List<?> tuple) {
-//        this.tuple = tuple;
-//    }
+    public void setTuple(List<?> tuple) {
+        this.tuple = tuple;
+    }
 
     public Map<String, Integer> getMap() {
         return map;
@@ -559,7 +559,7 @@ public class QuerySamplePOJO {
                 "ipv4 IPv4, " +
                 "ipv6 IPv6, " +
                 "array Array(String), " +
-//                "tuple Tuple(Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32, Int32), " +
+                "tuple Tuple(Int32, Float64, String, String), " +
                 "map Map(String, Int32), " +
                 "nested Nested (innerInt Int32, innerString String)" +
                 ") ENGINE = Memory";

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -31,7 +31,6 @@ import com.clickhouse.data.ClickHouseFormat;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import org.testcontainers.shaded.com.google.common.collect.Table;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
@@ -47,7 +46,6 @@ import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.math.BigDecimal;
 import java.math.BigInteger;
-import java.math.RoundingMode;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.InetAddress;
@@ -90,6 +88,10 @@ public class QueryTests extends BaseIntegrationTest {
     private boolean useHttpCompression = false;
 
     private boolean usePreallocatedBuffers = false;
+
+    static {
+//        System.setProperty("org.slf4j.simpleLogger.defaultLogLevel", "DEBUG");
+    }
 
     QueryTests(){
     }
@@ -1473,7 +1475,6 @@ public class QueryTests extends BaseIntegrationTest {
                 " FROM system.numbers LIMIT " + limit;
         TableSchema schema = client.getTableSchemaFromQuery(sql, "q1");
         client.register(SimplePOJO.class, schema);
-
         List<SimplePOJO> pojos = client.queryAll(sql, SimplePOJO.class);
         Assert.assertEquals(pojos.size(), limit);
     }
@@ -1497,12 +1498,12 @@ public class QueryTests extends BaseIntegrationTest {
     public void testQueryAllWithPOJO() throws Exception {
 
         final String tableName = "test_query_all_with_pojo";
-        final String createTableSQL = SamplePOJO.generateTableCreateSQL(tableName);
+        final String createTableSQL = QuerySamplePOJO.generateTableCreateSQL(tableName);
         client.execute("DROP TABLE IF EXISTS test_query_all_with_pojo").get();
         client.execute(createTableSQL).get();
 
-        SamplePOJO pojo = new SamplePOJO();
-        client.register(SamplePOJO.class, client.getTableSchema(tableName));
+        QuerySamplePOJO pojo = new QuerySamplePOJO();
+        client.register(QuerySamplePOJO.class, client.getTableSchema(tableName));
 
         client.insert(tableName, Collections.singletonList(pojo)).get();
 
@@ -1516,7 +1517,7 @@ public class QueryTests extends BaseIntegrationTest {
         pojo.setDateTime(pojo.getDateTime().minusNanos(pojo.getDateTime().getNano()));
         pojo.setDateTime64(pojo.getDateTime64().withNano((int) Math.ceil((pojo.getDateTime64().getNano() / 1000_000) * 1000_000)));
 
-        List<SamplePOJO> pojos = client.queryAll("SELECT * FROM " + tableName + " LIMIT 1", SamplePOJO.class);
+        List<QuerySamplePOJO> pojos = client.queryAll("SELECT * FROM " + tableName + " LIMIT 1", QuerySamplePOJO.class);
         Assert.assertEquals(pojos.get(0), pojo, "Expected " + pojo + " but got " + pojos.get(0));
     }
 


### PR DESCRIPTION
## Summary
Current implementation reads all values into objects even it can be done using primitive types. It was done to simplify code, but it may be not good for memory consumption.
Current PR:
- adds methods to read values into primitives 
- updates POJO deserialization code to use these new methods

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
