### PR TITLE
[client-v2] Make new transport layer implementation as default

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -206,7 +206,7 @@ public class Client implements AutoCloseable {
 
         // Read-only configuration
         private Map<String, String> configuration;
-        private boolean useNewImplementation = false;
+        private boolean useNewImplementation = true;
 
         private ExecutorService sharedOperationExecutor = null;
 
@@ -581,8 +581,8 @@ public class Client implements AutoCloseable {
         }
 
         /**
-         * Switches to new implementation of the client.
-         * @deprecated - do not use - it is only for development
+         * Switches to new implementation of the client. Default is true.
+         * @deprecated
          */
         public Builder useNewImplementation(boolean useNewImplementation) {
             this.useNewImplementation = useNewImplementation;
@@ -599,7 +599,6 @@ public class Client implements AutoCloseable {
         /**
          * Defines path to the trust store file. It cannot be combined with
          * certificates. Either trust store or certificates should be used.
-         *
          * {@see setSSLTrustStorePassword} and {@see setSSLTrustStoreType}
          * @param path
          * @return


### PR DESCRIPTION
## Summary
Client-v2 uses two transport implementations: initially it was based on previous version of the client, then new implementation was done. This PR make it as default so no configuration should be set to use it.

