### PR TITLE
[client-v2] remove info log for end of stream

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -221,7 +221,6 @@ public class BinaryStreamReader {
                     throw new IllegalArgumentException("Unsupported data type: " + column.getDataType());
             }
         } catch (EOFException e) {
-            log.info("End of stream reached before reading all data for column " + column.getColumnName());
             throw e;
         } catch (Exception e) {
             throw new ClientException("Failed to read value for column " + column.getColumnName(), e);


### PR DESCRIPTION
## Summary
Removed logging of end of stream - because too confusing and verbose.

