### PR TITLE
[jdbc] Make ResultSet to return JDBC compliant types for Date/DateTime columns 

### DIFF
--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseArrayValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseArrayValue.java
@@ -5,6 +5,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
+import java.sql.Date;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -96,9 +97,20 @@ public class ClickHouseArrayValue<T> extends ClickHouseObjectValue<T[]> implemen
         E[] array = (E[]) Array.newInstance(ClickHouseChecker.nonNull(clazz, ClickHouseValues.TYPE_CLASS), v.length);
         int index = 0;
         for (T o : v) {
-            array[index++] = clazz.cast(o);
+            array[index++] = castOrConvert(o, clazz);
         }
         return array;
+    }
+
+    private <E> E castOrConvert(T o, Class<E> clazz) {
+        if (o instanceof LocalDate && clazz == java.sql.Date.class) {
+            return (E) Date.valueOf((LocalDate) o);
+        } else if (o instanceof LocalDateTime && clazz == java.sql.Timestamp.class) {
+            return (E) java.sql.Timestamp.valueOf((LocalDateTime) o);
+        } else if (o instanceof LocalTime && clazz == java.sql.Time.class) {
+            return (E) java.sql.Time.valueOf((LocalTime) o);
+        }
+        return clazz.cast(o);
     }
 
     @Override

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseArrayValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseArrayValue.java
@@ -110,6 +110,7 @@ public class ClickHouseArrayValue<T> extends ClickHouseObjectValue<T[]> implemen
         } else if (o instanceof LocalTime && clazz == java.sql.Time.class) {
             return (E) java.sql.Time.valueOf((LocalTime) o);
         }
+
         return clazz.cast(o);
     }
 

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseArray.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseArray.java
@@ -3,6 +3,7 @@ package com.clickhouse.jdbc;
 import java.sql.Array;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.Map;
 
 import com.clickhouse.data.ClickHouseChecker;
@@ -46,24 +47,29 @@ public class ClickHouseArray implements Array {
     public Object getArray() throws SQLException {
         ensureValid();
 
-        return resultSet.getValue(columnIndex).asObject();
+        return resultSet.getObject(columnIndex);
     }
 
     @Override
     public Object getArray(Map<String, Class<?>> map) throws SQLException {
-        return getArray();
+        ensureValid();
+
+        return resultSet.getObject(columnIndex, map);
     }
 
     @Override
     public Object getArray(long index, int count) throws SQLException {
         ensureValid();
-
-        throw SqlExceptionUtils.unsupportedError("getArray not implemented");
+        Object[] arr = (Object[]) getArray();
+        return Arrays.copyOfRange(arr, (int) index, (int) (index + count));
     }
 
     @Override
     public Object getArray(long index, int count, Map<String, Class<?>> map) throws SQLException {
-        return getArray(index, count);
+        ensureValid();
+
+        Object[] arr = (Object[]) getArray(map);
+        return Arrays.copyOfRange(arr, (int) index, (int) (index + count));
     }
 
     @Override

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseConnectionTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseConnectionTest.java
@@ -102,7 +102,8 @@ public class ClickHouseConnectionTest extends JdbcIntegrationTest {
             array = conn.createArrayOf("Int8", new Byte[] { -1, 0, 1 });
             Assert.assertEquals(array.getArray(), new byte[] { -1, 0, 1 });
             array = conn.createArrayOf("UInt8", new Byte[] { -1, 0, 1 });
-            Assert.assertEquals(array.getArray(), new byte[] { -1, 0, 1 });
+            Assert.assertEquals(array.getArray(), new UnsignedByte[] { UnsignedByte.valueOf((byte) -1), UnsignedByte.ZERO,
+            UnsignedByte.ONE});
 
             array = conn.createArrayOf("Nullable(Int8)", new Byte[] { -1, null, 1 });
             Assert.assertEquals(array.getArray(), new Byte[] { -1, null, 1 });

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
@@ -11,6 +11,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
+import java.sql.Array;
 import java.sql.BatchUpdateException;
 import java.sql.Connection;
 import java.sql.Date;
@@ -134,8 +135,14 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
     @DataProvider(name = "typedParameters")
     private Object[][] getTypedParameters() {
         return new Object[][] {
-                new Object[] { "Array(DateTime32)", new LocalDateTime[] { LocalDateTime.of(2021, 11, 1, 1, 2, 3),
-                        LocalDateTime.of(2021, 11, 2, 2, 3, 4) } } };
+                new Object[] { "Array(DateTime32)",
+                        new LocalDateTime[] {
+                                LocalDateTime.of(2021, 11, 1, 1, 2, 3),
+                                LocalDateTime.of(2021, 11, 2, 2, 3, 4) },
+                        new Timestamp[] {
+                                Timestamp.valueOf(LocalDateTime.of(2021, 11, 1, 1, 2, 3)),
+                                Timestamp.valueOf(LocalDateTime.of(2021, 11, 2, 2, 3, 4)) }
+                } };
     }
 
     @DataProvider(name = "statementAndParams")
@@ -353,15 +360,15 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
             ResultSet rs = conn.createStatement().executeQuery("select * from test_read_write_date order by id");
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getInt(1), 1);
-            Assert.assertEquals(rs.getObject(2), d);
+            Assert.assertEquals(rs.getObject(2), Date.valueOf(d));
             Assert.assertEquals(rs.getDate(2), x);
-            Assert.assertEquals(rs.getObject(3), d);
+            Assert.assertEquals(rs.getObject(3), Date.valueOf(d));
             Assert.assertEquals(rs.getDate(3), x);
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getInt(1), 2);
-            Assert.assertEquals(rs.getObject(2), d);
+            Assert.assertEquals(rs.getObject(2), Date.valueOf(d));
             Assert.assertEquals(rs.getDate(2), x);
