### PR TITLE
[CI] Adjusted release/nightly to use LTS or predefined CH_VERSION

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -13,6 +13,7 @@ on:
 env:
   CHC_BRANCH: "main"
   CHC_VERSION: "0.7.1"
+  CH_VERSION: "24.8"
 
 jobs:
   nightly:
@@ -66,7 +67,7 @@ jobs:
         uses: samuelmeuli/action-maven-publish@v1
         with:
           maven_profiles: release
-          maven_args: -q --batch-mode
+          maven_args: -q --batch-mode -DclickhouseVersion=${{ env.CH_VERSION }}
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
           nexus_username: ${{ secrets.SONATYPE_TOKEN_USER }}
@@ -76,7 +77,7 @@ jobs:
         with:
           directory: clickhouse-r2dbc
           maven_profiles: release
-          maven_args: -q --batch-mode -Dr2dbc-spi.version=0.9.1.RELEASE
+          maven_args: -q --batch-mode -Dr2dbc-spi.version=0.9.1.RELEASE -DclickhouseVersion=${{ env.CH_VERSION }}
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
           nexus_username: ${{ secrets.SONATYPE_TOKEN_USER }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
         required: true
         default: "0.7.1-SNAPSHOT"
 
+env:
+  CH_VERSION: "24.8"
+
 jobs:
   release:
     name: "Build and Publish Artifact"
@@ -54,7 +57,7 @@ jobs:
         uses: samuelmeuli/action-maven-publish@v1
         with:
           maven_profiles: release
-          maven_args: -q --batch-mode
+          maven_args: -q --batch-mode -DclickhouseVersion=${{ env.CH_VERSION }}
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
           nexus_username: ${{ secrets.SONATYPE_TOKEN_USER }}
@@ -64,7 +67,7 @@ jobs:
         with:
           directory: clickhouse-r2dbc
           maven_profiles: release
-          maven_args: -q --batch-mode -Dr2dbc-spi.version=0.9.1.RELEASE
+          maven_args: -q --batch-mode -Dr2dbc-spi.version=0.9.1.RELEASE -DclickhouseVersion=${{ env.CH_VERSION }}
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg_passphrase: ${{ secrets.GPG_PASSPHRASE }}
           nexus_username: ${{ secrets.SONATYPE_TOKEN_USER }}


### PR DESCRIPTION
## Summary
Release and Nightly use latest CH version, what may have some  issues. It is more reasonable to test against LTS versions.
This PR changes current behavior to run release build with LTS version. 

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
