### PR TITLE
Fix JDBC driver prints stack trace to stdout

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseClient.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseClient.java
@@ -40,6 +40,8 @@ import com.clickhouse.data.ClickHouseUtils;
 import com.clickhouse.data.ClickHouseValue;
 import com.clickhouse.data.ClickHouseValues;
 import com.clickhouse.data.ClickHouseWriter;
+import com.clickhouse.logging.Logger;
+import com.clickhouse.logging.LoggerFactory;
 
 /**
  * A unified interface defines Java client for ClickHouse. A client can only
@@ -56,6 +58,7 @@ import com.clickhouse.data.ClickHouseWriter;
  * implementation properly in runtime.
  */
 public interface ClickHouseClient extends AutoCloseable {
+    Logger LOG = LoggerFactory.getLogger(ClickHouseClient.class);
 
     /**
      * Returns a builder for creating a new client.
@@ -959,8 +962,8 @@ public interface ClickHouseClient extends AutoCloseable {
                     .get(timeout, TimeUnit.MILLISECONDS)) {
                 return resp != null;
             } catch (Exception e) {
-                // ignore
-                e.printStackTrace();
+                LOG.debug("Failed to connect to the server", e);
+                return false;
             }
         }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -1035,6 +1035,7 @@ public class Client implements AutoCloseable {
             try (QueryResponse response = query("SELECT 1 FORMAT TabSeparated").get(timeout, TimeUnit.MILLISECONDS)) {
                 return true;
             } catch (Exception e) {
+                LOG.debug("Failed to connect to the server", e);
                 return false;
             }
         } else {


### PR DESCRIPTION
## Summary
This commit solves the issue #1827 by logging the exception instead of printing it to stdout. A log in the client v2 has also been added so that both clients are iso.

## Checklist
Delete items not relevant to your PR:
- [x] A human-readable description of the changes was provided to include in CHANGELOG

