### PR TITLE
register(): make underscore legal in column name

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -1040,7 +1040,7 @@ public class Client implements AutoCloseable {
         boolean defaultsSupport = schema.hasDefaults();
         tableSchemaHasDefaults.put(schemaKey, defaultsSupport);
         for (ClickHouseColumn column : schema.getColumns()) {
-            String propertyName = column.getColumnName().toLowerCase().replace("_", "").replace(".", "");
+            String propertyName = column.getColumnName().toLowerCase().replace(".", "");
             Method getterMethod = classGetters.get(propertyName);
             if (getterMethod != null) {
                 schemaSerializers.put(column.getColumnName(), (obj, stream) -> {


### PR DESCRIPTION
## Summary
fix for [[client-v2] Underscore in column name is removed](https://github.com/ClickHouse/clickhouse-java/issues/1866) 

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