-            Assert.assertEquals(rs.getObject(3), d);
+            Assert.assertEquals(rs.getObject(3), Date.valueOf(d));
             Assert.assertEquals(rs.getDate(3), x);
             Assert.assertFalse(rs.next());
         }
@@ -400,16 +407,16 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
             ResultSet rs = conn.createStatement().executeQuery("select * from test_read_write_date_cz order by id");
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getInt(1), 1);
-            Assert.assertEquals(rs.getObject(2), d);
+            Assert.assertEquals(rs.getObject(2), Date.valueOf(d));
             Assert.assertEquals(rs.getDate(2), x);
-            Assert.assertEquals(rs.getObject(3), d);
+            Assert.assertEquals(rs.getObject(3), Date.valueOf(d));
             Assert.assertEquals(rs.getDate(3), x);
             Assert.assertTrue(rs.next());
 
             Assert.assertEquals(rs.getInt(1), 2);
-            Assert.assertEquals(rs.getObject(2), d);
+            Assert.assertEquals(rs.getObject(2), Date.valueOf(d));
             Assert.assertEquals(rs.getDate(2), x);
-            Assert.assertEquals(rs.getObject(3), d);
+            Assert.assertEquals(rs.getObject(3), Date.valueOf(d));
             Assert.assertEquals(rs.getDate(3), x);
             Assert.assertFalse(rs.next());
         }
@@ -441,15 +448,15 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
             ResultSet rs = conn.createStatement().executeQuery("select * from test_read_write_datetime order by id");
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getInt(1), 1);
-            Assert.assertEquals(rs.getObject(2), dt);
+            Assert.assertEquals(rs.getObject(2), Timestamp.valueOf(dt));
             Assert.assertEquals(rs.getTimestamp(2), x);
-            Assert.assertEquals(rs.getObject(3), dt);
+            Assert.assertEquals(rs.getObject(3), Timestamp.valueOf(dt));
             Assert.assertEquals(rs.getTimestamp(3), x);
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getInt(1), 2);
-            Assert.assertEquals(rs.getObject(2), dx);
+            Assert.assertEquals(rs.getObject(2), Timestamp.valueOf(dx));
             Assert.assertEquals(rs.getTimestamp(2), xx);
-            Assert.assertEquals(rs.getObject(3), dx);
+            Assert.assertEquals(rs.getObject(3), Timestamp.valueOf(dx));
             Assert.assertEquals(rs.getTimestamp(3), xx);
             Assert.assertFalse(rs.next());
         }
@@ -477,7 +484,7 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
             ResultSet rs = stmt.executeQuery("select * from test_read_write_datetime_nanos");
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getObject(1), id);
-            Assert.assertEquals(rs.getObject(2), dt);
+            Assert.assertEquals(rs.getObject(2), Timestamp.valueOf(dt));
             // rs.getString(2) will return "2021-04-02 03:35:45.321"
             Assert.assertFalse(rs.next());
         }
@@ -510,15 +517,15 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
             ResultSet rs = s.executeQuery("select * from test_read_write_datetime_cz order by id");
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getInt(1), 1);
-            Assert.assertEquals(rs.getObject(2), dt);
+            Assert.assertEquals(rs.getObject(2), Timestamp.valueOf(dt));
             Assert.assertEquals(rs.getTimestamp(2), x);
-            Assert.assertEquals(rs.getObject(3), dt);
+            Assert.assertEquals(rs.getObject(3), Timestamp.valueOf(dt));
             Assert.assertEquals(rs.getTimestamp(3), x);
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getInt(1), 2);
-            Assert.assertEquals(rs.getObject(2), dt);
+            Assert.assertEquals(rs.getObject(2), Timestamp.valueOf(dt));
             Assert.assertEquals(rs.getTimestamp(2), x);
-            Assert.assertEquals(rs.getObject(3), dt);
+            Assert.assertEquals(rs.getObject(3), Timestamp.valueOf(dt));
             Assert.assertEquals(rs.getTimestamp(3), x);
             Assert.assertFalse(rs.next());
         }
@@ -588,21 +595,21 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
             ResultSet rs = s.executeQuery("select * from test_read_write_nullable_unsigned_types order by id");
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getInt(1), 1);
-            Assert.assertEquals(rs.getObject(2), new Byte[0]);
+            Assert.assertEquals(rs.getObject(2, Byte[].class), new Byte[0]);
             Assert.assertEquals(rs.getArray(2).getArray(), new Byte[0]);
-            Assert.assertEquals(rs.getObject(3), new UnsignedLong[0]);
+            Assert.assertEquals(rs.getObject(3, UnsignedLong[].class), new UnsignedLong[0]);
             Assert.assertEquals(rs.getArray(3).getArray(), new UnsignedLong[0]);
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getInt(1), 2);
-            Assert.assertEquals(rs.getObject(2), new Byte[] { 2, 2 });
+            Assert.assertEquals(rs.getObject(2, Byte[].class), new Byte[] { 2, 2 });
             Assert.assertEquals(rs.getArray(2).getArray(), new Byte[] { 2, 2 });
