### PR TITLE
[Client v2] illegal argument exception for tuple in array

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -559,6 +559,8 @@ public class BinaryStreamReader {
             try {
                 if (itemType.isArray()) {
                     array = Array.newInstance(ArrayValue.class, length);
+                } else if (itemType == List.class) {
+                    array = Array.newInstance(Object[].class, length);
                 } else {
                     array = Array.newInstance(itemType, length);
                 }


### PR DESCRIPTION
## Summary
When an tuple is nested inside an array an illegalArgumentException is returned when reading the value. This is related with the fact that Tuple are considered as a List from a ClickhouseDataType point of view, however tuples are read as Object[], thus when trying to create a ClickhouseArray, we try to insert a Object[] into a List[] which leads to this exception. 
This should resolve #1882 

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
