### PR TITLE
[client-v2] Fixes handling empty results while using reader

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
@@ -54,6 +54,9 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
 
     private volatile boolean hasNext = true;
 
+
+    private volatile boolean initialState = true; // reader is in initial state, no records have been read yet
+
     protected AbstractBinaryFormatReader(InputStream inputStream, QuerySettings querySettings, TableSchema schema,
                                          BinaryStreamReader.ByteBufferAllocator byteBufferAllocator) {
         this.input = inputStream;
@@ -148,11 +151,16 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
 
     @Override
     public boolean hasNext() {
+        if (initialState) {
+            readNextRecord();
+        }
+
         return hasNext;
     }
 
 
     protected void readNextRecord() {
+        initialState = false;
         try {
             nextRecordEmpty.set(true);
             if (!readRecord(nextRecord)) {
@@ -195,6 +203,7 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
     }
 
     protected void endReached() {
+        initialState = false;
         hasNext = false;
     }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/Records.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/Records.java
@@ -55,10 +55,12 @@ public class Records implements Iterable<GenericRecord>, AutoCloseable {
 
     /**
      * Returns {@code true} if this collection contains no elements.
+     * Prefer this method over {@link #getResultRows()} == 0 because current method reflect actual state of the collection
+     * while {@link #getResultRows()} is send from server before sending actual data.
      *
      * @return {@code true} if this collection contains no elements
      */
-    boolean isEmpty() {
+    public boolean isEmpty() {
         return empty;
     }
 


### PR DESCRIPTION
## Summary
BinaryFormatReader implementation is stateful and hold current record to be accessible before calling `next()`. Data is provided as stream and because of this reason handling `hasNext()` is complex because reader should read data upfront without affect current own position to avoid skipping records. 
This PR fixes detecting if no data is present in data stream. 

**Note**

There are two cases of empty result:
- `SELECT 1 LIMIT 0` - has no result data but has column name and type
- `CREATE TABLE test` - has nothing at all, so readers that expect schema before data should also handle it correctly. 



Closes https://github.com/ClickHouse/clickhouse-java/issues/1788
## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
