### PR TITLE
[client-v2] Nullable nested column

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -1068,9 +1068,13 @@ public class Client implements AutoCloseable {
                             }
                         }
                     } else {
-                        // If column is nullable && the object is also null add the not null marker
-                        if (column.isNullable() && value != null) {
+                        if (column.isNullable()) {
+                            // If column is nullable && the object is also null add the not null marker
                             BinaryStreamUtils.writeNonNull(stream);
+                            if (value == null) {
+                                BinaryStreamUtils.writeNull(stream);
+                                return;
+                            }
                         }
                         if (!column.isNullable() && value == null) {
                             if (column.getDataType() == ClickHouseDataType.Array)

--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -1069,18 +1069,17 @@ public class Client implements AutoCloseable {
                         }
                     } else {
                         if (column.isNullable()) {
-                            // If column is nullable && the object is also null add the not null marker
-                            BinaryStreamUtils.writeNonNull(stream);
                             if (value == null) {
                                 BinaryStreamUtils.writeNull(stream);
                                 return;
                             }
-                        }
-                        if (!column.isNullable() && value == null) {
-                            if (column.getDataType() == ClickHouseDataType.Array)
+                            BinaryStreamUtils.writeNonNull(stream);
+                        } else if (value == null) {
+                            if (column.getDataType() == ClickHouseDataType.Array) {
                                 BinaryStreamUtils.writeNonNull(stream);
-                            else
+                            } else {
                                 throw new IllegalArgumentException(String.format("An attempt to write null into not nullable column '%s'", column.getColumnName()));
+                            }
                         }
                     }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -3,7 +3,6 @@ package com.clickhouse.client.api.data_formats.internal;
 import com.clickhouse.client.api.ClientException;
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseDataType;
-import com.clickhouse.data.format.BinaryStreamUtils;
 import com.clickhouse.data.value.ClickHouseBitmap;
 import org.slf4j.Logger;
 import org.slf4j.helpers.NOPLogger;
@@ -22,13 +21,14 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.UUID;
+
+import static com.clickhouse.data.ClickHouseDataType.toObjectType;
 
 /**
  * This class is not thread safe and should not be shared between multiple threads.
@@ -523,6 +523,9 @@ public class BinaryStreamReader {
      */
     public ArrayValue readArray(ClickHouseColumn column) throws IOException {
         Class<?> itemType = column.getArrayBaseColumn().getDataType().getWiderPrimitiveClass();
+        if (column.getArrayBaseColumn().isNullable()) {
+            itemType = toObjectType(itemType);
+        }
         int len = readVarInt(input);
         ArrayValue array = new ArrayValue(column.getArrayNestedLevel() > 1 ? ArrayValue.class : itemType, len);
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/SerializerUtils.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/SerializerUtils.java
@@ -30,7 +30,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.UUID;

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/SerializerUtils.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/SerializerUtils.java
@@ -74,11 +74,14 @@ public class SerializerUtils {
         List<?> values = (List<?>) value;
         BinaryStreamUtils.writeVarInt(stream, values.size());
         for (Object val : values) {
-            if (column.getArrayBaseColumn().isNullable() && val == null) {
-                BinaryStreamUtils.writeNull(stream);
-            } else {
-                serializeData(stream, val, column.getArrayBaseColumn());
+            if (column.getArrayBaseColumn().isNullable()) {
+                if (val == null) {
+                    BinaryStreamUtils.writeNull(stream);
+                    continue;
+                }
+                BinaryStreamUtils.writeNonNull(stream);
             }
+            serializeData(stream, val, column.getArrayBaseColumn());
         }
     }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/SerializerUtils.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/SerializerUtils.java
@@ -30,6 +30,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.UUID;
@@ -74,7 +75,11 @@ public class SerializerUtils {
         List<?> values = (List<?>) value;
         BinaryStreamUtils.writeVarInt(stream, values.size());
         for (Object val : values) {
-            serializeData(stream, val, column.getArrayBaseColumn());
+            if (column.getArrayBaseColumn().isNullable() && val == null) {
+                BinaryStreamUtils.writeNull(stream);
+            } else {
+                serializeData(stream, val, column.getArrayBaseColumn());
+            }
         }
     }
 

--- a/client-v2/src/test/java/com/clickhouse/client/insert/SamplePOJO.java
+++ b/client-v2/src/test/java/com/clickhouse/client/insert/SamplePOJO.java
@@ -80,6 +80,7 @@ public class SamplePOJO {
     private Map<String, Integer> map;
     private List<Integer> nestedInnerInt;
     private List<String> nestedInnerString;
+    private List<Integer> nestedInnerNullableInt;
 
     private ClickHouseBitmap groupBitmapUint32;
     private ClickHouseBitmap groupBitmapUint64;
@@ -169,6 +170,10 @@ public class SamplePOJO {
         List<String> innerString = new ArrayList<>();
         innerString.add(RandomStringUtils.randomAlphabetic(1, 256));
         nestedInnerString = innerString;
+
+        List<Integer> innerNullableInt = new ArrayList<>();
+        innerNullableInt.add(null);
+        nestedInnerNullableInt = innerNullableInt;
 
         groupBitmapUint32 = ClickHouseBitmap.wrap(random.ints(5, Integer.MAX_VALUE - 100, Integer.MAX_VALUE).toArray());
         groupBitmapUint64 = ClickHouseBitmap.wrap(random.longs(5, Long.MAX_VALUE - 100, Long.MAX_VALUE).toArray());
@@ -542,6 +547,14 @@ public class SamplePOJO {
         this.nestedInnerString = nestedInnerString;
     }
 
+    public List<Integer> getNestedInnerNullableInt() {
+        return nestedInnerNullableInt;
+    }
+
+    public void setNestedInnerNullableInt(List<Integer> nestedInnerNullableInt) {
+        this.nestedInnerNullableInt = nestedInnerNullableInt;
+    }
+
     public ClickHouseBitmap getGroupBitmapUint32() {
         return groupBitmapUint32;
     }
@@ -664,7 +677,7 @@ public class SamplePOJO {
                 "array Array(String), " +
                 "tuple Tuple(UInt64, Int32, String), " +
                 "map Map(String, Int32), " +
-                "nested Nested (innerInt Int32, innerString String), " +
+                "nested Nested (innerInt Int32, innerString String, innerNullableInt Nullable(Int32))" +
 //                "groupBitmapUint32 AggregateFunction(groupBitmap, UInt32)," +
                 // TODO: fix this
 //                "groupBitmapUint64 AggregateFunction(groupBitmap, UInt64)" +

--- a/client-v2/src/test/java/com/clickhouse/client/insert/SamplePOJO.java
+++ b/client-v2/src/test/java/com/clickhouse/client/insert/SamplePOJO.java
@@ -173,6 +173,7 @@ public class SamplePOJO {
 
         List<Integer> innerNullableInt = new ArrayList<>();
         innerNullableInt.add(null);
+        innerNullableInt.add(random.nextInt(Integer.MAX_VALUE));
         nestedInnerNullableInt = innerNullableInt;
 
         groupBitmapUint32 = ClickHouseBitmap.wrap(random.ints(5, Integer.MAX_VALUE - 100, Integer.MAX_VALUE).toArray());

--- a/client-v2/src/test/java/com/clickhouse/client/insert/SamplePOJO.java
+++ b/client-v2/src/test/java/com/clickhouse/client/insert/SamplePOJO.java
@@ -165,9 +165,11 @@ public class SamplePOJO {
 
         List<Integer> innerInt = new ArrayList<>();
         innerInt.add(random.nextInt(Integer.MAX_VALUE));
+        innerInt.add(random.nextInt(Integer.MAX_VALUE));
         nestedInnerInt = innerInt;
 
         List<String> innerString = new ArrayList<>();
+        innerString.add(RandomStringUtils.randomAlphabetic(1, 256));
         innerString.add(RandomStringUtils.randomAlphabetic(1, 256));
         nestedInnerString = innerString;
 


### PR DESCRIPTION
## Summary
When using the client-v2 with nullable nested columns, client-v2 was unable to insert them as it was treating the inner items as non nullable. Have not tested it but I guess that the same thing was happening for Array(Nullable(column_type)).

These changes aim to check whether array base column is nullable and if the item in the array is also null, serialize null.

Closes: https://github.com/ClickHouse/clickhouse-java/issues/1858

## Checklist
Delete items not relevant to your PR:
- [x ] Unit and integration tests covering the common scenarios were added