### PR TITLE
[client-v2] Added documentation for OperationMetrics#completeOperation().

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/metrics/OperationMetrics.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/metrics/OperationMetrics.java
@@ -36,6 +36,11 @@ public class OperationMetrics {
         return queryId;
     }
 
+    /**
+     * Complete counting metrics on operation and stop all stopwatches.
+     * Multiple calls may have side effects.
+     * Note: should not be called by user code, except when created by user code.
+     */
     public void operationComplete() {
         for (Map.Entry<String, StopWatch> sw : clientStatistics.getStopWatches().entrySet()) {
             sw.getValue().stop();


### PR DESCRIPTION
## Summary
Added javadoc for `com.clickhouse.client.api.metrics.OperationMetrics#operationComplete` to warn about side effect if called multiple times.

See: https://github.com/ClickHouse/clickhouse-java/issues/1900

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
