### PR TITLE
[client-v1,client-v2, auth] Implemented authentication via http basic auth

### DIFF
--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
@@ -9,6 +9,7 @@ import java.net.Proxy;
 import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -38,6 +39,7 @@ import com.clickhouse.data.ClickHouseOutputStream;
 import com.clickhouse.data.ClickHouseUtils;
 import com.clickhouse.logging.Logger;
 import com.clickhouse.logging.LoggerFactory;
+import org.apache.hc.core5.http.HttpHeaders;
 
 public abstract class ClickHouseHttpConnection implements AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(ClickHouseHttpConnection.class);
@@ -238,11 +240,12 @@ public abstract class ClickHouseHttpConnection implements AutoCloseable {
             // TODO check if auth-scheme is available and supported
             map.put("authorization", credentials.getAccessToken());
         } else if (!hasAuthorizationHeader) {
-            map.put("x-clickhouse-user", credentials.getUserName());
             if (config.isSsl() && !ClickHouseChecker.isNullOrEmpty(config.getSslCert())) {
+                map.put("x-clickhouse-user", credentials.getUserName());
                 map.put("x-clickhouse-ssl-certificate-auth", "on");
             } else if (!ClickHouseChecker.isNullOrEmpty(credentials.getPassword())) {
-                map.put("x-clickhouse-key", credentials.getPassword());
+                map.put(HttpHeaders.AUTHORIZATION, "Basic " + Base64.getEncoder()
+                        .encodeToString((credentials.getUserName() + ":" + credentials.getPassword()).getBytes(StandardCharsets.UTF_8)));
             }
         }
 

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
@@ -243,9 +243,10 @@ public abstract class ClickHouseHttpConnection implements AutoCloseable {
             if (config.isSsl() && !ClickHouseChecker.isNullOrEmpty(config.getSslCert())) {
                 map.put("x-clickhouse-user", credentials.getUserName());
                 map.put("x-clickhouse-ssl-certificate-auth", "on");
-            } else if (!ClickHouseChecker.isNullOrEmpty(credentials.getPassword())) {
+            } else {
+                String password = credentials.getPassword() == null ? "" : credentials.getPassword();
                 map.put(HttpHeaders.AUTHORIZATION, "Basic " + Base64.getEncoder()
-                        .encodeToString((credentials.getUserName() + ":" + credentials.getPassword()).getBytes(StandardCharsets.UTF_8)));
+                        .encodeToString((credentials.getUserName() + ":" + password).getBytes(StandardCharsets.UTF_8)));
             }
         }
 

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpProto.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpProto.java
@@ -44,6 +44,10 @@ public class ClickHouseHttpProto {
      */
     public static final String HEADER_DB_USER = "X-ClickHouse-User";
 
+    /**
+     * Password of user to be used to authenticate. Note: header value should be unencoded, so using
+     * special characters might cause issues. It is recommended to use the Basic Authentication instead.
+     */
     public static final String HEADER_DB_PASSWORD = "X-ClickHouse-Key";
 
     public static final String HEADER_SSL_CERT_AUTH = "x-clickhouse-ssl-certificate-auth";

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/ClickHouseHttpOption.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/ClickHouseHttpOption.java
@@ -107,7 +107,13 @@ public enum ClickHouseHttpOption implements ClickHouseOption {
      */
     KEEP_ALIVE_TIMEOUT("alive_timeout", -1L,
             "Default keep-alive timeout in milliseconds."),
-    ;
+
+    /**
+     * Whether to use HTTP basic authentication. Default value is true.
+     * Password that contain UTF8 characters may not be passed through http headers and BASIC authentication
+     * is the only option here.
+     */
+    USE_BASIC_AUTHENTICATION("http_use_basic_auth", true, "Whether to use basic authentication.");
 
     private final String key;
     private final Serializable defaultValue;

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/AccessManagementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/AccessManagementTest.java
@@ -179,7 +179,7 @@ public class AccessManagementTest extends JdbcIntegrationTest {
 
     @Test(groups = "integration", dataProvider = "passwordAuthMethods")
     public void testPasswordAuthentication(String identifyWith, String identifyBy) throws SQLException {
-//        if (isCloud()) return; // TODO: testPasswordAuthentication - Revisit, see:
+        if (isCloud()) return; // Doesn’t allow to create users with specific passwords
         String url = String.format("jdbc:ch:%s", getEndpointString());
         Properties properties = new Properties();
         properties.setProperty(ClickHouseHttpOption.REMEMBER_LAST_SET_ROLES.getKey(), "true");
@@ -219,7 +219,7 @@ public class AccessManagementTest extends JdbcIntegrationTest {
 
     @Test(groups = "integration", dataProvider = "headerAuthDataProvider")
     public void testSwitchingBasicAuthToClickHouseHeaders(String identifyWith, String identifyBy, boolean shouldFail) throws SQLException {
-//        if (isCloud()) return; // TODO: testPasswordAuthentication - Revisit, see:
+        if (isCloud()) return; // Doesn't allow to create users with specific passwords
         String url = String.format("jdbc:ch:%s", getEndpointString());
         Properties properties = new Properties();
         properties.put(ClickHouseHttpOption.USE_BASIC_AUTHENTICATION.getKey(), false);

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/AccessManagementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/AccessManagementTest.java
@@ -176,4 +176,43 @@ public class AccessManagementTest extends JdbcIntegrationTest {
             Assert.fail("Failed to check roles", e);
         }
     }
+
+    @Test(groups = "integration", dataProvider = "passwordAuthMethods")
+    public void testPasswordAuthentication(String identifyWith, String identifyBy) throws SQLException {
+        if (isCloud()) return; // TODO: testPasswordAuthentication - Revisit, see:
+        String url = String.format("jdbc:ch:%s", getEndpointString());
+        Properties properties = new Properties();
+        properties.setProperty(ClickHouseHttpOption.REMEMBER_LAST_SET_ROLES.getKey(), "true");
+        ClickHouseDataSource dataSource = new ClickHouseDataSource(url, properties);
+
+        try (Connection connection = dataSource.getConnection("access_dba", "123")) {
+            Statement st = connection.createStatement();
+            st.execute("DROP USER IF EXISTS some_user");
+            st.execute("CREATE USER some_user IDENTIFIED WITH " + identifyWith + " BY '" + identifyBy + "'");
+        } catch (Exception e) {
+            Assert.fail("Failed on setup", e);
+        }
+
+        try (Connection connection = dataSource.getConnection("some_user", identifyBy)) {
+            Statement st = connection.createStatement();
+            ResultSet rs = st.executeQuery("SELECT 1");
+            Assert.assertTrue(rs.next());
+            Assert.assertEquals(rs.getInt(1), 1);
+        } catch (Exception e) {
+            Assert.fail("Failed to authenticate", e);
+        }
+    }
+
+    @DataProvider(name = "passwordAuthMethods")
+    private static Object[][] passwordAuthMethods() {
+        return new Object[][] {
+                { "plaintext_password", "password" },
+                { "plaintext_password", "S3Cr=?t"},
+                { "plaintext_password", "123§" },
+                { "sha256_password", "password" },
+                { "sha256_password", "123§" },
+                { "sha256_password", "S3Cr=?t"},
+                { "sha256_password", "S3Cr?=t"},
+        };
+    }
 }

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/AccessManagementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/AccessManagementTest.java
@@ -195,9 +195,9 @@ public class AccessManagementTest extends JdbcIntegrationTest {
 
         try (Connection connection = dataSource.getConnection("some_user", identifyBy)) {
             Statement st = connection.createStatement();
-            ResultSet rs = st.executeQuery("SELECT 1");
+            ResultSet rs = st.executeQuery("SELECT user() AS user_name");
             Assert.assertTrue(rs.next());
-            Assert.assertEquals(rs.getInt(1), 1);
+            Assert.assertEquals(rs.getString(1), "some_user");
         } catch (Exception e) {
             Assert.fail("Failed to authenticate", e);
         }
@@ -207,6 +207,7 @@ public class AccessManagementTest extends JdbcIntegrationTest {
     private static Object[][] passwordAuthMethods() {
         return new Object[][] {
                 { "plaintext_password", "password" },
+                { "plaintext_password", "" },
                 { "plaintext_password", "S3Cr=?t"},
                 { "plaintext_password", "123§" },
                 { "sha256_password", "password" },

--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -876,6 +876,16 @@ public class Client implements AutoCloseable {
             return this;
         }
 
+        /**
+         * Whether to use HTTP basic authentication. Default value is true.
+         * Password that contain UTF8 characters may not be passed through http headers and BASIC authentication
+         * is the only option here.
+         */
+        public Builder useHTTPBasicAuth(boolean useBasicAuth) {
+            this.configuration.put(ClientSettings.HTTP_USE_BASIC_AUTH, String.valueOf(useBasicAuth));
+            return this;
+        }
+
         public Client build() {
             setDefaults();
 
@@ -1008,6 +1018,10 @@ public class Client implements AutoCloseable {
 
             if (columnToMethodMatchingStrategy == null) {
                 columnToMethodMatchingStrategy = DefaultColumnToMethodMatchingStrategy.INSTANCE;
+            }
+
+            if (!configuration.containsKey(ClientSettings.HTTP_USE_BASIC_AUTH)) {
+                useHTTPBasicAuth(true);
             }
         }
     }

--- a/client-v2/src/main/java/com/clickhouse/client/api/ClientSettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/ClientSettings.java
@@ -37,4 +37,6 @@ public class ClientSettings {
     public static final String SESSION_DB_ROLES = "session_db_roles";
 
     public static final String SETTING_LOG_COMMENT = SERVER_SETTING_PREFIX + "log_comment";
+
+    public static final String HTTP_USE_BASIC_AUTH = "http_use_basic_auth";
 }

--- a/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
@@ -517,9 +517,7 @@ public class HttpTransportTests extends BaseIntegrationTest {
                 .setPassword(identifyBy)
                 .build()) {
 
-            try (QueryResponse resp = client.query("SELECT 1").get()) {
-                Assert.assertEquals(resp.getReadRows(), 1);
-            }
+            Assert.assertEquals(client.queryAll("SELECT user()").get(0).getString(1), "some_user");
         } catch (Exception e) {
             Assert.fail("Failed to authenticate", e);
         }
@@ -529,6 +527,7 @@ public class HttpTransportTests extends BaseIntegrationTest {
     public static Object[][] testPasswordAuthenticationProvider() {
         return new Object[][] {
                 { "plaintext_password", "password" },
+                { "plaintext_password", "" },
                 { "plaintext_password", "S3Cr=?t"},
                 { "plaintext_password", "123§" },
                 { "sha256_password", "password" },


### PR DESCRIPTION
## Summary
Password can be passed as value of the `X-ClickHouse-Key` header [docs](https://clickhouse.com/docs/en/interfaces/http#default-database). But header values have some limitations about what characters can be used (learned from practical tests and https://www.rfc-editor.org/rfc/rfc7230#section-3.2.6) what would require escaping special chars. Basic authentication helps to avoid all this and is standard authentication mechanism.
This PR changes both clients (v1, v2). 

New configuration parameter is added: 
- `com.clickhouse.client.http.config.ClickHouseHttpOption#USE_BASIC_AUTHENTICATION` - allows to switch using ClickHouse `X-` headers to authenticate. Default is using basic auth. 

Closes: https://github.com/ClickHouse/clickhouse-java/issues/1305

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