-            Assert.assertEquals(rs.getObject(3), new UnsignedLong[] { UnsignedLong.valueOf(2L), null });
+            Assert.assertEquals(rs.getObject(3, UnsignedLong[].class), new UnsignedLong[] { UnsignedLong.valueOf(2L), null });
             Assert.assertEquals(rs.getArray(3).getArray(), new UnsignedLong[] { UnsignedLong.valueOf(2L), null });
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getInt(1), 3);
-            Assert.assertEquals(rs.getObject(2), new Byte[] { null, 3 });
+            Assert.assertEquals(rs.getObject(2, Byte[].class), new Byte[] { null, 3 });
             Assert.assertEquals(rs.getArray(2).getArray(), new Byte[] { null, 3 });
-            Assert.assertEquals(rs.getObject(3), new UnsignedLong[] { null, UnsignedLong.valueOf(3L) });
+            Assert.assertEquals(rs.getObject(3, UnsignedLong[].class), new UnsignedLong[] { null, UnsignedLong.valueOf(3L) });
             Assert.assertEquals(rs.getArray(3).getArray(), new UnsignedLong[] { null, UnsignedLong.valueOf(3L) });
             Assert.assertFalse(rs.next());
         }
@@ -646,14 +653,14 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
             Assert.assertEquals(rs.getInt(1), 1);
             Assert.assertEquals(rs.getString(2), "");
             Assert.assertEquals(rs.getObject(3), "");
-            Assert.assertEquals(rs.getObject(4), new String[] { "" });
+            Assert.assertEquals(((Array)rs.getObject(4)).getArray(), new String[] { "" });
             Assert.assertEquals(rs.getArray(5).getArray(), new String[] { "" });
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getInt(1), 2);
             Assert.assertEquals(rs.getObject(2), "");
             Assert.assertEquals(rs.getString(3), null);
             Assert.assertEquals(rs.getArray(4).getArray(), new String[0]);
-            Assert.assertEquals(rs.getObject(5), new String[] { null });
+            Assert.assertEquals(rs.getObject(5, String[].class), new String[] { null });
             Assert.assertFalse(rs.next());
         }
     }
@@ -682,7 +689,7 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
                 ResultSet rs = ps.executeQuery();
                 Assert.assertTrue(rs.next());
                 Assert.assertEquals(rs.getObject(1), id);
-                Assert.assertEquals(rs.getObject(2), dt);
+                Assert.assertEquals(rs.getObject(2), Timestamp.valueOf(dt));
                 Assert.assertEquals(rs.getLong(2), dt.atZone(conn.getServerTimeZone().toZoneId()).toEpochSecond());
                 Assert.assertFalse(rs.next());
             }
@@ -691,7 +698,8 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
                 ps.setObject(1, id);
                 ResultSet rs = ps.executeQuery();
                 Assert.assertTrue(rs.next());
-                Assert.assertEquals(rs.getObject(2), LocalDateTime.of(2021, 9, 1, 0, 0, 0, 123456000));
+                Assert.assertEquals(rs.getObject(2),
+                        Timestamp.valueOf(LocalDateTime.of(2021, 9, 1, 0, 0, 0, 123456000)));
                 Assert.assertFalse(rs.next());
             }
         }
@@ -858,7 +866,8 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
             ResultSet rs = stmt.executeQuery();
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getInt(1), 2);
-            Assert.assertEquals(rs.getObject(2), LocalDateTime.of(2021, 3, 26, 12, 34, 56));
+            Assert.assertEquals(rs.getObject(2),
+                    Timestamp.valueOf(LocalDateTime.of(2021, 3, 26, 12, 34, 56)));
             Assert.assertFalse(rs.next());
         }
     }
@@ -1164,7 +1173,7 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
     }
 
     @Test(dataProvider = "typedParameters", groups = "integration")
-    public void testArrayParameter(String t, Object v) throws SQLException {
+    public void testArrayParameter(String t, Object v, Object expectedValue) throws SQLException {
         try (ClickHouseConnection conn = newConnection(new Properties());
                 PreparedStatement stmt = conn.prepareStatement("select ?::?")) {
             if (conn.getServerVersion().check("(,21.3]")) {
@@ -1176,7 +1185,7 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
             stmt.setObject(2, new StringBuilder(t));
             ResultSet rs = stmt.executeQuery();
             Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getObject(1), v);
+            Assert.assertEquals(((Array)rs.getObject(1)).getArray(), expectedValue);
             Assert.assertFalse(rs.next());
         }
     }
@@ -1287,8 +1296,8 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
                 ResultSet rs = s.executeQuery("select * from test_insert_byte_array order by id");
                 Assert.assertTrue(rs.next());
                 Assert.assertEquals(rs.getInt(1), 1);
-                Assert.assertEquals(rs.getObject(2), new byte[] { 1, 2, 3 });
-                Assert.assertEquals(rs.getObject(3), new byte[][] { { 1, 2, 3 }, { 4, 5, 6 } });
+                Assert.assertEquals(((Array)rs.getObject(2)).getArray(), new byte[] { 1, 2, 3 });
+                Assert.assertEquals(((Array)rs.getObject(3)).getArray(), new byte[][] { { 1, 2, 3 }, { 4, 5, 6 } });
                 Assert.assertFalse(rs.next());
             }
         }
@@ -1474,8 +1483,8 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
                     for (int j = 0; j < i; j++) {
                         bytes[j] = (byte) (j + 1);
                     }
-                    Assert.assertEquals(rs.getObject(2), bytes);
-                    Assert.assertEquals(rs.getObject(3), bytes);
+                    Assert.assertEquals(((Array)rs.getObject(2)).getArray(), bytes);
+                    Assert.assertEquals(((Array)rs.getObject(3)).getArray(), bytes);
                 }
                 Assert.assertFalse(rs.next());
             }
