### PR TITLE
[client-v2] Added session roles for client and operations

### DIFF
--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpProto.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpProto.java
@@ -51,4 +51,5 @@ public class ClickHouseHttpProto {
      */
     public static final String QPARAM_QUERY_ID = "query_id";
 
+    public static final String QPARAM_ROLE = "role";
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -1617,10 +1617,10 @@ public class Client implements AutoCloseable {
      * @param sqlQuery - SQL query
      * @return - complete list of records
      */
-    public List<GenericRecord> queryAll(String sqlQuery) {
+    public List<GenericRecord> queryAll(String sqlQuery, QuerySettings settings) {
         try {
             int operationTimeout = getOperationTimeout();
-            QuerySettings settings = new QuerySettings().setFormat(ClickHouseFormat.RowBinaryWithNamesAndTypes)
+            settings.setFormat(ClickHouseFormat.RowBinaryWithNamesAndTypes)
                     .waitEndOfQuery(true);
             try (QueryResponse response = operationTimeout == 0 ? query(sqlQuery, settings).get() :
                     query(sqlQuery, settings).get(operationTimeout, TimeUnit.MILLISECONDS)) {
@@ -1641,6 +1641,10 @@ public class Client implements AutoCloseable {
         } catch (Exception e) {
             throw new ClientException("Failed to get query response", e);
         }
+    }
+
+    public List<GenericRecord> queryAll(String sqlQuery) {
+        return queryAll(sqlQuery, new QuerySettings());
     }
 
     public <T> List<T> queryAll(String sqlQuery, Class<T> clazz, TableSchema schema) {
@@ -1891,6 +1895,28 @@ public class Client implements AutoCloseable {
         return Collections.unmodifiableSet(endpoints);
     }
 
+    /**
+     * Sets list of DB roles that should be applied to each query.
+     *
+     * @param dbRoles
+     */
+    public void setDBRoles(Collection<String> dbRoles) {
+        this.configuration.put(ClientSettings.SESSION_DB_ROLES, ClientSettings.commaSeparated(dbRoles));
+        this.unmodifiableDbRolesView =
+                Collections.unmodifiableCollection(ClientSettings.valuesFromCommaSeparated(
+                        this.configuration.get(ClientSettings.SESSION_DB_ROLES)));
+    }
+
+    private Collection<String> unmodifiableDbRolesView = Collections.emptyList();
+
+    /**
+     * Returns list of DB roles that should be applied to each query.
+     *
+     * @return List of DB roles
+     */
+    public Collection<String> getDBRoles() {
+        return unmodifiableDbRolesView;
+    }
 
     private ClickHouseNode getNextAliveNode() {
         return serverNodes.get(0);

--- a/client-v2/src/main/java/com/clickhouse/client/api/ClientSettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/ClientSettings.java
@@ -2,6 +2,7 @@ package com.clickhouse.client.api;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -18,14 +19,20 @@ public class ClientSettings {
     public static String commaSeparated(Collection<?> values) {
         StringBuilder sb = new StringBuilder();
         for (Object value : values) {
-            sb.append(value.toString().replaceAll(",", "\\,")).append(",");
+            sb.append(value.toString().replaceAll(",", "\\\\,")).append(",");
         }
         sb.setLength(sb.length() - 1);
         return sb.toString();
     }
 
     public static List<String> valuesFromCommaSeparated(String value) {
-        return Arrays.stream(value.split(",")).map(s -> s.replaceAll("\\\\,", ","))
+        if (value == null || value.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        return Arrays.stream(value.split("(?<!\\\\),")).map(s -> s.replaceAll("\\\\,", ","))
                 .collect(Collectors.toList());
     }
+
+    public static final String SESSION_DB_ROLES = "session_db_roles";
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/command/CommandResponse.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/command/CommandResponse.java
@@ -5,7 +5,7 @@ import com.clickhouse.client.api.metrics.OperationMetrics;
 import com.clickhouse.client.api.metrics.ServerMetrics;
 import com.clickhouse.client.api.query.QueryResponse;
 
-public class CommandResponse{
+public class CommandResponse implements AutoCloseable {
 
     private final QueryResponse response;
 
@@ -70,5 +70,10 @@ public class CommandResponse{
      */
     public long getServerTime() {
         return response.getServerTime();
+    }
+
+    @Override
+    public void close() throws Exception {
+        response.close();
     }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/MapBackedRecord.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/MapBackedRecord.java
@@ -241,8 +241,7 @@ public class MapBackedRecord implements GenericRecord {
 
     @Override
     public <T> List<T> getList(String colName) {
-        ClickHouseArrayValue<?> array = readValue(colName);
-        return null;
+        return getList(schema.nameToIndex(colName));
     }
 
 
@@ -387,7 +386,12 @@ public class MapBackedRecord implements GenericRecord {
 
     @Override
     public <T> List<T> getList(int index) {
-        return readValue(index);
+        Object value = readValue(index);
+        if (value instanceof BinaryStreamReader.ArrayValue) {
+            return ((BinaryStreamReader.ArrayValue) value).asList();
+        } else {
+            throw new ClientException("Column is not of array type");
+        }
     }
 
     @Override

--- a/client-v2/src/main/java/com/clickhouse/client/api/insert/InsertSettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/insert/InsertSettings.java
@@ -205,4 +205,23 @@ public class InsertSettings {
         rawSettings.put(ClientSettings.SERVER_SETTING_PREFIX + name, ClientSettings.commaSeparated(values));
         return this;
     }
+
+    /**
+     * Sets DB roles for an operation. Roles that were set by {@link Client#setDBRoles(Collection)} will be overridden.
+     *
+     * @param dbRoles
+     */
+    public InsertSettings setDBRoles(Collection<String> dbRoles) {
+        rawSettings.put(ClientSettings.SESSION_DB_ROLES, dbRoles);
+        return this;
+    }
+
+    /**
+     * Gets DB roles for an operation.
+     *
+     * @return list of DB roles
+     */
+    public Collection<String> getDBRoles() {
+        return (Collection<String>) rawSettings.get(ClientSettings.SESSION_DB_ROLES);
+    }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
@@ -70,6 +70,8 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.NoSuchAlgorithmException;
 import java.util.Base64;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Map;
@@ -425,6 +427,9 @@ public class HttpAPIClientHelper {
         }
     }
     private void addQueryParams(URIBuilder req, Map<String, String> chConfig, Map<String, Object> requestConfig) {
+        if (requestConfig == null) {
+            requestConfig = Collections.emptyMap();
+        }
 
         for (Map.Entry<String, String> entry : chConfig.entrySet()) {
             if (entry.getKey().startsWith(ClientSettings.SERVER_SETTING_PREFIX)) {
@@ -432,19 +437,17 @@ public class HttpAPIClientHelper {
             }
         }
 
-        if (requestConfig != null) {
-            if (requestConfig.containsKey(ClickHouseHttpOption.WAIT_END_OF_QUERY.getKey())) {
-                req.addParameter(ClickHouseHttpOption.WAIT_END_OF_QUERY.getKey(),
-                        requestConfig.get(ClickHouseHttpOption.WAIT_END_OF_QUERY.getKey()).toString());
-            }
-            if (requestConfig.containsKey(ClickHouseClientOption.QUERY_ID.getKey())) {
-                req.addParameter(ClickHouseHttpProto.QPARAM_QUERY_ID, requestConfig.get(ClickHouseClientOption.QUERY_ID.getKey()).toString());
-            }
-            if (requestConfig.containsKey("statement_params")) {
-                Map<String, Object> params = (Map<String, Object>) requestConfig.get("statement_params");
-                for (Map.Entry<String, Object> entry : params.entrySet()) {
-                    req.addParameter("param_" + entry.getKey(), String.valueOf(entry.getValue()));
-                }
+        if (requestConfig.containsKey(ClickHouseHttpOption.WAIT_END_OF_QUERY.getKey())) {
+            req.addParameter(ClickHouseHttpOption.WAIT_END_OF_QUERY.getKey(),
+                    requestConfig.get(ClickHouseHttpOption.WAIT_END_OF_QUERY.getKey()).toString());
+        }
+        if (requestConfig.containsKey(ClickHouseClientOption.QUERY_ID.getKey())) {
+            req.addParameter(ClickHouseHttpProto.QPARAM_QUERY_ID, requestConfig.get(ClickHouseClientOption.QUERY_ID.getKey()).toString());
+        }
+        if (requestConfig.containsKey("statement_params")) {
+            Map<String, Object> params = (Map<String, Object>) requestConfig.get("statement_params");
+            for (Map.Entry<String, Object> entry : params.entrySet()) {
+                req.addParameter("param_" + entry.getKey(), String.valueOf(entry.getValue()));
             }
         }
 
@@ -467,11 +470,16 @@ public class HttpAPIClientHelper {
             }
         }
 
-        if (requestConfig != null) {
-            for (Map.Entry<String, Object> entry : requestConfig.entrySet()) {
-                if (entry.getKey().startsWith(ClientSettings.SERVER_SETTING_PREFIX)) {
-                    req.addParameter(entry.getKey().substring(ClientSettings.SERVER_SETTING_PREFIX.length()), entry.getValue().toString());
-                }
+        Collection<String> sessionRoles = (Collection<String>) requestConfig.getOrDefault(ClientSettings.SESSION_DB_ROLES,
+                ClientSettings.valuesFromCommaSeparated(chConfiguration.getOrDefault(ClientSettings.SESSION_DB_ROLES, "")));
+        if (!sessionRoles.isEmpty()) {
+
+            sessionRoles.forEach(r -> req.addParameter(ClickHouseHttpProto.QPARAM_ROLE, r));
+        }
+
+        for (Map.Entry<String, Object> entry : requestConfig.entrySet()) {
+            if (entry.getKey().startsWith(ClientSettings.SERVER_SETTING_PREFIX)) {
+                req.addParameter(entry.getKey().substring(ClientSettings.SERVER_SETTING_PREFIX.length()), entry.getValue().toString());
             }
         }
     }

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
@@ -221,4 +221,23 @@ public class QuerySettings {
         rawSettings.put(ClientSettings.SERVER_SETTING_PREFIX + name, ClientSettings.commaSeparated(values));
         return this;
     }
+
+    /**
+     * Sets DB roles for an operation. Roles that were set by {@link Client#setDBRoles(Collection)} will be overridden.
+     *
+     * @param dbRoles
+     */
+    public QuerySettings setDBRoles(Collection<String> dbRoles) {
+        rawSettings.put(ClientSettings.SESSION_DB_ROLES, dbRoles);
+        return this;
+    }
+
+    /**
+     * Gets DB roles for an operation.
+     *
+     * @return list of DB roles
+     */
+    public Collection<String> getDBRoles() {
+        return (Collection<String>) rawSettings.get(ClientSettings.SESSION_DB_ROLES);
+    }
 }

--- a/client-v2/src/test/java/com/clickhouse/client/SettingsTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/SettingsTests.java
@@ -1,5 +1,19 @@
 package com.clickhouse.client;
 
+import com.clickhouse.client.api.ClientSettings;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Arrays;
+import java.util.List;
+
 public class SettingsTests {
 
+    @Test
+    void testClientSettings() {
+        List<String> source = Arrays.asList("ROL1", "ROL2,☺", "Rol,3,3");
+        String listA = ClientSettings.commaSeparated(source);
+        List<String> listB = ClientSettings.valuesFromCommaSeparated(listA);
+        Assert.assertEquals(listB, source);
+    }
 }

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -31,6 +31,7 @@ import com.clickhouse.client.api.query.Records;
 import com.clickhouse.client.http.config.HttpConnectionProvider;
 import com.clickhouse.data.ClickHouseDataType;
 import com.clickhouse.data.ClickHouseFormat;
+import com.clickhouse.data.ClickHouseVersion;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -1588,6 +1589,12 @@ public class QueryTests extends BaseIntegrationTest {
 
     @Test(groups = {"integration"}, dataProvider = "sessionRoles", dataProviderClass = QueryTests.class)
     public void testOperationCustomRoles(String[] roles) throws Exception {
+        List<GenericRecord> serverVersion = client.queryAll("SELECT version()");
+        if (ClickHouseVersion.of(serverVersion.get(0).getString(1)).check("(,24.3]")) {
+            System.out.println("Test is skipped: feature is supported since 24.4");
+            return;
+        }
+
         final String password = UUID.randomUUID().toString();
         final String rolesList = "\"" + Strings.join("\",\"", roles) + "\"";
         try (CommandResponse resp = client.execute("DROP ROLE IF EXISTS " + rolesList).get()) {
@@ -1600,6 +1607,7 @@ public class QueryTests extends BaseIntegrationTest {
         }
         try (CommandResponse resp = client.execute("GRANT " + rolesList + " TO some_user").get()) {
         }
+
 
         try (Client userClient = newClient().setUsername("some_user").setPassword(password).build()) {
             QuerySettings settings = new QuerySettings().setDBRoles(Arrays.asList(roles));
@@ -1619,6 +1627,12 @@ public class QueryTests extends BaseIntegrationTest {
     }
     @Test(groups = {"integration"}, dataProvider = "clientSessionRoles", dataProviderClass = QueryTests.class)
     public void testClientCustomRoles(String[] roles) throws Exception {
+        List<GenericRecord> serverVersion = client.queryAll("SELECT version()");
+        if (ClickHouseVersion.of(serverVersion.get(0).getString(1)).check("(,24.3]")) {
+            System.out.println("Test is skipped: feature is supported since 24.4");
+            return;
+        }
+
         final String password = UUID.randomUUID().toString();
         final String rolesList = "\"" + Strings.join("\",\"", roles) + "\"";
         try (CommandResponse resp = client.execute("DROP ROLE IF EXISTS " + rolesList).get()) {


### PR DESCRIPTION
## Summary
There is a [feature](https://clickhouse.com/docs/en/interfaces/http#setting-role-with-query-parameters) and it should be supported by the new client. It allows to set roles for every operation where session may not be maintained (http requests are balanced between different DB instances). 

!! Documentation should be updated also. 

Closes: https://github.com/ClickHouse/clickhouse-java/issues/1832

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
