### PR TITLE
[Client v2] insert settings ignored

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java
@@ -182,6 +182,11 @@ public enum ClickHouseClientOption implements ClickHouseOption {
      */
     FORMAT("format", ClickHouseDataConfig.DEFAULT_FORMAT, "Default format."),
     /**
+     * Token used to deduplicate insert query.
+     */
+    INSERT_DEDUPLICATION_TOKEN("insert_deduplication_token", "",
+        "Token used to deduplicate insert query, an empty token means no deduplication."),
+    /**
      * Whether to log leading comment(as log_comment in system.query_log) of the
      * query.
      */

--- a/client-v2/src/main/java/com/clickhouse/client/api/insert/InsertSettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/insert/InsertSettings.java
@@ -70,7 +70,7 @@ public class InsertSettings {
      * @return
      */
     public InsertSettings setDeduplicationToken(String token) {
-        rawSettings.put("insert_deduplication_token", token);
+        rawSettings.put(ClickHouseClientOption.INSERT_DEDUPLICATION_TOKEN.getKey(), token);
         return this;
     }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
@@ -449,6 +449,9 @@ public class HttpAPIClientHelper {
             if (requestConfig.containsKey(ClickHouseClientOption.QUERY_ID.getKey())) {
                 req.addParameter(ClickHouseHttpProto.QPARAM_QUERY_ID, requestConfig.get(ClickHouseClientOption.QUERY_ID.getKey()).toString());
             }
+            if (requestConfig.containsKey("insert_deduplication_token")){
+                req.addParameter("insert_deduplication_token", requestConfig.get("insert_deduplication_token").toString());
+            }
             if (requestConfig.containsKey("statement_params")) {
                 Map<String, Object> params = (Map<String, Object>) requestConfig.get("statement_params");
                 for (Map.Entry<String, Object> entry : params.entrySet()) {

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
@@ -449,8 +449,8 @@ public class HttpAPIClientHelper {
             if (requestConfig.containsKey(ClickHouseClientOption.QUERY_ID.getKey())) {
                 req.addParameter(ClickHouseHttpProto.QPARAM_QUERY_ID, requestConfig.get(ClickHouseClientOption.QUERY_ID.getKey()).toString());
             }
-            if (requestConfig.containsKey("insert_deduplication_token")){
-                req.addParameter("insert_deduplication_token", requestConfig.get("insert_deduplication_token").toString());
+            if (requestConfig.containsKey(ClickHouseClientOption.INSERT_DEDUPLICATION_TOKEN.getKey())){
+                req.addParameter("insert_deduplication_token", requestConfig.get(ClickHouseClientOption.INSERT_DEDUPLICATION_TOKEN.getKey()).toString());
             }
             if (requestConfig.containsKey("statement_params")) {
                 Map<String, Object> params = (Map<String, Object>) requestConfig.get("statement_params");

--- a/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
@@ -294,4 +294,31 @@ public class InsertTests extends BaseIntegrationTest {
         List<GenericRecord> records = client.queryAll("SELECT * FROM " + new_database + "." + tableName);
         assertEquals(records.size(), 1000);
     }
+
+    @Test(groups = { "integration" })
+    public void testInsertSettingsDeduplicationToken() throws Exception {
+        final String tableName = "insert_settings_database_test";
+        final String createTableSQL = "CREATE TABLE " + tableName + " ( A Int64 ) ENGINE = MergeTree ORDER BY A SETTINGS " +
+                                      "non_replicated_deduplication_window = 100";
+        final String deduplicationToken = RandomStringUtils.randomAlphabetic(36);
+
+        dropTable(tableName);
+        createTable(createTableSQL);
+
+        InsertSettings insertSettings = settings.setInputStreamCopyBufferSize(8198 * 2)
+            .setDeduplicationToken(deduplicationToken);
+
+        for (int i = 0; i < 3; ++i) {
+            ByteArrayOutputStream data = new ByteArrayOutputStream();
+            PrintWriter writer = new PrintWriter(data);
+            writer.printf("%d\n", i);
+            writer.flush();
+            InsertResponse response = client.insert(tableName, new ByteArrayInputStream(data.toByteArray()), ClickHouseFormat.TSV, insertSettings)
+                .get(30, TimeUnit.SECONDS);
+            response.close();
+        }
+
+        List<GenericRecord> records = client.queryAll("SELECT * FROM " + tableName);
+        assertEquals(records.size(), 1);
+    }
 }


### PR DESCRIPTION
## Summary
Add the support of the insert_deduplication_token in the client v2. Resolve #1877 

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