@@ -1581,8 +1590,8 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
             try (ResultSet rs = s.executeQuery("select * from test_nested_insert order by id")) {
                 Assert.assertTrue(rs.next());
                 Assert.assertEquals(rs.getInt(1), 3);
-                Assert.assertEquals(rs.getObject(2), new byte[] { 7, 8, 9 });
-                Assert.assertEquals(rs.getObject(3), new String[] { "foo3", "bar3", "bug3" });
+                Assert.assertEquals(rs.getObject(2, byte[].class), new byte[] { 7, 8, 9 });
+                Assert.assertEquals(rs.getObject(3, String[].class), new String[] { "foo3", "bar3", "bug3" });
                 Assert.assertFalse(rs.next());
             }
         }
@@ -1677,8 +1686,8 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
             ResultSet rs = s.executeQuery("select * from test_array_insert order by id");
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getInt(1), 1);
-            Assert.assertEquals(rs.getObject(2), new short[] { 1, 2, 3 });
-            Assert.assertEquals(rs.getObject(3),
+            Assert.assertEquals(((Array)rs.getObject(2)).getArray(), new short[] { 1, 2, 3 });
+            Assert.assertEquals(((Array)rs.getObject(3)).getArray(),
                     new UnsignedInteger[] { UnsignedInteger.valueOf(3), null, UnsignedInteger.ONE });
             Assert.assertFalse(rs.next());
         }
@@ -1700,7 +1709,7 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getInt(1), 1);
             Assert.assertEquals(rs.getArray(2).getArray(), new String[] { "1", "2", "3" });
-            Assert.assertEquals(rs.getObject(3), new String[] { "3", null, "1" });
+            Assert.assertEquals(rs.getObject(3, String[].class), new String[] { "3", null, "1" });
             Assert.assertFalse(rs.next());
         }
     }

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseResultSetTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseResultSetTest.java
@@ -2,6 +2,7 @@ package com.clickhouse.jdbc;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
@@ -455,6 +456,34 @@ public class ClickHouseResultSetTest extends JdbcIntegrationTest {
             Timestamp tzTimeTimestamp = rs.getTimestamp(2);
             Assert.assertEquals(serverNowTime, tzTimeTime);
             Assert.assertEquals(serverNowTimestamp, tzTimeTimestamp);
+        }
+    }
+
+
+    @Test(groups = "integration")
+    public void testGettingDateTimeColumns() throws SQLException {
+        final String sql = "SELECT toDate(now()) AS d,  array(toDate(now())) AS d_arr, " +
+                " toDateTime(now()) AS dt, array(toDateTime(now())) AS dt_arr";
+        try (ClickHouseConnection conn = newConnection(new Properties());
+                Statement stmt = conn.createStatement()) {
+            ResultSet rs = stmt.executeQuery(sql);
+            rs.next();
+
+            Assert.assertTrue(rs.getObject("d") instanceof java.sql.Date, "Expected java.sql.Date");
+            Assert.assertTrue(rs.getObject("dt") instanceof java.sql.Timestamp, "Expected java.sql.Timestamp");
+            Assert.assertTrue(rs.getObject("d_arr") instanceof java.sql.Date[], "Expected java.sql.Date[]");
+            Assert.assertTrue(rs.getObject("dt_arr") instanceof java.sql.Timestamp[], "Expected java.sql.Timestamp[]");
+
+            Assert.assertNotNull(rs.getTime("d"));
+            Assert.assertNotNull(rs.getTime("dt"));
+            Assert.assertTrue(rs.getArray("d_arr").getArray() instanceof java.sql.Date[], "Expected java.sql.Date[]");
+            Assert.assertTrue(rs.getArray("dt_arr").getArray() instanceof java.sql.Timestamp[], "Expected java.sql.Timestamp[]");
+
+
+            Assert.assertNotNull(rs.getObject("d", LocalDate.class), "Expected LocalDate");
+            Assert.assertNotNull(rs.getObject("dt", LocalDateTime.class), "Expected LocalDateTime");
+            Assert.assertNotNull(rs.getObject("d_arr", LocalDate[].class), "Expected LocalDate[]");
+            Assert.assertNotNull(rs.getObject("dt_arr", LocalDateTime[].class), "Expected LocalDateTime[]");
         }
     }
 }

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseStatementTest.java
@@ -26,6 +26,7 @@ import java.math.BigDecimal;
 import java.sql.Array;
 import java.sql.BatchUpdateException;
 import java.sql.Connection;
+import java.sql.Date;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
@@ -115,7 +116,7 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
                 Assert.assertTrue(rs.next());
                 Assert.assertEquals(rs.getString(1), "k");
                 ps.setString(1, rs.getString(1));
-                Object[] values = (Object[]) rs.getObject(2);
+                Object[] values = (Object[]) ((Array)rs.getObject(2)).getArray();
                 ps.setObject(2, values);
                 Assert.assertEquals(values.length, 4);
                 for (int i = 0; i < values.length; i++) {
@@ -250,7 +251,7 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getObject("ts", LocalDateTime.class), LocalDateTime.of(2021, 11, 1, 12, 34, 56));
             Assert.assertEquals(rs.getObject("t", LocalTime.class), LocalTime.of(12, 34, 56));
-            Assert.assertEquals(rs.getObject("d"), LocalDate.of(2021, 11, 1));
+            Assert.assertEquals(rs.getObject("d"), Date.valueOf(LocalDate.of(2021, 11, 1)));
             Assert.assertEquals(rs.getTime("t"), Time.valueOf(LocalTime.of(12, 34, 56)));
             Assert.assertFalse(rs.next());
         }
