### PR TITLE
[jdbc] Restores jdbc-all.jar  content

### DIFF
--- a/clickhouse-jdbc/pom.xml
+++ b/clickhouse-jdbc/pom.xml
@@ -52,6 +52,16 @@
 <!--        </dependency>-->
         <dependency>
             <groupId>${project.parent.groupId}</groupId>
+            <artifactId>clickhouse-client</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>clickhouse-data</artifactId>
+            <version>${revision}</version>
+        </dependency>
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
             <artifactId>clickhouse-http-client</artifactId>
             <version>${revision}</version>
             <optional>true</optional>
@@ -401,11 +411,11 @@
                                 <includes>
                                     <include>com.clickhouse:clickhouse-data</include>
                                     <include>com.clickhouse:clickhouse-client</include>
-                                    <include>com.clickhouse:clickhouse-cli-client</include>
+<!--                                    <include>com.clickhouse:clickhouse-cli-client</include>-->
                                     <include>com.clickhouse:clickhouse-http-client</include>
                                     <include>org.apache.httpcomponents.client5:httpclient5</include>
                                     <include>org.apache.httpcomponents.core5:httpcore5</include>
-                                    <include>org.apache.httpcomponents.core5:httpcore5-h2</include>
+<!--                                    <include>org.apache.httpcomponents.core5:httpcore5-h2</include>-->
                                     <include>org.lz4:lz4-pure-java</include>
                                 </includes>
                             </artifactSet>
@@ -461,6 +471,7 @@
                             <artifactSet>
                                 <includes>
                                     <include>com.clickhouse:clickhouse-data</include>
+                                    <include>com.clickhouse:clickhouse-client</include>
 <!-- CLI Client Deprecation                                   <include>com.clickhouse:clickhouse-client</include>-->
 <!-- CLI Client Deprecation                                   <include>com.clickhouse:clickhouse-cli-client</include>-->
 <!-- GRPC Client. Deprecation.                                   <include>com.clickhouse:clickhouse-grpc-client</include>-->
@@ -485,6 +496,7 @@
 <!-- GRPC Client. Deprecation.                                   <include>io.opencensus:opencensus-contrib-grpc-metrics</include>-->
                                     <include>io.perfmark:perfmark-api</include>
                                     <include>org.apache.commons:commons-compress</include>
+                                    <include>com.clickhouse:clickhouse-http-client</include>
                                     <include>org.apache.httpcomponents.client5:httpclient5</include>
                                     <include>org.apache.httpcomponents.core5:httpcore5</include>
                                     <include>org.apache.httpcomponents.core5:httpcore5-h2</include>

--- a/examples/demo-kotlin-service/build.gradle.kts
+++ b/examples/demo-kotlin-service/build.gradle.kts
@@ -33,7 +33,7 @@ dependencies {
     implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
 
     // https://mvnrepository.com/artifact/com.clickhouse/client-v2
-    implementation("com.clickhouse:client-v2:0.6.4-SNAPSHOT")
+    implementation("com.clickhouse:client-v2:0.6.5-SNAPSHOT")
 
     // http client used by clickhouse client
     implementation("org.apache.httpcomponents.client5:httpclient5:5.3.1")


### PR DESCRIPTION
## Summary
Dependencies to `clickhouse-data` and `clickhouse-client` project were broken while removing dependencies for grpc and cli client from JDBC artifact. 
Current PR restores required dependencies. Previously `all` artifact had different dependencies than `shaded`. 

Closes https://github.com/ClickHouse/clickhouse-java/issues/1823

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
