### PR TITLE
[client-v2] Added setting log_comment

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/command/CommandResponse.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/command/CommandResponse.java
@@ -5,7 +5,7 @@ import com.clickhouse.client.api.metrics.OperationMetrics;
 import com.clickhouse.client.api.metrics.ServerMetrics;
 import com.clickhouse.client.api.query.QueryResponse;
 
-public class CommandResponse{
+public class CommandResponse implements AutoCloseable {
 
     private final QueryResponse response;
 
@@ -70,5 +70,10 @@ public class CommandResponse{
      */
     public long getServerTime() {
         return response.getServerTime();
+    }
+
+    @Override
+    public void close() throws Exception {
+        response.close();
     }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/insert/InsertSettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/insert/InsertSettings.java
@@ -205,4 +205,23 @@ public class InsertSettings {
         rawSettings.put(ClientSettings.SERVER_SETTING_PREFIX + name, ClientSettings.commaSeparated(values));
         return this;
     }
+
+    /**
+     * Sets the comment that will be added to the query log record associated with the query.
+     * @param logComment - comment to be added to the log
+     * @return same instance of the builder
+     */
+    public InsertSettings logComment(String logComment) {
+        this.logComment = logComment;
+        if (logComment != null && !logComment.isEmpty()) {
+            rawSettings.put(ClientSettings.SERVER_SETTING_PREFIX + "log_comment", logComment);
+        }
+        return this;
+    }
+
+    private String logComment = null;
+
+    public String getLogComment() {
+        return logComment;
+    }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
@@ -221,4 +221,23 @@ public class QuerySettings {
         rawSettings.put(ClientSettings.SERVER_SETTING_PREFIX + name, ClientSettings.commaSeparated(values));
         return this;
     }
+
+    /**
+     * Sets the comment that will be added to the query log record associated with the query.
+     * @param logComment - comment to be added to the log
+     * @return same instance of the builder
+     */
+    public QuerySettings logComment(String logComment) {
+        this.logComment = logComment;
+        if (logComment != null && !logComment.isEmpty()) {
+            rawSettings.put(ClientSettings.SERVER_SETTING_PREFIX + "log_comment", logComment);
+        }
+        return this;
+    }
+
+    private String logComment = null;
+
+    public String getLogComment() {
+        return logComment;
+    }
 }


### PR DESCRIPTION
## Summary
There is an option to set a comment that will be seen in `system.query_log` record associated with a query. It is useful for troubleshooting. In case of HTTP interface client should send the comment thru query parameter `log_comment`. 

Closes: https://github.com/ClickHouse/clickhouse-java/issues/1836
## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