@@ -815,7 +816,7 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
             ResultSet rs = stmt.executeQuery(sql);
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getArray(1).getArray(), expectedArray);
-            Assert.assertEquals(rs.getObject(1), expectedArray);
+            Assert.assertEquals(rs.getObject(1, List.class), expectedArray);
             Assert.assertEquals(rs.getObject(2), expectedTuple);
             Assert.assertFalse(rs.next());
         }
@@ -904,12 +905,12 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
                 ClickHouseStatement stmt = conn.createStatement()) {
             ResultSet rs = stmt.executeQuery("select now(), now('Asia/Chongqing')");
             Assert.assertTrue(rs.next());
-            LocalDateTime dt1 = (LocalDateTime) rs.getObject(1);
+            Timestamp dt1 = (Timestamp) rs.getObject(1);
             LocalDateTime dt2 = rs.getObject(1, LocalDateTime.class);
-            Assert.assertTrue(dt1 == dt2);
-            OffsetDateTime ot1 = (OffsetDateTime) rs.getObject(2);
+            Assert.assertEquals(dt1.toLocalDateTime(), dt2);
+            Timestamp ot1 = (Timestamp) rs.getObject(2);
             OffsetDateTime ot2 = rs.getObject(2, OffsetDateTime.class);
-            Assert.assertTrue(ot1 == ot2);
+            Assert.assertEquals(ot1.toLocalDateTime(), ot2.toLocalDateTime());
             Assert.assertFalse(rs.next());
         }
 
@@ -925,8 +926,8 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
             ResultSet rs = stmt.executeQuery(sql);
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getObject(1),
-                    ZonedDateTime.ofInstant(Instant.ofEpochSecond(1616633456L), ZoneId.of(tz))
-                            .toLocalDateTime());
+                    Timestamp.valueOf(ZonedDateTime.ofInstant(Instant.ofEpochSecond(1616633456L), ZoneId.of(tz))
+                            .toLocalDateTime()));
             Assert.assertFalse(rs.next());
         }
     }
@@ -1033,14 +1034,14 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
             Assert.assertEquals(rs.getObject(index++), UnsignedInteger.ONE);
             Assert.assertEquals(rs.getObject(index++), 1L);
             Assert.assertEquals(rs.getObject(index++), UnsignedLong.ONE);
-            Assert.assertEquals(rs.getObject(index++), new byte[] { (byte) 1 });
-            Assert.assertEquals(rs.getObject(index++), new byte[] { (byte) 1 });
-            Assert.assertEquals(rs.getObject(index++), new short[] { (short) 1 });
-            Assert.assertEquals(rs.getObject(index++), new short[] { (short) 1 });
-            Assert.assertEquals(rs.getObject(index++), new int[] { 1 });
-            Assert.assertEquals(rs.getObject(index++), new int[] { 1 });
-            Assert.assertEquals(rs.getObject(index++), new long[] { 1L });
-            Assert.assertEquals(rs.getObject(index++), new long[] { 1L });
+            Assert.assertEquals(rs.getObject(index++, byte[].class), new byte[] { (byte) 1 });
+            Assert.assertEquals(rs.getObject(index++, byte[].class), new byte[] { (byte) 1 });
+            Assert.assertEquals(rs.getObject(index++, short[].class), new short[] { (short) 1 });
+            Assert.assertEquals(rs.getObject(index++, short[].class), new short[] { (short) 1 });
+            Assert.assertEquals(rs.getObject(index++, int[].class), new int[] { 1 });
+            Assert.assertEquals(rs.getObject(index++, int[].class), new int[] { 1 });
+            Assert.assertEquals(rs.getObject(index++, long[].class), new long[] { 1L });
+            Assert.assertEquals(rs.getObject(index++, long[].class), new long[] { 1L });
             Assert.assertFalse(rs.next());
         }
 
@@ -1059,14 +1060,14 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
             Assert.assertEquals(rs.getObject(index++), UnsignedInteger.ONE);
             Assert.assertEquals(rs.getObject(index++), 1L);
             Assert.assertEquals(rs.getObject(index++), UnsignedLong.ONE);
-            Assert.assertEquals(rs.getObject(index++), new byte[] { (byte) 1 });
-            Assert.assertEquals(rs.getObject(index++), new UnsignedByte[] { UnsignedByte.ONE });
-            Assert.assertEquals(rs.getObject(index++), new short[] { (short) 1 });
-            Assert.assertEquals(rs.getObject(index++), new UnsignedShort[] { UnsignedShort.ONE });
-            Assert.assertEquals(rs.getObject(index++), new int[] { 1 });
-            Assert.assertEquals(rs.getObject(index++), new UnsignedInteger[] { UnsignedInteger.ONE });
-            Assert.assertEquals(rs.getObject(index++), new Long[] { 1L });
-            Assert.assertEquals(rs.getObject(index++), new UnsignedLong[] { UnsignedLong.ONE });
+            Assert.assertEquals(rs.getObject(index++, byte[].class), new byte[] { (byte) 1 });
+            Assert.assertEquals(rs.getObject(index++, UnsignedByte[].class), new UnsignedByte[] { UnsignedByte.ONE });
+            Assert.assertEquals(rs.getObject(index++, short[].class), new short[] { (short) 1 });
+            Assert.assertEquals(rs.getObject(index++, UnsignedShort[].class), new UnsignedShort[] { UnsignedShort.ONE });
+            Assert.assertEquals(rs.getObject(index++, int[].class), new int[] { 1 });
+            Assert.assertEquals(rs.getObject(index++, UnsignedInteger[].class), new UnsignedInteger[] { UnsignedInteger.ONE });
+            Assert.assertEquals(rs.getObject(index++, Long[].class), new Long[] { 1L });
+            Assert.assertEquals(rs.getObject(index++, UnsignedLong[].class), new UnsignedLong[] { UnsignedLong.ONE });
             Assert.assertFalse(rs.next());
         }
 
