### PR TITLE
[JDBC] Added removed dependency to shaded jar. Corrected jdbc example to verify

### DIFF
--- a/clickhouse-jdbc/pom.xml
+++ b/clickhouse-jdbc/pom.xml
@@ -302,6 +302,7 @@
                                     <include>com.clickhouse:clickhouse-http-client</include>
                                     <include>org.apache.httpcomponents.client5:httpclient5</include>
                                     <include>org.apache.httpcomponents.core5:httpcore5</include>
+                                    <include>org.apache.httpcomponents.core5:httpcore5-h2</include>
                                     <include>org.lz4:lz4-pure-java</include>
                                 </includes>
                             </artifactSet>

--- a/examples/jdbc/README.md
+++ b/examples/jdbc/README.md
@@ -18,5 +18,15 @@ To run simplified example:
  mvn exec:java -Dexec.mainClass="com.clickhouse.examples.jdbc.Basic"
 ```
 
+To run example with jdbc-all packaging (fat-jar):
+```shell
+ mvn -Pfatjar exec:java -Dexec.mainClass="com.clickhouse.examples.jdbc.Basic"
+```
+
+To run example with jdbc-shaded packaging:
+```shell
+ mvn -Pshaded exec:java -Dexec.mainClass="com.clickhouse.examples.jdbc.Basic"
+```
+
 Addition options can be passed to the application:
 - `-DchUrl` - ClickHouse JDBC URL. Default is `jdbc:clickhouse://localhost:8123/default`

--- a/examples/jdbc/pom.xml
+++ b/examples/jdbc/pom.xml
@@ -75,24 +75,53 @@
         <minJdk>1.8</minJdk>
     </properties>
 
+    <profiles>
+        <profile>
+            <id>http</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <dependencies>
+                <dependency>
+                    <groupId>com.clickhouse</groupId>
+                    <artifactId>clickhouse-jdbc</artifactId>
+                    <version>${clickhouse-java.version}</version>
+                    <classifier>http</classifier>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>shaded</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.clickhouse</groupId>
+                    <artifactId>clickhouse-jdbc</artifactId>
+                    <version>${clickhouse-java.version}</version>
+                    <classifier>shaded</classifier>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <profile>
+            <id>fatjar</id>
+            <dependencies>
+                <dependency>
+                    <groupId>com.clickhouse</groupId>
+                    <artifactId>clickhouse-jdbc</artifactId>
+                    <version>${clickhouse-java.version}</version>
+                    <classifier>all</classifier>
+                </dependency>
+            </dependencies>
+        </profile>
+
+    </profiles>
+
     <dependencies>
-        <dependency>
-            <groupId>com.clickhouse</groupId>
-            <artifactId>clickhouse-jdbc</artifactId>
-            <version>${clickhouse-java.version}</version>
-            <classifier>http</classifier>
-        </dependency>
         <dependency>
             <groupId>com.zaxxer</groupId>
             <artifactId>HikariCP</artifactId>
             <version>${hikaricp.version}</version>
-        </dependency>
-
-        <!-- Recommended to communicate with ClickHouse server over http -->
-        <dependency>
-            <groupId>org.apache.httpcomponents.client5</groupId>
-            <artifactId>httpclient5</artifactId>
-            <version>${apache-httpclient.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## Summary
There is a package classifier "http" with shaded AHC. While deprecation of some components one crucial dependency was removed that (surprise!) was used in base scenario. This PR returns this dependency and adds profiles to example so it can be verified. 

Closes: https://github.com/ClickHouse/clickhouse-java/issues/1912

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
