### PR TITLE
[client-v2] Make compression dependencies as required

### DIFF
--- a/clickhouse-http-client/pom.xml
+++ b/clickhouse-http-client/pom.xml
@@ -40,19 +40,14 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents.core5</groupId>
-                    <artifactId>httpcore5</artifactId>
-                </exclusion>
-            </exclusions>
-            <optional>true</optional>
+            <version>${apache.httpclient.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents.core5</groupId>
             <artifactId>httpcore5</artifactId>
-            <optional>true</optional>
+            <version>${apache.httpclient.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.brotli</groupId>
             <artifactId>dec</artifactId>

--- a/clickhouse-jdbc/pom.xml
+++ b/clickhouse-jdbc/pom.xml
@@ -47,26 +47,7 @@
             <artifactId>commons-compress</artifactId>
             <optional>true</optional>
         </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents.client5</groupId>
-            <artifactId>httpclient5</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.httpcomponents.core5</groupId>
-                    <artifactId>httpcore5</artifactId>
-                </exclusion>
-                <exclusion>
-                    <groupId>org.slf4j</groupId>
-                    <artifactId>slf4j-api</artifactId>
-                </exclusion>
-            </exclusions>
-            <optional>true</optional>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents.core5</groupId>
-            <artifactId>httpcore5</artifactId>
-            <optional>true</optional>
-        </dependency>
+
         <dependency>
             <groupId>org.lz4</groupId>
             <artifactId>lz4-pure-java</artifactId>
@@ -145,7 +126,7 @@
         <dependency>
             <groupId>com.clickhouse</groupId>
             <artifactId>clickhouse-http-client</artifactId>
-            <version>0.7.0-SNAPSHOT</version>
+            <version>${revision}</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/client-v2/pom.xml
+++ b/client-v2/pom.xml
@@ -16,6 +16,10 @@
     <description>New client api for ClickHouse</description>
     <url>https://github.com/ClickHouse/clickhouse-java/tree/main/clickhouse-client-api</url>
 
+    <properties>
+        <apache.httpclient.version>5.3.1</apache.httpclient.version>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.parent.groupId}</groupId>
@@ -26,6 +30,7 @@
             <groupId>${project.parent.groupId}</groupId>
             <artifactId>clickhouse-http-client</artifactId>
             <version>${revision}</version>
+            <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -35,7 +40,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents.client5</groupId>
             <artifactId>httpclient5</artifactId>
-            <version>5.3.1</version>
+            <version>${apache.httpclient.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.luben</groupId>
@@ -45,20 +50,23 @@
         <dependency>
             <groupId>org.lz4</groupId>
             <artifactId>lz4-pure-java</artifactId>
-            <optional>true</optional>
+            <version>${lz4.version}</version>
         </dependency>
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>org.apache.commons.compress</artifactId>
-            <version>${repackaged.version}</version>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-compress</artifactId>
+            <version>${compress.version}</version>
         </dependency>
-        <!-- https://mvnrepository.com/artifact/com.fasterxml.jackson.core/jackson-core -->
+        <dependency>
+            <groupId>org.ow2.asm</groupId>
+            <artifactId>asm</artifactId>
+            <version>9.7</version>
+        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>2.17.2</version>
         </dependency>
-
         <!-- Test Dependencies -->
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -73,25 +81,12 @@
             <scope>test</scope>
             <version>2.17.2</version>
         </dependency>
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <optional>true</optional>
-        </dependency>
         <!-- necessary for Java 9+ -->
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>annotations-api</artifactId>
             <scope>provided</scope>
         </dependency>
-
-        <!-- https://mvnrepository.com/artifact/org.ow2.asm/asm -->
-        <dependency>
-            <groupId>org.ow2.asm</groupId>
-            <artifactId>asm</artifactId>
-            <version>9.7</version>
-        </dependency>
-
 
         <!-- Test dependencies -->
         <dependency>

--- a/examples/client-v2/pom.xml
+++ b/examples/client-v2/pom.xml
@@ -65,7 +65,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
         <clickhouse-java.version>0.7.0-SNAPSHOT</clickhouse-java.version>
-        <apache-httpclient.version>5.2.1</apache-httpclient.version>
+        <apache-httpclient.version>5.3.1</apache-httpclient.version>
 
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
 
@@ -78,32 +78,14 @@
             <artifactId>client-v2</artifactId>
             <version>${clickhouse-java.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.clickhouse</groupId>
-            <artifactId>clickhouse-http-client</artifactId>
-            <version>${clickhouse-java.version}</version>
-        </dependency>
 
-        <!-- Recommended to communicate with ClickHouse server over http -->
-        <dependency>
-            <groupId>org.apache.httpcomponents.client5</groupId>
-            <artifactId>httpclient5</artifactId>
-            <version>${apache-httpclient.version}</version>
-        </dependency>
+        <!-- If Old implementation needed -->
+<!--        <dependency>-->
+<!--            <groupId>com.clickhouse</groupId>-->
+<!--            <artifactId>clickhouse-http-client</artifactId>-->
+<!--            <version>${clickhouse-java.version}</version>-->
+<!--        </dependency>-->
 
-        <!-- Support of the compression -->
-        <!-- https://mvnrepository.com/artifact/org.apache.commons/commons-compress -->
-        <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-compress</artifactId>
-            <version>1.26.2</version>
-        </dependency>
-        <!-- https://mvnrepository.com/artifact/org.lz4/lz4-java -->
-        <dependency>
-            <groupId>org.lz4</groupId>
-            <artifactId>lz4-java</artifactId>
-            <version>1.8.0</version>
-        </dependency>
 
         <!-- Recommended for JSON parsing -->
         <dependency>

--- a/examples/demo-kotlin-service/build.gradle.kts
+++ b/examples/demo-kotlin-service/build.gradle.kts
@@ -35,14 +35,6 @@ dependencies {
     // https://mvnrepository.com/artifact/com.clickhouse/client-v2
     implementation("com.clickhouse:client-v2:0.7.0-SNAPSHOT")
 
-    // http client used by clickhouse client
-    implementation("org.apache.httpcomponents.client5:httpclient5:5.3.1")
-    // compression dependencies
-    runtimeOnly("org.apache.commons:commons-compress:1.26.2")
-    runtimeOnly("org.lz4:lz4-pure-java:1.8.0")
-
-
-
     testImplementation("io.ktor:ktor-server-test-host-jvm")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
 }

--- a/examples/demo-service/build.gradle.kts
+++ b/examples/demo-service/build.gradle.kts
@@ -30,16 +30,10 @@ dependencies {
 	// -- clickhouse dependencies
 	// Main dependency
 	implementation("com.clickhouse:client-v2:0.7.0-SNAPSHOT") // nightly build
-//	implementation("com.clickhouse:client-v2:0.6.5") // stable version
-	// http client used by clickhouse client
-	implementation("org.apache.httpcomponents.client5:httpclient5:5.3.1")
-	// compression dependencies
-	runtimeOnly("org.apache.commons:commons-compress:1.26.2")
-	runtimeOnly("org.lz4:lz4-pure-java:1.8.0")
-	// client V1 if old implementation is needed
-//	implementation("com.clickhouse:clickhouse-http-client:0.6.5")
+//	implementation("com.clickhouse:client-v2:0.7.0") // stable version
 
-
+	// -- clickhouse-http-client dependencies if old implementation is needed
+//	implementation("com.clickhouse:clickhouse-http-client:0.7.0-SNAPSHOT")
 
 	// -- application dependencies
 	implementation("org.springframework.boot:spring-boot-starter-actuator")

--- a/examples/demo-service/src/main/java/com/clickhouse/demo_service/DbConfiguration.java
+++ b/examples/demo-service/src/main/java/com/clickhouse/demo_service/DbConfiguration.java
@@ -2,7 +2,6 @@ package com.clickhouse.demo_service;
 
 
 import com.clickhouse.client.api.Client;
-import com.clickhouse.client.http.config.ClickHouseHttpOption;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <brotli.version>0.1.2</brotli.version>
         <brotli4j.version>1.12.0</brotli4j.version>
         <caffeine.version>3.1.7</caffeine.version>
-        <compress.version>1.26.1</compress.version>
+        <compress.version>1.27.1</compress.version>
         <dnsjava.version>3.6.0</dnsjava.version>
         <fastutil.version>8.5.12</fastutil.version>
         <gson.version>2.10.1</gson.version>
@@ -331,22 +331,6 @@
                 <artifactId>testng</artifactId>
                 <version>${testng.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents.client5</groupId>
-                <artifactId>httpclient5</artifactId>
-                <version>${apache.httpclient.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents.core5</groupId>
-                <artifactId>httpcore5</artifactId>
-                <version>${apache.httpclient.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.httpcomponents.core5</groupId>
-                <artifactId>httpcore5-h2</artifactId>
-                <version>${apache.httpclient.version}</version>
-            </dependency>
-
             <dependency>
                 <groupId>org.mariadb.jdbc</groupId>
                 <artifactId>mariadb-java-client</artifactId>


### PR DESCRIPTION
## Summary
Client uses compression by default, but related library dependencies are optional. It causes confusion because users have to add extra dependencies while library cannot work without it without adjustments. 
This PR fixes:
- compression dependencies are required.
- apache http client dependencies are cleaned  up 
- updated in examples 

Currently dependencies look like: 
```
productionRuntimeClasspath
+--- com.clickhouse:client-v2:0.7.0-SNAPSHOT
|    +--- com.clickhouse:clickhouse-client:0.7.0-SNAPSHOT
|    +--- com.clickhouse:clickhouse-data:0.7.0-SNAPSHOT
|    +--- org.slf4j:slf4j-api:2.0.7 -> 2.0.13
|    +--- org.apache.httpcomponents.client5:httpclient5:5.3.1
|    +--- org.lz4:lz4-pure-java:1.8.0
|    +--- org.apache.commons:commons-compress:1.27.1
|    +--- commons-codec:commons-codec:1.17.1 -> 1.16.1
|    +--- commons-io:commons-io:2.16.1
|    +--- org.apache.commons:commons-lang3:3.16.0 -> 3.14.0
|    +--- org.ow2.asm:asm:9.7
|    \--- com.fasterxml.jackson.core:jackson-core:2.17.2
```

Closes: https://github.com/ClickHouse/clickhouse-java/issues/1805
Closes: https://github.com/ClickHouse/clickhouse-java/issues/1853

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
