### PR TITLE
[jdbc] Enhance useragent to indicate Apache Spark

### DIFF
--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
@@ -53,7 +53,7 @@ public abstract class ClickHouseHttpConnection implements AutoCloseable {
     private static final byte[] SUFFIX_FORMAT = "_format\"\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
     private static final byte[] SUFFIX_STRUCTURE = "_structure\"\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
     private static final byte[] SUFFIX_FILENAME = "\"; filename=\"".getBytes(StandardCharsets.US_ASCII);
-    private static final List<String> FRAMEWORKS = List.of("apache.spark");
+    private static final List<String> FRAMEWORKS_TO_INFER = List.of("apache.spark");
 
     private static StringBuilder appendQueryParameter(StringBuilder builder, String key, String value) {
         return builder.append(urlEncode(key, StandardCharsets.UTF_8)).append('=')
@@ -414,7 +414,7 @@ public abstract class ClickHouseHttpConnection implements AutoCloseable {
     protected String getAdditionalFrameworkUserAgent() {
         Set<String> inferredFrameworks = new LinkedHashSet<>();
         for (StackTraceElement ste : Thread.currentThread().getStackTrace()) {
-            for (String framework : FRAMEWORKS) {
+            for (String framework : FRAMEWORKS_TO_INFER) {
                 if (ste.toString().contains(framework)) {
                     inferredFrameworks.add(String.format("(%s)", framework));
                 }

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
@@ -53,7 +53,6 @@ public abstract class ClickHouseHttpConnection implements AutoCloseable {
     private static final byte[] SUFFIX_FORMAT = "_format\"\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
     private static final byte[] SUFFIX_STRUCTURE = "_structure\"\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
     private static final byte[] SUFFIX_FILENAME = "\"; filename=\"".getBytes(StandardCharsets.US_ASCII);
-    private static final List<String> FRAMEWORKS_TO_INFER = List.of("apache.spark");
 
     private static StringBuilder appendQueryParameter(StringBuilder builder, String key, String value) {
         return builder.append(urlEncode(key, StandardCharsets.UTF_8)).append('=')
@@ -411,22 +410,10 @@ public abstract class ClickHouseHttpConnection implements AutoCloseable {
         return config.getClientName();
     }
 
-    protected String getAdditionalFrameworkUserAgent() {
-        Set<String> inferredFrameworks = new LinkedHashSet<>();
-        for (StackTraceElement ste : Thread.currentThread().getStackTrace()) {
-            for (String framework : FRAMEWORKS_TO_INFER) {
-                if (ste.toString().contains(framework)) {
-                    inferredFrameworks.add(String.format("(%s)", framework));
-                }
-            }
-        }
-        return String.join("; ", inferredFrameworks);
-    }
-
     protected final String getUserAgent() {
         final ClickHouseConfig c = config;
         String name = c.getClientName();
-        String userAgent = getDefaultUserAgent() + getAdditionalFrameworkUserAgent();
+        String userAgent = getDefaultUserAgent();
 
         if (!ClickHouseClientOption.CLIENT_NAME.getDefaultValue().equals(name)) {
             return name + " " + userAgent;

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
@@ -9,15 +9,8 @@ import java.net.Proxy;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Set;
 
 import com.clickhouse.client.ClickHouseClient;
 import com.clickhouse.client.ClickHouseConfig;
@@ -417,10 +410,23 @@ public abstract class ClickHouseHttpConnection implements AutoCloseable {
         return config.getClientName();
     }
 
+    protected String getAdditionalFrameworkUserAgent() {
+        List<String> frameworks = List.of("apache.spark");
+        Set<String> inferredFrameworks = new LinkedHashSet<>();
+        for (StackTraceElement ste : Thread.currentThread().getStackTrace()) {
+            for (String framework : frameworks) {
+                if (ste.toString().contains(framework)) {
+                    inferredFrameworks.add(String.format("(%s)", framework));
+                }
+            }
+        }
+        return String.join("; ", inferredFrameworks);
+    }
+
     protected final String getUserAgent() {
         final ClickHouseConfig c = config;
         String name = c.getClientName();
-        String userAgent = getDefaultUserAgent();
+        String userAgent = getDefaultUserAgent() + getAdditionalFrameworkUserAgent();
 
         if (!ClickHouseClientOption.CLIENT_NAME.getDefaultValue().equals(name)) {
             return name + " " + userAgent;

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
@@ -53,6 +53,7 @@ public abstract class ClickHouseHttpConnection implements AutoCloseable {
     private static final byte[] SUFFIX_FORMAT = "_format\"\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
     private static final byte[] SUFFIX_STRUCTURE = "_structure\"\r\n\r\n".getBytes(StandardCharsets.US_ASCII);
     private static final byte[] SUFFIX_FILENAME = "\"; filename=\"".getBytes(StandardCharsets.US_ASCII);
+    private static final List<String> FRAMEWORKS = List.of("apache.spark");
 
     private static StringBuilder appendQueryParameter(StringBuilder builder, String key, String value) {
         return builder.append(urlEncode(key, StandardCharsets.UTF_8)).append('=')
@@ -411,10 +412,9 @@ public abstract class ClickHouseHttpConnection implements AutoCloseable {
     }
 
     protected String getAdditionalFrameworkUserAgent() {
-        List<String> frameworks = List.of("apache.spark");
         Set<String> inferredFrameworks = new LinkedHashSet<>();
         for (StackTraceElement ste : Thread.currentThread().getStackTrace()) {
-            for (String framework : frameworks) {
+            for (String framework : FRAMEWORKS) {
                 if (ste.toString().contains(framework)) {
                     inferredFrameworks.add(String.format("(%s)", framework));
                 }

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDriver.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDriver.java
@@ -42,9 +42,9 @@ public class ClickHouseDriver implements Driver {
 
     static final java.util.logging.Logger parentLogger = java.util.logging.Logger.getLogger("com.clickhouse.jdbc");
 
-    static String frameworksDetected = null;
+    public static String frameworksDetected = null;
 
-    private static class FrameworksDetection {
+    public static class FrameworksDetection {
         private static final List<String> FRAMEWORKS_TO_DETECT = List.of("apache.spark");
         static volatile String frameworksDetected = null;
 
@@ -134,8 +134,6 @@ public class ClickHouseDriver implements Driver {
                 options.put(o, ClickHouseOption.fromString(e.getValue().toString(), o.getValueType()));
             }
         }
-        if (frameworksDetected != null)
-            options.put(ClickHouseClientOption.PRODUCT_NAME, frameworksDetected);
         return options;
     }
 
@@ -172,8 +170,6 @@ public class ClickHouseDriver implements Driver {
         if (!acceptsURL(url)) {
             return null;
         }
-        if (!url.toLowerCase().contains("disable-frameworks-detection"))
-            frameworksDetected = FrameworksDetection.getFrameworksDetected();
 
         log.debug("Creating connection");
         return new ClickHouseConnectionImpl(url, info);

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDriver.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDriver.java
@@ -6,14 +6,7 @@ import java.sql.DriverManager;
 import java.sql.DriverPropertyInfo;
 import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Properties;
-import java.util.ServiceLoader;
+import java.util.*;
 import java.util.Map.Entry;
 
 import com.clickhouse.client.ClickHouseClient;
@@ -48,6 +41,32 @@ public class ClickHouseDriver implements Driver {
     static final ClickHouseVersion specVersion;
 
     static final java.util.logging.Logger parentLogger = java.util.logging.Logger.getLogger("com.clickhouse.jdbc");
+
+    static String frameworksDetected = null;
+
+    private static class FrameworksDetection {
+        private static final List<String> FRAMEWORKS_TO_DETECT = List.of("apache.spark");
+        static volatile String frameworksDetected = null;
+
+        private FrameworksDetection() {
+        }
+        public static String getFrameworksDetected() {
+            if (frameworksDetected == null) {
+                Set<String> inferredFrameworks = new LinkedHashSet<>();
+                for (StackTraceElement ste : Thread.currentThread().getStackTrace()) {
+                    for (String framework : FRAMEWORKS_TO_DETECT) {
+                        if (ste.toString().contains(framework)) {
+                            inferredFrameworks.add(String.format("(%s)", framework));
+                        }
+                    }
+                }
+
+                frameworksDetected = String.join("; ", inferredFrameworks);
+            }
+            return frameworksDetected;
+        }
+
+    }
 
     static {
         String str = ClickHouseDriver.class.getPackage().getImplementationVersion();
@@ -115,7 +134,8 @@ public class ClickHouseDriver implements Driver {
                 options.put(o, ClickHouseOption.fromString(e.getValue().toString(), o.getValueType()));
             }
         }
-
+        if (frameworksDetected != null)
+            options.put(ClickHouseClientOption.PRODUCT_NAME, frameworksDetected);
         return options;
     }
 
@@ -128,7 +148,7 @@ public class ClickHouseDriver implements Driver {
 
         Class<?> clazz = option.getValueType();
         if (Boolean.class == clazz || boolean.class == clazz) {
-            propInfo.choices = new String[] { "true", "false" };
+            propInfo.choices = new String[]{"true", "false"};
         } else if (clazz.isEnum()) {
             Object[] values = clazz.getEnumConstants();
             String[] names = new String[values.length];
@@ -152,6 +172,8 @@ public class ClickHouseDriver implements Driver {
         if (!acceptsURL(url)) {
             return null;
         }
+        if (!url.toLowerCase().contains("disable-frameworks-detection"))
+            frameworksDetected = FrameworksDetection.getFrameworksDetected();
 
         log.debug("Creating connection");
         return new ClickHouseConnectionImpl(url, info);

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseConnectionImpl.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseConnectionImpl.java
@@ -291,7 +291,11 @@ public class ClickHouseConnectionImpl extends JdbcWrapper implements ClickHouseC
     public ClickHouseConnectionImpl(ConnectionInfo connInfo) throws SQLException {
         Properties props = connInfo.getProperties();
         jvmTimeZone = TimeZone.getDefault();
-
+        if (props.get("disable_frameworks_detection") == null || !props.get("disable_frameworks_detection").toString().equalsIgnoreCase("true")) {
+            ClickHouseDriver.frameworksDetected = ClickHouseDriver.FrameworksDetection.getFrameworksDetected();
+            if (ClickHouseDriver.frameworksDetected != null)
+                props.setProperty(ClickHouseClientOption.PRODUCT_NAME.getKey(), props.getProperty(ClickHouseClientOption.PRODUCT_NAME.getKey()) + ClickHouseDriver.frameworksDetected);
+        }
         ClickHouseClientBuilder clientBuilder = ClickHouseClient.builder()
                 .options(ClickHouseDriver.toClientOptions(props))
                 .defaultCredentials(connInfo.getDefaultCredentials());


### PR DESCRIPTION
Many users use Apache Spark (or any other framework) via this JDBC connector.
This PR adds "framework detecting" functionality. It looks at the current stack trace, infers the framework usage based on a closed list of tracked frameworks, and adds an indication for it in the user agent string.