@@ -1085,14 +1086,14 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
             Assert.assertEquals(rs.getObject(index++), UnsignedInteger.ONE);
             Assert.assertEquals(rs.getObject(index++), 1L);
             Assert.assertEquals(rs.getObject(index++), UnsignedLong.ONE);
-            Assert.assertEquals(rs.getObject(index++), new byte[] { (byte) 1 });
-            Assert.assertEquals(rs.getObject(index++), new byte[] { (byte) 1 });
-            Assert.assertEquals(rs.getObject(index++), new short[] { (short) 1 });
-            Assert.assertEquals(rs.getObject(index++), new short[] { (short) 1 });
-            Assert.assertEquals(rs.getObject(index++), new int[] { 1 });
-            Assert.assertEquals(rs.getObject(index++), new int[] { 1 });
-            Assert.assertEquals(rs.getObject(index++), new long[] { 1L });
-            Assert.assertEquals(rs.getObject(index++), new long[] { 1L });
+            Assert.assertEquals(rs.getObject(index++, byte[].class), new byte[] { (byte) 1 });
+            Assert.assertEquals(rs.getObject(index++, byte[].class), new byte[] { (byte) 1 });
+            Assert.assertEquals(rs.getObject(index++, short[].class), new short[] { (short) 1 });
+            Assert.assertEquals(rs.getObject(index++, short[].class), new short[] { (short) 1 });
+            Assert.assertEquals(rs.getObject(index++, int[].class), new int[] { 1 });
+            Assert.assertEquals(rs.getObject(index++, int[].class), new int[] { 1 });
+            Assert.assertEquals(rs.getObject(index++, long[].class), new long[] { 1L });
+            Assert.assertEquals(rs.getObject(index++, long[].class), new long[] { 1L });
             Assert.assertFalse(rs.next());
         }
     }
