### PR TITLE
[client-v2] Fixes BinaryStreamReader parsing DateTime64 values. Using a column defined scale now. 

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/DataTypeUtils.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/DataTypeUtils.java
@@ -4,7 +4,19 @@ import java.time.format.DateTimeFormatter;
 
 public class DataTypeUtils {
 
-    public static DateTimeFormatter DATE_TIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+    /**
+     * Formatter for the DateTime type.
+     */
+    public static DateTimeFormatter DATETIME_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
 
+    /**
+     * Formatter for the Date type.
+     */
     public static DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+
+    /**
+     * Formatter for the DateTime type with nanoseconds.
+     */
+    public static DateTimeFormatter DATETIME_WITH_NANOS_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.nnnnnnnnn");
+
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -171,7 +171,7 @@ public class BinaryStreamReader {
                     return convertDateTime(readDateTime32(column.getTimeZone() == null ? timeZone :
                             column.getTimeZone()), typeHint);
                 case DateTime64:
-                    return convertDateTime(readDateTime64(3, column.getTimeZone() == null ? timeZone :
+                    return convertDateTime(readDateTime64(column.getScale(), column.getTimeZone() == null ? timeZone :
                             column.getTimeZone()), typeHint);
 
                 case IntervalYear:

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -706,18 +706,36 @@ public class QueryTests extends BaseIntegrationTest {
                 "min_date Date",
                 "max_date Date",
                 "min_dateTime DateTime",
-                "max_dateTime DateTime"
+                "max_dateTime DateTime",
+                "min_dateTime64 DateTime64",
+                "max_dateTime64 DateTime64",
+                "min_dateTime64_6 DateTime64(6)",
+                "max_dateTime64_6 DateTime64(6)",
+                "min_dateTime64_9 DateTime64(9)",
+                "max_dateTime64_9 DateTime64(9)"
         );
 
         final LocalDate minDate = LocalDate.parse("1970-01-01");
         final LocalDate maxDate = LocalDate.parse("2149-06-06");
-        final LocalDateTime minDateTime = LocalDateTime.parse("1970-01-01T00:00:00");
+        final LocalDateTime minDateTime = LocalDateTime.parse("1970-01-01T01:02:03");
         final LocalDateTime maxDateTime = LocalDateTime.parse("2106-02-07T06:28:15");
+        final LocalDateTime minDateTime64 = LocalDateTime.parse("1970-01-01T01:02:03.123");
+        final LocalDateTime maxDateTime64 = LocalDateTime.parse("2106-02-07T06:28:15.123");
+        final LocalDateTime minDateTime64_6 = LocalDateTime.parse("1970-01-01T01:02:03.123456");
+        final LocalDateTime maxDateTime64_6 = LocalDateTime.parse("2106-02-07T06:28:15.123456");
+        final LocalDateTime minDateTime64_9 = LocalDateTime.parse("1970-01-01T01:02:03.123456789");
+        final LocalDateTime maxDateTime64_9 = LocalDateTime.parse("2106-02-07T06:28:15.123456789");
         final List<Supplier<String>> valueGenerators = Arrays.asList(
                 () -> sq(minDate.toString()),
                 () -> sq(maxDate.toString()),
-                () -> sq(minDateTime.format(DataTypeUtils.DATE_TIME_FORMATTER)),
-                () -> sq(maxDateTime.format(DataTypeUtils.DATE_TIME_FORMATTER))
+                () -> sq(minDateTime.format(DataTypeUtils.DATETIME_FORMATTER)),
+                () -> sq(maxDateTime.format(DataTypeUtils.DATETIME_FORMATTER)),
+                () -> sq(minDateTime64.format(DataTypeUtils.DATETIME_WITH_NANOS_FORMATTER)),
+                () -> sq(maxDateTime64.format(DataTypeUtils.DATETIME_WITH_NANOS_FORMATTER)),
+                () -> sq(minDateTime64_6.format(DataTypeUtils.DATETIME_WITH_NANOS_FORMATTER)),
+                () -> sq(maxDateTime64_6.format(DataTypeUtils.DATETIME_WITH_NANOS_FORMATTER)),
+                () -> sq(minDateTime64_9.format(DataTypeUtils.DATETIME_WITH_NANOS_FORMATTER)),
+                () -> sq(maxDateTime64_9.format(DataTypeUtils.DATETIME_WITH_NANOS_FORMATTER))
         );
 
         final List<Consumer<ClickHouseBinaryFormatReader>> verifiers = new ArrayList<>();
@@ -740,6 +758,36 @@ public class QueryTests extends BaseIntegrationTest {
             Assert.assertTrue(r.hasValue("max_dateTime"), "No value for column max_dateTime found");
             Assert.assertEquals(r.getLocalDateTime("max_dateTime"), maxDateTime);
             Assert.assertEquals(r.getLocalDateTime(4), maxDateTime);
+        });
+        verifiers.add(r -> {
+            Assert.assertTrue(r.hasValue("min_dateTime64"), "No value for column min_dateTime64 found");
+            Assert.assertEquals(r.getLocalDateTime("min_dateTime64"), minDateTime64);
+            Assert.assertEquals(r.getLocalDateTime(5), minDateTime64);
+        });
+        verifiers.add(r -> {
+            Assert.assertTrue(r.hasValue("max_dateTime64"), "No value for column max_dateTime64 found");
+            Assert.assertEquals(r.getLocalDateTime("max_dateTime64"), maxDateTime64);
+            Assert.assertEquals(r.getLocalDateTime(6), maxDateTime64);
+        });
+        verifiers.add(r -> {
+            Assert.assertTrue(r.hasValue("min_dateTime64_6"), "No value for column min_dateTime64_6 found");
+            Assert.assertEquals(r.getLocalDateTime("min_dateTime64_6"), minDateTime64_6);
+            Assert.assertEquals(r.getLocalDateTime(7), minDateTime64_6);
+        });
+        verifiers.add(r -> {
+            Assert.assertTrue(r.hasValue("max_dateTime64_6"), "No value for column max_dateTime64_6 found");
+            Assert.assertEquals(r.getLocalDateTime("max_dateTime64_6"), maxDateTime64_6);
+            Assert.assertEquals(r.getLocalDateTime(8), maxDateTime64_6);
+        });
+        verifiers.add(r -> {
+            Assert.assertTrue(r.hasValue("min_dateTime64_9"), "No value for column min_dateTime64_9 found");
+            Assert.assertEquals(r.getLocalDateTime("min_dateTime64_9"), minDateTime64_9);
+            Assert.assertEquals(r.getLocalDateTime(9), minDateTime64_9);
+        });
+        verifiers.add(r -> {
+            Assert.assertTrue(r.hasValue("max_dateTime64_9"), "No value for column max_dateTime64_9 found");
+            Assert.assertEquals(r.getLocalDateTime("max_dateTime64_9"), maxDateTime64_9);
+            Assert.assertEquals(r.getLocalDateTime(10), maxDateTime64_9);
         });
 
         testDataTypes(columns, valueGenerators, verifiers);


### PR DESCRIPTION
## Summary
Added more tests for DateTime values and made it be read with column defined scale.

Closes: https://github.com/ClickHouse/clickhouse-java/issues/1851

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
