### PR TITLE
[client-v2] Fixes handling error when successful http status by error code header in response

### DIFF
--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
@@ -194,11 +194,11 @@ public class ApacheHttpConnectionImpl extends ClickHouseHttpConnection {
     }
 
     private void checkResponse(ClickHouseConfig config, CloseableHttpResponse response) throws IOException {
-        if (response.getCode() == HttpURLConnection.HTTP_OK) {
+        final Header errorCode = response.getFirstHeader(ClickHouseHttpProto.HEADER_EXCEPTION_CODE);
+        if (response.getCode() == HttpURLConnection.HTTP_OK && errorCode == null) {
             return;
         }
 
-        final Header errorCode = response.getFirstHeader(ClickHouseHttpProto.HEADER_EXCEPTION_CODE);
         final Header serverName = response.getFirstHeader(ClickHouseHttpProto.HEADER_SRV_DISPLAY_NAME);
         if (response.getEntity() == null) {
             throw new ConnectException(

--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -1807,6 +1807,8 @@ public class Client implements AutoCloseable {
             throw new ClientException("Operation has likely timed out after " + getOperationTimeout() + " seconds.", e);
         } catch (ExecutionException e) {
             throw new ClientException("Failed to get table schema", e.getCause());
+        } catch (ServerException e) {
+            throw e;
         } catch (Exception e) {
             throw new ClientException("Failed to get table schema", e);
         }

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
@@ -348,7 +348,6 @@ public class HttpAPIClientHelper {
 
         try {
             ClassicHttpResponse httpResponse = httpClient.executeOpen(null, req, context);
-            httpResponse.getEntity().getTrailers().get();
             httpResponse.setEntity(wrapEntity(httpResponse.getEntity(), true));
             if (httpResponse.getCode() == HttpStatus.SC_PROXY_AUTHENTICATION_REQUIRED) {
                 throw new ClientMisconfigurationException("Proxy authentication required. Please check your proxy settings.");

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
@@ -348,13 +348,14 @@ public class HttpAPIClientHelper {
 
         try {
             ClassicHttpResponse httpResponse = httpClient.executeOpen(null, req, context);
+            httpResponse.getEntity().getTrailers().get();
             httpResponse.setEntity(wrapEntity(httpResponse.getEntity(), true));
             if (httpResponse.getCode() == HttpStatus.SC_PROXY_AUTHENTICATION_REQUIRED) {
                 throw new ClientMisconfigurationException("Proxy authentication required. Please check your proxy settings.");
             } else if (httpResponse.getCode() == HttpStatus.SC_BAD_GATEWAY) {
                 httpResponse.close();
                 throw new ClientException("Server returned '502 Bad gateway'. Check network and proxy settings.");
-            } else if (httpResponse.getCode() >= HttpStatus.SC_BAD_REQUEST) {
+            } else if (httpResponse.getCode() >= HttpStatus.SC_BAD_REQUEST || httpResponse.containsHeader(ClickHouseHttpProto.HEADER_EXCEPTION_CODE)) {
                 try {
                     throw readError(httpResponse);
                 } finally {

--- a/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
@@ -321,12 +321,11 @@ public class HttpTransportTests extends BaseIntegrationTest {
             try (QueryResponse response =
                          client.query("SELECT invalid;statement", querySettings).get(1, TimeUnit.SECONDS)) {
                 Assert.fail("Expected exception");
-            } catch (ClientException e) {
+            } catch (ServerException e) {
                 e.printStackTrace();
-                ServerException serverException = (ServerException) e.getCause();
-                Assert.assertEquals(serverException.getCode(), 62);
-                Assert.assertTrue(serverException.getMessage().startsWith("Code: 62. DB::Exception: Syntax error (Multi-statements are not allowed): failed at position 15 (end of query)"),
-                        "Unexpected error message: " + serverException.getMessage());
+                Assert.assertEquals(e.getCode(), 62);
+                Assert.assertTrue(e.getMessage().startsWith("Code: 62. DB::Exception: Syntax error (Multi-statements are not allowed): failed at position 15 (end of query)"),
+                        "Unexpected error message: " + e.getMessage());
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/client-v2/src/test/java/com/clickhouse/client/command/CommandTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/command/CommandTests.java
@@ -5,6 +5,7 @@ import com.clickhouse.client.ClickHouseNode;
 import com.clickhouse.client.ClickHouseProtocol;
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ClientException;
+import com.clickhouse.client.api.ServerException;
 import com.clickhouse.client.api.command.CommandResponse;
 import com.clickhouse.client.api.enums.Protocol;
 import org.testng.Assert;
@@ -45,8 +46,10 @@ public class CommandTests extends BaseIntegrationTest {
     public void testInvalidCommandExecution() throws Exception {
         try {
             client.execute("ALTER TABLE non_existing_table ADD COLUMN id2 UInt32").get(10, TimeUnit.SECONDS);
+        } catch (ServerException e) {
+            Assert.assertEquals(e.getCode(), 60);
         } catch (ExecutionException e) {
-            Assert.assertTrue(e.getCause() instanceof ClientException);
+            Assert.assertTrue(e.getCause() instanceof ServerException);
         } catch (ClientException e) {
             // expected
         }

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -550,8 +550,10 @@ public class QueryTests extends BaseIntegrationTest {
         try {
             client.queryRecords("SELECT * FROM unknown_table").get(3, TimeUnit.SECONDS);
             Assert.fail("expected exception");
+        } catch (ServerException e) {
+            Assert.assertTrue(e.getMessage().contains("Unknown table"));
         } catch (ExecutionException e) {
-            Assert.assertTrue(e.getCause() instanceof ClientException);
+            Assert.assertTrue(e.getCause() instanceof ServerException);
         } catch (ClientException e) {
             // expected
         }


### PR DESCRIPTION
## Summary
Fixes the problem with case when server responds "200 OK" but then long running query fails and headers have exception code. 

Linked to https://github.com/ClickHouse/clickhouse-java/issues/1821 

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