@@ -1139,23 +1140,24 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
             try (ResultSet rs = stmt.executeQuery("select * from test_nested_array_in_tuple order by id")) {
                 Assert.assertTrue(rs.next());
                 Assert.assertEquals(rs.getInt(1), 1);
-                Assert.assertEquals(((Object[]) rs.getObject(2)).length, 2);
-                Assert.assertEquals(((List<?>) ((Object[]) rs.getObject(2))[0]).size(), 2);
-                Assert.assertEquals(((List<?>) ((Object[]) rs.getObject(2))[0]).get(0), UnsignedShort.ZERO);
-                Assert.assertEquals(((List<?>) ((Object[]) rs.getObject(2))[0]).get(1), new int[] { 1, 2 });
-                Assert.assertEquals(((List<?>) ((Object[]) rs.getObject(2))[1]).size(), 2);
-                Assert.assertEquals(((List<?>) ((Object[]) rs.getObject(2))[1]).get(0), UnsignedShort.ONE);
-                Assert.assertEquals(((List<?>) ((Object[]) rs.getObject(2))[1]).get(1), new int[] { 2, 3 });
+                Array array = (Array)rs.getObject(2);
+                Assert.assertEquals(((Object[]) array.getArray()).length, 2);
+                Assert.assertEquals(((List<?>) ((Object[]) array.getArray())[0]).size(), 2);
+                Assert.assertEquals(((List<?>) ((Object[]) array.getArray())[0]).get(0), UnsignedShort.ZERO);
+                Assert.assertEquals(((List<?>) ((Object[]) array.getArray())[0]).get(1), new int[] { 1, 2 });
+                Assert.assertEquals(((List<?>) ((Object[]) array.getArray())[1]).size(), 2);
+                Assert.assertEquals(((List<?>) ((Object[]) array.getArray())[1]).get(0), UnsignedShort.ONE);
+                Assert.assertEquals(((List<?>) ((Object[]) array.getArray())[1]).get(1), new int[] { 2, 3 });
                 Assert.assertTrue(rs.next());
-                Assert.assertEquals(((Object[]) rs.getObject(2)).length, 2);
-                Assert.assertEquals(((List<?>) ((Object[]) rs.getObject(2))[0]).size(), 2);
-                Assert.assertEquals(((List<?>) ((Object[]) rs.getObject(2))[0]).get(0),
+                Assert.assertEquals(((Object[]) array.getArray()).length, 2);
+                Assert.assertEquals(((List<?>) ((Object[]) array.getArray())[0]).size(), 2);
+                Assert.assertEquals(((List<?>) ((Object[]) array.getArray())[0]).get(0),
                         UnsignedShort.valueOf((short) 2));
-                Assert.assertEquals(((List<?>) ((Object[]) rs.getObject(2))[0]).get(1), new int[] { 4, 5 });
-                Assert.assertEquals(((List<?>) ((Object[]) rs.getObject(2))[1]).size(), 2);
-                Assert.assertEquals(((List<?>) ((Object[]) rs.getObject(2))[1]).get(0),
+                Assert.assertEquals(((List<?>) ((Object[]) array.getArray())[0]).get(1), new int[] { 4, 5 });
+                Assert.assertEquals(((List<?>) ((Object[]) array.getArray())[1]).size(), 2);
+                Assert.assertEquals(((List<?>) ((Object[]) array.getArray())[1]).get(0),
                         UnsignedShort.valueOf((short) 3));
-                Assert.assertEquals(((List<?>) ((Object[]) rs.getObject(2))[1]).get(1), new int[] { 6, 7 });
+                Assert.assertEquals(((List<?>) ((Object[]) array.getArray())[1]).get(1), new int[] { 6, 7 });
                 Assert.assertFalse(rs.next());
             }
 
@@ -1165,34 +1167,35 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
             try (ResultSet rs = stmt.executeQuery("select * from test_nested_array_in_tuple order by id")) {
                 Assert.assertTrue(rs.next());
                 Assert.assertEquals(rs.getInt(1), 1);
-                Assert.assertEquals(((Object[]) rs.getObject(2)).length, 2);
-                Assert.assertEquals(((List<?>) ((Object[]) rs.getObject(2))[0]).size(), 2);
-                Assert.assertEquals(((List<?>) ((Object[]) rs.getObject(2))[0]).get(0), UnsignedShort.ZERO);
-                Assert.assertEquals(((BigDecimal[]) ((List<?>) ((Object[]) rs.getObject(2))[0]).get(1))[0],
+                Array array = (Array)rs.getObject(2);
+                Assert.assertEquals(((Object[]) array.getArray()).length, 2);
+                Assert.assertEquals(((List<?>) ((Object[]) array.getArray())[0]).size(), 2);
+                Assert.assertEquals(((List<?>) ((Object[]) array.getArray())[0]).get(0), UnsignedShort.ZERO);
+                Assert.assertEquals(((BigDecimal[]) ((List<?>) ((Object[]) array.getArray())[0]).get(1))[0],
                         BigDecimal.valueOf(1));
-                Assert.assertEquals(((BigDecimal[]) ((List<?>) ((Object[]) rs.getObject(2))[0]).get(1))[1],
+                Assert.assertEquals(((BigDecimal[]) ((List<?>) ((Object[]) array.getArray())[0]).get(1))[1],
                         BigDecimal.valueOf(2));
-                Assert.assertEquals(((List<?>) ((Object[]) rs.getObject(2))[1]).size(), 2);
-                Assert.assertEquals(((List<?>) ((Object[]) rs.getObject(2))[1]).get(0), UnsignedShort.ONE);
-                Assert.assertEquals(((BigDecimal[]) ((List<?>) ((Object[]) rs.getObject(2))[1]).get(1))[0],
+                Assert.assertEquals(((List<?>) ((Object[]) array.getArray())[1]).size(), 2);
+                Assert.assertEquals(((List<?>) ((Object[]) array.getArray())[1]).get(0), UnsignedShort.ONE);
+                Assert.assertEquals(((BigDecimal[]) ((List<?>) ((Object[]) array.getArray())[1]).get(1))[0],
                         BigDecimal.valueOf(2));
-                Assert.assertEquals(((BigDecimal[]) ((List<?>) ((Object[]) rs.getObject(2))[1]).get(1))[1],
+                Assert.assertEquals(((BigDecimal[]) ((List<?>) ((Object[]) array.getArray())[1]).get(1))[1],
                         BigDecimal.valueOf(3));
                 Assert.assertTrue(rs.next());
-                Assert.assertEquals(((Object[]) rs.getObject(2)).length, 2);
-                Assert.assertEquals(((List<?>) ((Object[]) rs.getObject(2))[0]).size(), 2);
-                Assert.assertEquals(((List<?>) ((Object[]) rs.getObject(2))[0]).get(0),
+                Assert.assertEquals(((Object[]) array.getArray()).length, 2);
+                Assert.assertEquals(((List<?>) ((Object[]) array.getArray())[0]).size(), 2);
+                Assert.assertEquals(((List<?>) ((Object[]) array.getArray())[0]).get(0),
                         UnsignedShort.valueOf((short) 2));
-                Assert.assertEquals(((BigDecimal[]) ((List<?>) ((Object[]) rs.getObject(2))[0]).get(1))[0],
+                Assert.assertEquals(((BigDecimal[]) ((List<?>) ((Object[]) array.getArray())[0]).get(1))[0],
                         BigDecimal.valueOf(4));
-                Assert.assertEquals(((BigDecimal[]) ((List<?>) ((Object[]) rs.getObject(2))[0]).get(1))[1],
+                Assert.assertEquals(((BigDecimal[]) ((List<?>) ((Object[]) array.getArray())[0]).get(1))[1],
                         BigDecimal.valueOf(5));
-                Assert.assertEquals(((List<?>) ((Object[]) rs.getObject(2))[1]).size(), 2);
-                Assert.assertEquals(((List<?>) ((Object[]) rs.getObject(2))[1]).get(0),
+                Assert.assertEquals(((List<?>) ((Object[]) array.getArray())[1]).size(), 2);
+                Assert.assertEquals(((List<?>) ((Object[]) array.getArray())[1]).get(0),
                         UnsignedShort.valueOf((short) 3));
-                Assert.assertEquals(((BigDecimal[]) ((List<?>) ((Object[]) rs.getObject(2))[1]).get(1))[0],
+                Assert.assertEquals(((BigDecimal[]) ((List<?>) ((Object[]) array.getArray())[1]).get(1))[0],
                         BigDecimal.valueOf(6));
-                Assert.assertEquals(((BigDecimal[]) ((List<?>) ((Object[]) rs.getObject(2))[1]).get(1))[1],
+                Assert.assertEquals(((BigDecimal[]) ((List<?>) ((Object[]) array.getArray())[1]).get(1))[1],
                         BigDecimal.valueOf(7));
                 Assert.assertFalse(rs.next());
             }
@@ -1211,16 +1214,17 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
                                 "select * from (select 1 id, [['1','2'],['3', '4']] v union all select 2 id, [['5','6'],['7','8']] v) order by id")) {
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getInt(1), 1);
-            Assert.assertEquals(rs.getObject(2), arr1 = (Object[][]) rs.getArray(2).getArray());
-            Assert.assertEquals(((Object[][]) rs.getObject(2)).length, 2);
-            Assert.assertEquals(((Object[][]) rs.getObject(2))[0], new Object[] { "1", "2" });
-            Assert.assertEquals(((Object[][]) rs.getObject(2))[1], new Object[] { "3", "4" });
+            Array array = (Array)rs.getObject(2);
+            Assert.assertEquals(array.getArray(), arr1 = (Object[][]) rs.getArray(2).getArray());
+            Assert.assertEquals(((Object[][]) array.getArray()).length, 2);
+            Assert.assertEquals(((Object[][]) array.getArray())[0], new Object[] { "1", "2" });
+            Assert.assertEquals(((Object[][]) array.getArray())[1], new Object[] { "3", "4" });
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getInt(1), 2);
-            Assert.assertEquals(rs.getObject(2), arr2 = (Object[][]) rs.getArray(2).getArray());
-            Assert.assertEquals(((Object[][]) rs.getObject(2)).length, 2);
-            Assert.assertEquals(((Object[][]) rs.getObject(2))[0], new Object[] { "5", "6" });
-            Assert.assertEquals(((Object[][]) rs.getObject(2))[1], new Object[] { "7", "8" });
+            Assert.assertEquals(array.getArray(), arr2 = (Object[][]) rs.getArray(2).getArray());
+            Assert.assertEquals(((Object[][]) array.getArray()).length, 2);
+            Assert.assertEquals(((Object[][]) array.getArray())[0], new Object[] { "5", "6" });
+            Assert.assertEquals(((Object[][]) array.getArray())[1], new Object[] { "7", "8" });
             Assert.assertFalse(rs.next());
         }
 
@@ -1238,7 +1242,7 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
             ResultSet rs = stmt.executeQuery(sql);
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getObject(1), Arrays.asList(UnsignedByte.ONE, UnsignedByte.valueOf((byte) 2)));
-            Assert.assertEquals(rs.getObject(2), new byte[] { (byte) 3, (byte) 4 });
+            Assert.assertEquals(rs.getObject(2, byte[].class), new byte[] { (byte) 3, (byte) 4 });
             Assert.assertFalse(rs.next());
         }
 
@@ -1248,7 +1252,7 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
             ResultSet rs = stmt.executeQuery(sql);
             Assert.assertTrue(rs.next());
             Assert.assertEquals(rs.getObject(1), Arrays.asList(UnsignedByte.ONE, UnsignedByte.valueOf((byte) 2)));
-            Assert.assertEquals(rs.getObject(2),
+            Assert.assertEquals(rs.getObject(2, UnsignedByte[].class),
                     new UnsignedByte[] { UnsignedByte.valueOf((byte) 3), UnsignedByte.valueOf((byte) 4) });
             Assert.assertFalse(rs.next());
         }
@@ -1259,8 +1263,8 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
                 ClickHouseStatement stmt = conn.createStatement()) {
             ResultSet rs = stmt.executeQuery(sql);
             Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getObject(1), Arrays.asList((short) 1, (short) 2));
-            Assert.assertEquals(rs.getObject(2), new short[] { (short) 3, (short) 4 });
+            Assert.assertEquals(rs.getObject(2, short[].class), new short[] { (short) 3, (short) 4 });
+            Assert.assertEquals(rs.getObject(1, List.class), Arrays.asList((short) 1, (short) 2));
             Assert.assertFalse(rs.next());
         }
 
@@ -1272,6 +1276,7 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
             Assert.assertTrue(rs.next());
             Assert.assertEquals(((ClickHouseStruct) rs.getObject(1)).getAttributes(),
                     new Object[] { UnsignedByte.ONE, UnsignedByte.valueOf((byte) 2) });
+            Assert.assertTrue(rs.getObject(2) instanceof Array);
             Assert.assertEquals(((ClickHouseArray) rs.getObject(2)).getArray(), rs.getArray(2).getArray());
             Assert.assertFalse(rs.next());
         }
@@ -1467,8 +1472,8 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
             ResultSet rs = stmt.executeQuery("select toDateTime('2024-01-01 10:00:00', 'America/Los_Angeles'), toDateTime('2024-05-01 10:00:00', " +
                     " 'America/Los_Angeles'), now() SETTINGS session_timezone = 'America/Los_Angeles'");
             rs.next();
-            OffsetDateTime dstStart = (OffsetDateTime) rs.getObject(1);
-            OffsetDateTime dstEnd = (OffsetDateTime) rs.getObject(2);
+            OffsetDateTime dstStart = rs.getObject(1, OffsetDateTime.class);
+            OffsetDateTime dstEnd = rs.getObject(2, OffsetDateTime.class);
             OffsetDateTime now = rs.getObject(3, OffsetDateTime.class);
             System.out.println("dstStart: " + dstStart + ", dstEnd: " + dstEnd + ", now: " + now);
             Assert.assertEquals(dstStart.getOffset(), ZoneOffset.ofHours(-8));


### PR DESCRIPTION
## Summary
JDBC defines what data types should be returned by default when `ResultSet#getObject()` is called. Today returned types do not match this schema and it breaks many external integrations.
This PR add conversion in JDBC driver to resolve the issue. It is important to not change java client itself, because it should operate as is and because it may break interfaces. 

Closes: https://github.com/ClickHouse/clickhouse-java/issues/1409

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
