### PR TITLE
[client-v2] Remove dependencies on old projects 

### DIFF
--- a/client-v2/docs/dependencies.md
+++ b/client-v2/docs/dependencies.md
@@ -1,0 +1,19 @@
+# Module Dependencies
+
+## Abstract
+This document describes module dependencies and a reason for their existence. Additionally 
+the document keeps historical information about the dependencies.
+
+## Dependencies
+
+### 0.7.1-patch1
+
+ - `com.clickhouse:clickhouse-data:jar:0.7.1-patch1-SNAPSHOT:compile` - Required for reading custom data types. When client-v1 required classes should be moved to client-v2 module this dependency will be removed.
+ - `com.clickhouse:clickhouse-client:jar:0.7.1-patch1-SNAPSHOT:compile` - Required because there is an option to use client-v1. Additionally, this dependency is required because a few core classes like `ClickHouseNode` are used in client-v2. When client-v1 is deprecated - all required classes should be moved to client-v2 module and this dependency will be removed.
+ - `org.slf4j:slf4j-api:jar:2.0.7:compile` - Most commonly used logging frontend. 
+ - `org.apache.commons:commons-compress:jar:1.27.1:compile` - Required for compression. 
+ - `org.lz4:lz4-pure-java:jar:1.8.0:compile` - Required for compression.
+ - `org.ow2.asm:asm:jar:9.7:compile` - Required for serialization/deserialization.
+ - `org.apache.httpcomponents.client5:httpclient5:jar:5.3.1:compile` - only HTTP client that is currently supported. In the future it should be an optional dependency when support for different clients will be added. This client also implements async API that might be used in the future.
+ - `com.fasterxml.jackson.core:jackson-core:jar:2.17.2:compile` - used to safely parse summary from ClickHouse.
+ - `org.roaringbitmap:RoaringBitmap:jar:0.9.47:compile` - used for serialization/deserialization of aggregate functions. For some reason `clickhouse-data` modules has this dependency as `provided`. 

--- a/client-v2/pom.xml
+++ b/client-v2/pom.xml
@@ -26,11 +26,7 @@
             <artifactId>clickhouse-client</artifactId>
             <version>${revision}</version>
         </dependency>
-        <dependency>
-            <groupId>${project.parent.groupId}</groupId>
-            <artifactId>clickhouse-http-client</artifactId>
-            <version>${revision}</version>
-        </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
@@ -68,6 +64,12 @@
         </dependency>
 
         <!-- Test Dependencies -->
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
+            <artifactId>clickhouse-http-client</artifactId>
+            <version>${revision}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
             <artifactId>gson</artifactId>

--- a/client-v2/pom.xml
+++ b/client-v2/pom.xml
@@ -23,6 +23,18 @@
     <dependencies>
         <dependency>
             <groupId>${project.parent.groupId}</groupId>
+            <artifactId>clickhouse-data</artifactId>
+            <version>${revision}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.roaringbitmap</groupId>
+            <artifactId>RoaringBitmap</artifactId>
+            <version>${roaring-bitmap.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>${project.parent.groupId}</groupId>
             <artifactId>clickhouse-client</artifactId>
             <version>${revision}</version>
         </dependency>
@@ -37,26 +49,25 @@
             <artifactId>httpclient5</artifactId>
             <version>${apache.httpclient.version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.github.luben</groupId>
-            <artifactId>zstd-jni</artifactId>
-            <optional>true</optional>
-        </dependency>
+
         <dependency>
             <groupId>org.lz4</groupId>
             <artifactId>lz4-pure-java</artifactId>
             <version>${lz4.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-compress</artifactId>
             <version>${compress.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
             <version>9.7</version>
         </dependency>
+
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
@@ -82,12 +93,6 @@
             <artifactId>jackson-databind</artifactId>
             <scope>test</scope>
             <version>2.17.2</version>
-        </dependency>
-        <!-- necessary for Java 9+ -->
-        <dependency>
-            <groupId>org.apache.tomcat</groupId>
-            <artifactId>annotations-api</artifactId>
-            <scope>provided</scope>
         </dependency>
 
         <!-- Test dependencies -->
@@ -121,18 +126,14 @@
             <version>${testng.version}</version>
             <scope>test</scope>
         </dependency>
-        <!-- Replace with newer version as soon java 11 is minimal version -->
+
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-jre8</artifactId>
             <version>2.35.2</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.roaringbitmap</groupId>
-            <artifactId>RoaringBitmap</artifactId>
-            <scope>test</scope>
-        </dependency>
+
     </dependencies>
 
     <build>

--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -18,6 +18,7 @@ import com.clickhouse.client.api.data_formats.internal.ProcessParser;
 import com.clickhouse.client.api.data_formats.internal.SerializerUtils;
 import com.clickhouse.client.api.enums.Protocol;
 import com.clickhouse.client.api.enums.ProxyType;
+import com.clickhouse.client.api.http.ClickHouseHttpProto;
 import com.clickhouse.client.api.insert.DataSerializationException;
 import com.clickhouse.client.api.insert.InsertResponse;
 import com.clickhouse.client.api.insert.InsertSettings;
@@ -42,8 +43,6 @@ import com.clickhouse.client.api.query.QuerySettings;
 import com.clickhouse.client.api.query.Records;
 import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.client.config.ClickHouseDefaults;
-import com.clickhouse.client.http.ClickHouseHttpProto;
-import com.clickhouse.client.http.config.ClickHouseHttpOption;
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseDataType;
 import com.clickhouse.data.ClickHouseFormat;
@@ -389,7 +388,7 @@ public class Client implements AutoCloseable {
          * @param maxConnections - maximum number of connections
          */
         public Builder setMaxConnections(int maxConnections) {
-            this.configuration.put(ClickHouseHttpOption.MAX_OPEN_CONNECTIONS.getKey(), String.valueOf(maxConnections));
+            this.configuration.put(ClientSettings.HTTP_MAX_OPEN_CONNECTIONS, String.valueOf(maxConnections));
             return this;
         }
 
@@ -416,7 +415,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setKeepAliveTimeout(long timeout, ChronoUnit unit) {
-            this.configuration.put(ClickHouseHttpOption.KEEP_ALIVE_TIMEOUT.getKey(), String.valueOf(Duration.of(timeout, unit).toMillis()));
+            this.configuration.put(ClientSettings.HTTP_KEEP_ALIVE_TIMEOUT, String.valueOf(Duration.of(timeout, unit).toMillis()));
             return this;
         }
 
@@ -980,7 +979,7 @@ public class Client implements AutoCloseable {
                 useAsyncRequests(false);
             }
 
-            if (!configuration.containsKey(ClickHouseHttpOption.MAX_OPEN_CONNECTIONS.getKey())) {
+            if (!configuration.containsKey(ClientSettings.HTTP_MAX_OPEN_CONNECTIONS)) {
                 setMaxConnections(10);
             }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -159,7 +159,7 @@ public class Client implements AutoCloseable {
         this.serializers = new ConcurrentHashMap<>();
         this.deserializers = new ConcurrentHashMap<>();
 
-        boolean isAsyncEnabled = MapUtils.getFlag(this.configuration, ClientConfigProperties.ASYNC_OPERATIONS, false);
+        boolean isAsyncEnabled = MapUtils.getFlag(this.configuration, ClientConfigProperties.ASYNC_OPERATIONS.getKey(), false);
         if (isAsyncEnabled && sharedOperationExecutor == null) {
             this.sharedOperationExecutor = Executors.newCachedThreadPool(new DefaultThreadFactory("chc-operation"));
         } else {
@@ -300,7 +300,7 @@ public class Client implements AutoCloseable {
          * @param username - a valid username
          */
         public Builder setUsername(String username) {
-            this.configuration.put("user", username);
+            this.configuration.put(ClientConfigProperties.USER.getKey(), username);
             return this;
         }
 
@@ -311,7 +311,7 @@ public class Client implements AutoCloseable {
          * @param password - plain text password
          */
         public Builder setPassword(String password) {
-            this.configuration.put("password", password);
+            this.configuration.put(ClientConfigProperties.PASSWORD.getKey(), password);
             return this;
         }
 
@@ -322,7 +322,7 @@ public class Client implements AutoCloseable {
          * @param accessToken - plain text access token
          */
         public Builder setAccessToken(String accessToken) {
-            this.configuration.put("access_token", accessToken);
+            this.configuration.put(ClientConfigProperties.ACCESS_TOKEN.getKey(), accessToken);
             return this;
         }
 
@@ -333,7 +333,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder useSSLAuthentication(boolean useSSLAuthentication) {
-            this.configuration.put("ssl_authentication", String.valueOf(useSSLAuthentication));
+            this.configuration.put(ClientConfigProperties.SSL_AUTH.getKey(), String.valueOf(useSSLAuthentication));
             return this;
         }
 
@@ -343,7 +343,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder enableConnectionPool(boolean enable) {
-            this.configuration.put("connection_pool_enabled", String.valueOf(enable));
+            this.configuration.put(ClientConfigProperties.CONNECTION_POOL_ENABLED.getKey(), String.valueOf(enable));
             return this;
         }
 
@@ -353,7 +353,7 @@ public class Client implements AutoCloseable {
          * @param timeout - connection timeout in milliseconds
          */
         public Builder setConnectTimeout(long timeout) {
-            this.configuration.put("connect_timeout", String.valueOf(timeout));
+            this.configuration.put(ClientConfigProperties.CONNECTION_TIMEOUT.getKey(), String.valueOf(timeout));
             return this;
         }
 
@@ -375,7 +375,7 @@ public class Client implements AutoCloseable {
          * @param unit - time unit
          */
         public Builder setConnectionRequestTimeout(long timeout, ChronoUnit unit) {
-            this.configuration.put("connection_request_timeout", String.valueOf(Duration.of(timeout, unit).toMillis()));
+            this.configuration.put(ClientConfigProperties.CONNECTION_REQUEST_TIMEOUT.getKey(), String.valueOf(Duration.of(timeout, unit).toMillis()));
             return this;
         }
 
@@ -388,7 +388,7 @@ public class Client implements AutoCloseable {
          * @param maxConnections - maximum number of connections
          */
         public Builder setMaxConnections(int maxConnections) {
-            this.configuration.put(ClientConfigProperties.HTTP_MAX_OPEN_CONNECTIONS, String.valueOf(maxConnections));
+            this.configuration.put(ClientConfigProperties.HTTP_MAX_OPEN_CONNECTIONS.getKey(), String.valueOf(maxConnections));
             return this;
         }
 
@@ -401,7 +401,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setConnectionTTL(long timeout, ChronoUnit unit) {
-            this.configuration.put(ClientConfigProperties.CONNECTION_TTL, String.valueOf(Duration.of(timeout, unit).toMillis()));
+            this.configuration.put(ClientConfigProperties.CONNECTION_TTL.getKey(), String.valueOf(Duration.of(timeout, unit).toMillis()));
             return this;
         }
 
@@ -415,7 +415,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setKeepAliveTimeout(long timeout, ChronoUnit unit) {
-            this.configuration.put(ClientConfigProperties.HTTP_KEEP_ALIVE_TIMEOUT, String.valueOf(Duration.of(timeout, unit).toMillis()));
+            this.configuration.put(ClientConfigProperties.HTTP_KEEP_ALIVE_TIMEOUT.getKey(), String.valueOf(Duration.of(timeout, unit).toMillis()));
             return this;
         }
 
@@ -427,7 +427,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setConnectionReuseStrategy(ConnectionReuseStrategy strategy) {
-            this.configuration.put(ClientConfigProperties.CONNECTION_REUSE_STRATEGY, strategy.name());
+            this.configuration.put(ClientConfigProperties.CONNECTION_REUSE_STRATEGY.getKey(), strategy.name());
             return this;
         }
 
@@ -439,7 +439,7 @@ public class Client implements AutoCloseable {
          * @param timeout - socket timeout in milliseconds
          */
         public Builder setSocketTimeout(long timeout) {
-            this.configuration.put(ClientConfigProperties.SOCKET_OPERATION_TIMEOUT, String.valueOf(timeout));
+            this.configuration.put(ClientConfigProperties.SOCKET_OPERATION_TIMEOUT.getKey(), String.valueOf(timeout));
             return this;
         }
 
@@ -459,7 +459,7 @@ public class Client implements AutoCloseable {
          * @param size - socket receive buffer size in bytes
          */
         public Builder setSocketRcvbuf(long size) {
-            this.configuration.put(ClientConfigProperties.SOCKET_RCVBUF_OPT, String.valueOf(size));
+            this.configuration.put(ClientConfigProperties.SOCKET_RCVBUF_OPT.getKey(), String.valueOf(size));
             return this;
         }
 
@@ -469,7 +469,7 @@ public class Client implements AutoCloseable {
          * @param size - socket send buffer size in bytes
          */
         public Builder setSocketSndbuf(long size) {
-            this.configuration.put(ClientConfigProperties.SOCKET_RCVBUF_OPT, String.valueOf(size));
+            this.configuration.put(ClientConfigProperties.SOCKET_RCVBUF_OPT.getKey(), String.valueOf(size));
             return this;
         }
 
@@ -479,7 +479,7 @@ public class Client implements AutoCloseable {
          * @param value - socket reuse address option
          */
         public Builder setSocketReuseAddress(boolean value) {
-            this.configuration.put(ClientConfigProperties.SOCKET_REUSEADDR_OPT, String.valueOf(value));
+            this.configuration.put(ClientConfigProperties.SOCKET_REUSEADDR_OPT.getKey(), String.valueOf(value));
             return this;
         }
 
@@ -490,7 +490,7 @@ public class Client implements AutoCloseable {
          * @param value - socket keep alive option
          */
         public Builder setSocketKeepAlive(boolean value) {
-            this.configuration.put(ClientConfigProperties.SOCKET_KEEPALIVE_OPT, String.valueOf(value));
+            this.configuration.put(ClientConfigProperties.SOCKET_KEEPALIVE_OPT.getKey(), String.valueOf(value));
             return this;
         }
 
@@ -500,7 +500,7 @@ public class Client implements AutoCloseable {
          * @param value - socket tcp no delay option
          */
         public Builder setSocketTcpNodelay(boolean value) {
-            this.configuration.put(ClientConfigProperties.SOCKET_TCP_NO_DELAY_OPT, String.valueOf(value));
+            this.configuration.put(ClientConfigProperties.SOCKET_TCP_NO_DELAY_OPT.getKey(), String.valueOf(value));
             return this;
         }
 
@@ -510,7 +510,7 @@ public class Client implements AutoCloseable {
          * @param secondsToWait - socket linger time in seconds
          */
         public Builder setSocketLinger(int secondsToWait) {
-            this.configuration.put(ClientConfigProperties.SOCKET_LINGER_OPT, String.valueOf(secondsToWait));
+            this.configuration.put(ClientConfigProperties.SOCKET_LINGER_OPT.getKey(), String.valueOf(secondsToWait));
             return this;
         }
 
@@ -521,7 +521,7 @@ public class Client implements AutoCloseable {
          * @param enabled - indicates if server response compression is enabled
          */
         public Builder compressServerResponse(boolean enabled) {
-            this.configuration.put(ClientConfigProperties.COMPRESS_SERVER_RESPONSE, String.valueOf(enabled));
+            this.configuration.put(ClientConfigProperties.COMPRESS_SERVER_RESPONSE.getKey(), String.valueOf(enabled));
             return this;
         }
 
@@ -532,7 +532,7 @@ public class Client implements AutoCloseable {
          * @param enabled - indicates if client request compression is enabled
          */
         public Builder compressClientRequest(boolean enabled) {
-            this.configuration.put(ClientConfigProperties.COMPRESS_CLIENT_REQUEST, String.valueOf(enabled));
+            this.configuration.put(ClientConfigProperties.COMPRESS_CLIENT_REQUEST.getKey(), String.valueOf(enabled));
             return this;
         }
 
@@ -545,7 +545,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder useHttpCompression(boolean enabled) {
-            this.configuration.put(ClientConfigProperties.USE_HTTP_COMPRESSION, String.valueOf(enabled));
+            this.configuration.put(ClientConfigProperties.USE_HTTP_COMPRESSION.getKey(), String.valueOf(enabled));
             return this;
         }
 
@@ -558,7 +558,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setLZ4UncompressedBufferSize(int size) {
-            this.configuration.put(ClientConfigProperties.COMPRESSION_LZ4_UNCOMPRESSED_BUF_SIZE, String.valueOf(size));
+            this.configuration.put(ClientConfigProperties.COMPRESSION_LZ4_UNCOMPRESSED_BUF_SIZE.getKey(), String.valueOf(size));
             return this;
         }
 
@@ -567,7 +567,7 @@ public class Client implements AutoCloseable {
          * @param database - actual default database name.
          */
         public Builder setDefaultDatabase(String database) {
-            this.configuration.put(ClientConfigProperties.DATABASE, database);
+            this.configuration.put(ClientConfigProperties.DATABASE.getKey(), database);
             return this;
         }
 
@@ -576,9 +576,9 @@ public class Client implements AutoCloseable {
             ValidationUtils.checkNonBlank(host, "host");
             ValidationUtils.checkRange(port, 1, ValidationUtils.TCP_PORT_NUMBER_MAX, "port");
 
-            this.configuration.put(ClientConfigProperties.PROXY_TYPE, type.name());
-            this.configuration.put(ClientConfigProperties.PROXY_HOST, host);
-            this.configuration.put(ClientConfigProperties.PROXY_PORT, String.valueOf(port));
+            this.configuration.put(ClientConfigProperties.PROXY_TYPE.getKey(), type.name());
+            this.configuration.put(ClientConfigProperties.PROXY_HOST.getKey(), host);
+            this.configuration.put(ClientConfigProperties.PROXY_PORT.getKey(), String.valueOf(port));
             return this;
         }
 
@@ -595,7 +595,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setExecutionTimeout(long timeout, ChronoUnit timeUnit) {
-            this.configuration.put(ClientConfigProperties.MAX_EXECUTION_TIME, String.valueOf(Duration.of(timeout, timeUnit).toMillis()));
+            this.configuration.put(ClientConfigProperties.MAX_EXECUTION_TIME.getKey(), String.valueOf(Duration.of(timeout, timeUnit).toMillis()));
             return this;
         }
 
@@ -623,7 +623,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setSSLTrustStore(String path) {
-            this.configuration.put(ClientConfigProperties.SSL_TRUST_STORE, path);
+            this.configuration.put(ClientConfigProperties.SSL_TRUST_STORE.getKey(), path);
             return this;
         }
 
@@ -634,7 +634,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setSSLTrustStorePassword(String password) {
-            this.configuration.put(ClientConfigProperties.SSL_KEY_STORE_PASSWORD, password);
+            this.configuration.put(ClientConfigProperties.SSL_KEY_STORE_PASSWORD.getKey(), password);
             return this;
         }
 
@@ -645,7 +645,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setSSLTrustStoreType(String type) {
-            this.configuration.put(ClientConfigProperties.SSL_KEYSTORE_TYPE, type);
+            this.configuration.put(ClientConfigProperties.SSL_KEYSTORE_TYPE.getKey(), type);
             return this;
         }
 
@@ -658,7 +658,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setRootCertificate(String path) {
-            this.configuration.put(ClientConfigProperties.CA_CERTIFICATE, path);
+            this.configuration.put(ClientConfigProperties.CA_CERTIFICATE.getKey(), path);
             return this;
         }
 
@@ -668,7 +668,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setClientCertificate(String path) {
-            this.configuration.put(ClientConfigProperties.SSL_CERTIFICATE, path);
+            this.configuration.put(ClientConfigProperties.SSL_CERTIFICATE.getKey(), path);
             return this;
         }
 
@@ -678,7 +678,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setClientKey(String path) {
-            this.configuration.put(ClientConfigProperties.SSL_KEY, path);
+            this.configuration.put(ClientConfigProperties.SSL_KEY.getKey(), path);
             return this;
         }
 
@@ -690,7 +690,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder useServerTimeZone(boolean useServerTimeZone) {
-            this.configuration.put(ClientConfigProperties.USE_SERVER_TIMEZONE, String.valueOf(useServerTimeZone));
+            this.configuration.put(ClientConfigProperties.USE_SERVER_TIMEZONE.getKey(), String.valueOf(useServerTimeZone));
             return this;
         }
 
@@ -702,7 +702,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder useTimeZone(String timeZone) {
-            this.configuration.put(ClientConfigProperties.USE_TIMEZONE, timeZone);
+            this.configuration.put(ClientConfigProperties.USE_TIMEZONE.getKey(), timeZone);
             return this;
         }
 
@@ -713,7 +713,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setServerTimeZone(String timeZone) {
-            this.configuration.put(ClientConfigProperties.SERVER_TIMEZONE, timeZone);
+            this.configuration.put(ClientConfigProperties.SERVER_TIMEZONE.getKey(), timeZone);
             return this;
         }
 
@@ -729,7 +729,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder useAsyncRequests(boolean async) {
-            this.configuration.put(ClientConfigProperties.ASYNC_OPERATIONS, String.valueOf(async));
+            this.configuration.put(ClientConfigProperties.ASYNC_OPERATIONS.getKey(), String.valueOf(async));
             return this;
         }
 
@@ -754,7 +754,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setClientNetworkBufferSize(int size) {
-            this.configuration.put(ClientConfigProperties.CLIENT_NETWORK_BUFFER_SIZE, String.valueOf(size));
+            this.configuration.put(ClientConfigProperties.CLIENT_NETWORK_BUFFER_SIZE.getKey(), String.valueOf(size));
             return this;
         }
 
@@ -772,12 +772,12 @@ public class Client implements AutoCloseable {
             for (ClientFaultCause cause : causes) {
                 joiner.add(cause.name());
             }
-            this.configuration.put("client_retry_on_failures", joiner.toString());
+            this.configuration.put(ClientConfigProperties.CLIENT_RETRY_ON_FAILURE.getKey(), joiner.toString());
             return this;
         }
 
         public Builder setMaxRetries(int maxRetries) {
-            this.configuration.put(ClientConfigProperties.RETRY_ON_FAILURE, String.valueOf(maxRetries));
+            this.configuration.put(ClientConfigProperties.RETRY_ON_FAILURE.getKey(), String.valueOf(maxRetries));
             return this;
         }
 
@@ -881,9 +881,10 @@ public class Client implements AutoCloseable {
          * is the only option here.
          */
         public Builder useHTTPBasicAuth(boolean useBasicAuth) {
-            this.configuration.put(ClientConfigProperties.HTTP_USE_BASIC_AUTH, String.valueOf(useBasicAuth));
+            this.configuration.put(ClientConfigProperties.HTTP_USE_BASIC_AUTH.getKey(), String.valueOf(useBasicAuth));
             return this;
         }
+
 
         public Client build() {
             setDefaults();
@@ -905,19 +906,19 @@ public class Client implements AutoCloseable {
             }
 
             if (this.configuration.containsKey("ssl_authentication") &&
-                !this.configuration.containsKey(ClientConfigProperties.SSL_CERTIFICATE)) {
+                !this.configuration.containsKey(ClientConfigProperties.SSL_CERTIFICATE.getKey())) {
                 throw new IllegalArgumentException("SSL authentication requires a client certificate");
             }
 
-            if (this.configuration.containsKey(ClientConfigProperties.SSL_TRUST_STORE) &&
-                this.configuration.containsKey(ClientConfigProperties.SSL_CERTIFICATE)) {
+            if (this.configuration.containsKey(ClientConfigProperties.SSL_TRUST_STORE.getKey()) &&
+                this.configuration.containsKey(ClientConfigProperties.SSL_CERTIFICATE.getKey())) {
                 throw new IllegalArgumentException("Trust store and certificates cannot be used together");
             }
 
             // Check timezone settings
-            String useTimeZoneValue = this.configuration.get(ClientConfigProperties.USE_TIMEZONE);
-            String serverTimeZoneValue = this.configuration.get(ClientConfigProperties.SERVER_TIMEZONE);
-            boolean useServerTimeZone = MapUtils.getFlag(this.configuration, ClientConfigProperties.USE_SERVER_TIMEZONE);
+            String useTimeZoneValue = this.configuration.get(ClientConfigProperties.USE_TIMEZONE.getKey());
+            String serverTimeZoneValue = this.configuration.get(ClientConfigProperties.SERVER_TIMEZONE.getKey());
+            boolean useServerTimeZone = MapUtils.getFlag(this.configuration, ClientConfigProperties.USE_SERVER_TIMEZONE.getKey());
             if (useTimeZoneValue != null) {
                 if (useServerTimeZone) {
                     throw new IllegalArgumentException("USE_TIME_ZONE option cannot be used when using server timezone");
@@ -950,16 +951,16 @@ public class Client implements AutoCloseable {
         private void setDefaults() {
 
             // set default database name if not specified
-            if (!configuration.containsKey(ClientConfigProperties.DATABASE)) {
+            if (!configuration.containsKey(ClientConfigProperties.DATABASE.getKey())) {
                 setDefaultDatabase((String) "default");
             }
 
-            if (!configuration.containsKey(ClientConfigProperties.MAX_EXECUTION_TIME)) {
+            if (!configuration.containsKey(ClientConfigProperties.MAX_EXECUTION_TIME.getKey())) {
                 setExecutionTimeout(0, MILLIS);
             }
 
-            if (!configuration.containsKey(ClientConfigProperties.MAX_THREADS_PER_CLIENT)) {
-                configuration.put(ClientConfigProperties.MAX_THREADS_PER_CLIENT,
+            if (!configuration.containsKey(ClientConfigProperties.MAX_THREADS_PER_CLIENT.getKey())) {
+                configuration.put(ClientConfigProperties.MAX_THREADS_PER_CLIENT.getKey(),
                         String.valueOf(0));
             }
 
@@ -967,47 +968,48 @@ public class Client implements AutoCloseable {
                 setLZ4UncompressedBufferSize(ClickHouseLZ4OutputStream.UNCOMPRESSED_BUFF_SIZE);
             }
 
-            if (!configuration.containsKey(ClientConfigProperties.USE_SERVER_TIMEZONE)) {
+            if (!configuration.containsKey(ClientConfigProperties.USE_SERVER_TIMEZONE.getKey())) {
                 useServerTimeZone(true);
             }
 
-            if (!configuration.containsKey(ClientConfigProperties.SERVER_TIMEZONE)) {
+            if (!configuration.containsKey(ClientConfigProperties.SERVER_TIMEZONE.getKey())) {
                 setServerTimeZone("UTC");
             }
 
-            if (!configuration.containsKey(ClientConfigProperties.ASYNC_OPERATIONS)) {
+            if (!configuration.containsKey(ClientConfigProperties.ASYNC_OPERATIONS.getKey())) {
                 useAsyncRequests(false);
             }
 
-            if (!configuration.containsKey(ClientConfigProperties.HTTP_MAX_OPEN_CONNECTIONS)) {
+            if (!configuration.containsKey(ClientConfigProperties.HTTP_MAX_OPEN_CONNECTIONS.getKey())) {
                 setMaxConnections(10);
             }
 
-            if (!configuration.containsKey("connection_request_timeout")) {
+            if (!configuration.containsKey(ClientConfigProperties.CONNECTION_REQUEST_TIMEOUT.getKey())) {
                 setConnectionRequestTimeout(10, SECONDS);
             }
 
-            if (!configuration.containsKey("connection_reuse_strategy")) {
+            if (!configuration.containsKey(ClientConfigProperties.CONNECTION_REUSE_STRATEGY.getKey())) {
                 setConnectionReuseStrategy(ConnectionReuseStrategy.FIFO);
             }
 
-            if (!configuration.containsKey("connection_pool_enabled")) {
+            if (!configuration.containsKey(ClientConfigProperties.CONNECTION_POOL_ENABLED.getKey())) {
                 enableConnectionPool(true);
             }
 
-            if (!configuration.containsKey("connection_ttl")) {
+            if (!configuration.containsKey(ClientConfigProperties.CONNECTION_TTL.getKey())) {
                 setConnectionTTL(-1, MILLIS);
             }
 
-            if (!configuration.containsKey("client_retry_on_failures")) {
-                retryOnFailures(ClientFaultCause.NoHttpResponse, ClientFaultCause.ConnectTimeout, ClientFaultCause.ConnectionRequestTimeout);
+            if (!configuration.containsKey(ClientConfigProperties.CLIENT_RETRY_ON_FAILURE.getKey())) {
+                retryOnFailures(ClientFaultCause.NoHttpResponse, ClientFaultCause.ConnectTimeout,
+                        ClientFaultCause.ConnectionRequestTimeout);
             }
 
-            if (!configuration.containsKey("client_network_buffer_size")) {
+            if (!configuration.containsKey(ClientConfigProperties.CLIENT_NETWORK_BUFFER_SIZE.getKey())) {
                 setClientNetworkBufferSize(DEFAULT_NETWORK_BUFFER_SIZE);
             }
 
-            if (!configuration.containsKey(ClientConfigProperties.RETRY_ON_FAILURE)) {
+            if (!configuration.containsKey(ClientConfigProperties.RETRY_ON_FAILURE.getKey())) {
                 setMaxRetries(3);
             }
 
@@ -1019,7 +1021,7 @@ public class Client implements AutoCloseable {
                 columnToMethodMatchingStrategy = DefaultColumnToMethodMatchingStrategy.INSTANCE;
             }
 
-            if (!configuration.containsKey(ClientConfigProperties.HTTP_USE_BASIC_AUTH)) {
+            if (!configuration.containsKey(ClientConfigProperties.HTTP_USE_BASIC_AUTH.getKey())) {
                 useHTTPBasicAuth(true);
             }
         }
@@ -1243,10 +1245,10 @@ public class Client implements AutoCloseable {
 
 
         if (useNewImplementation) {
-            String retry = configuration.get(ClientConfigProperties.RETRY_ON_FAILURE);
+            String retry = configuration.get(ClientConfigProperties.RETRY_ON_FAILURE.getKey());
             final int maxRetries = retry == null ? 0 : Integer.parseInt(retry);
 
-            settings.setOption(ClientConfigProperties.INPUT_OUTPUT_FORMAT, format.name());
+            settings.setOption(ClientConfigProperties.INPUT_OUTPUT_FORMAT.getKey(), format.name());
             final InsertSettings finalSettings = settings;
             Supplier<InsertResponse> supplier = () -> {
                 // Selecting some node
@@ -1369,17 +1371,17 @@ public class Client implements AutoCloseable {
         Supplier<InsertResponse> responseSupplier;
         if (useNewImplementation) {
 
-            String retry = configuration.get(ClientConfigProperties.RETRY_ON_FAILURE);
+            String retry = configuration.get(ClientConfigProperties.RETRY_ON_FAILURE.getKey());
             final int maxRetries = retry == null ? 0 : Integer.parseInt(retry);
             final int writeBufferSize = settings.getInputStreamCopyBufferSize() <= 0 ?
-                    Integer.parseInt(configuration.getOrDefault(ClientConfigProperties.CLIENT_NETWORK_BUFFER_SIZE, "8192")) :
+                    Integer.parseInt(configuration.getOrDefault(ClientConfigProperties.CLIENT_NETWORK_BUFFER_SIZE.getKey(), "8192")) :
                     settings.getInputStreamCopyBufferSize();
 
             if (writeBufferSize <= 0) {
                 throw new IllegalArgumentException("Buffer size must be greater than 0");
             }
 
-            settings.setOption(ClientConfigProperties.INPUT_OUTPUT_FORMAT, format.name());
+            settings.setOption(ClientConfigProperties.INPUT_OUTPUT_FORMAT.getKey(), format.name());
             final InsertSettings finalSettings = settings;
             responseSupplier = () -> {
                 // Selecting some node
@@ -1466,8 +1468,7 @@ public class Client implements AutoCloseable {
                     } else {
                         clickHouseResponse = future.get();
                     }
-                    InsertResponse response = new InsertResponse(clickHouseResponse, finalClientStats);
-                    return response;
+                    return new InsertResponse(clickHouseResponse, finalClientStats);
                 } catch (ExecutionException e) {
                     throw  new ClientException("Failed to get insert response", e.getCause());
                 } catch (CompletionException e) {
@@ -1550,7 +1551,7 @@ public class Client implements AutoCloseable {
         Supplier<QueryResponse> responseSupplier;
 
         if (useNewImplementation) {
-            String retry = configuration.get(ClientConfigProperties.RETRY_ON_FAILURE);
+            String retry = configuration.get(ClientConfigProperties.RETRY_ON_FAILURE.getKey());
             final int maxRetries = retry == null ? 0 : Integer.parseInt(retry);
 
             if (queryParams != null) {
@@ -1920,24 +1921,24 @@ public class Client implements AutoCloseable {
     private void applyDefaults(QuerySettings settings) {
         Map<String, Object> settingsMap = settings.getAllSettings();
 
-        String key = ClientConfigProperties.USE_SERVER_TIMEZONE;
+        String key = ClientConfigProperties.USE_SERVER_TIMEZONE.getKey();
         if (!settingsMap.containsKey(key) && configuration.containsKey(key)) {
             settings.setOption(key, MapUtils.getFlag(configuration, key));
         }
 
-        key = ClientConfigProperties.USE_TIMEZONE;
+        key = ClientConfigProperties.USE_TIMEZONE.getKey();
         if ( !settings.getUseServerTimeZone() && !settingsMap.containsKey(key) && configuration.containsKey(key)) {
             settings.setOption(key, TimeZone.getTimeZone(configuration.get(key)));
         }
 
-        key = ClientConfigProperties.SERVER_TIMEZONE;
+        key = ClientConfigProperties.SERVER_TIMEZONE.getKey();
         if (!settingsMap.containsKey(key) && configuration.containsKey(key)) {
             settings.setOption(key, TimeZone.getTimeZone(configuration.get(key)));
         }
     }
 
     private <T> CompletableFuture<T> runAsyncOperation(Supplier<T> resultSupplier, Map<String, Object> requestSettings) {
-        boolean isAsync = MapUtils.getFlag(configuration, requestSettings, ClientConfigProperties.ASYNC_OPERATIONS);
+        boolean isAsync = MapUtils.getFlag(configuration, requestSettings, ClientConfigProperties.ASYNC_OPERATIONS.getKey());
         return isAsync ? CompletableFuture.supplyAsync(resultSupplier, sharedOperationExecutor) : CompletableFuture.completedFuture(resultSupplier.get());
     }
 
@@ -1957,7 +1958,7 @@ public class Client implements AutoCloseable {
 
     /** Returns operation timeout in seconds */
     protected int getOperationTimeout() {
-        return Integer.parseInt(configuration.get(ClientConfigProperties.MAX_EXECUTION_TIME));
+        return Integer.parseInt(configuration.get(ClientConfigProperties.MAX_EXECUTION_TIME.getKey()));
     }
 
     /**
@@ -1974,10 +1975,10 @@ public class Client implements AutoCloseable {
      * @param dbRoles
      */
     public void setDBRoles(Collection<String> dbRoles) {
-        this.configuration.put(ClientConfigProperties.SESSION_DB_ROLES, ClientConfigProperties.commaSeparated(dbRoles));
+        this.configuration.put(ClientConfigProperties.SESSION_DB_ROLES.getKey(), ClientConfigProperties.commaSeparated(dbRoles));
         this.unmodifiableDbRolesView =
                 Collections.unmodifiableCollection(ClientConfigProperties.valuesFromCommaSeparated(
-                        this.configuration.get(ClientConfigProperties.SESSION_DB_ROLES)));
+                        this.configuration.get(ClientConfigProperties.SESSION_DB_ROLES.getKey())));
     }
 
     private Collection<String> unmodifiableDbRolesView = Collections.emptyList();

--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -159,7 +159,7 @@ public class Client implements AutoCloseable {
         this.serializers = new ConcurrentHashMap<>();
         this.deserializers = new ConcurrentHashMap<>();
 
-        boolean isAsyncEnabled = MapUtils.getFlag(this.configuration, ClientSettings.ASYNC_OPERATIONS, false);
+        boolean isAsyncEnabled = MapUtils.getFlag(this.configuration, ClientConfigProperties.ASYNC_OPERATIONS, false);
         if (isAsyncEnabled && sharedOperationExecutor == null) {
             this.sharedOperationExecutor = Executors.newCachedThreadPool(new DefaultThreadFactory("chc-operation"));
         } else {
@@ -388,7 +388,7 @@ public class Client implements AutoCloseable {
          * @param maxConnections - maximum number of connections
          */
         public Builder setMaxConnections(int maxConnections) {
-            this.configuration.put(ClientSettings.HTTP_MAX_OPEN_CONNECTIONS, String.valueOf(maxConnections));
+            this.configuration.put(ClientConfigProperties.HTTP_MAX_OPEN_CONNECTIONS, String.valueOf(maxConnections));
             return this;
         }
 
@@ -401,7 +401,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setConnectionTTL(long timeout, ChronoUnit unit) {
-            this.configuration.put(ClientSettings.CONNECTION_TTL, String.valueOf(Duration.of(timeout, unit).toMillis()));
+            this.configuration.put(ClientConfigProperties.CONNECTION_TTL, String.valueOf(Duration.of(timeout, unit).toMillis()));
             return this;
         }
 
@@ -415,7 +415,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setKeepAliveTimeout(long timeout, ChronoUnit unit) {
-            this.configuration.put(ClientSettings.HTTP_KEEP_ALIVE_TIMEOUT, String.valueOf(Duration.of(timeout, unit).toMillis()));
+            this.configuration.put(ClientConfigProperties.HTTP_KEEP_ALIVE_TIMEOUT, String.valueOf(Duration.of(timeout, unit).toMillis()));
             return this;
         }
 
@@ -427,7 +427,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setConnectionReuseStrategy(ConnectionReuseStrategy strategy) {
-            this.configuration.put(ClientSettings.CONNECTION_REUSE_STRATEGY, strategy.name());
+            this.configuration.put(ClientConfigProperties.CONNECTION_REUSE_STRATEGY, strategy.name());
             return this;
         }
 
@@ -439,7 +439,7 @@ public class Client implements AutoCloseable {
          * @param timeout - socket timeout in milliseconds
          */
         public Builder setSocketTimeout(long timeout) {
-            this.configuration.put(ClientSettings.SOCKET_OPERATION_TIMEOUT, String.valueOf(timeout));
+            this.configuration.put(ClientConfigProperties.SOCKET_OPERATION_TIMEOUT, String.valueOf(timeout));
             return this;
         }
 
@@ -459,7 +459,7 @@ public class Client implements AutoCloseable {
          * @param size - socket receive buffer size in bytes
          */
         public Builder setSocketRcvbuf(long size) {
-            this.configuration.put(ClientSettings.SOCKET_RCVBUF_OPT, String.valueOf(size));
+            this.configuration.put(ClientConfigProperties.SOCKET_RCVBUF_OPT, String.valueOf(size));
             return this;
         }
 
@@ -469,7 +469,7 @@ public class Client implements AutoCloseable {
          * @param size - socket send buffer size in bytes
          */
         public Builder setSocketSndbuf(long size) {
-            this.configuration.put(ClientSettings.SOCKET_RCVBUF_OPT, String.valueOf(size));
+            this.configuration.put(ClientConfigProperties.SOCKET_RCVBUF_OPT, String.valueOf(size));
             return this;
         }
 
@@ -479,7 +479,7 @@ public class Client implements AutoCloseable {
          * @param value - socket reuse address option
          */
         public Builder setSocketReuseAddress(boolean value) {
-            this.configuration.put(ClientSettings.SOCKET_REUSEADDR_OPT, String.valueOf(value));
+            this.configuration.put(ClientConfigProperties.SOCKET_REUSEADDR_OPT, String.valueOf(value));
             return this;
         }
 
@@ -490,7 +490,7 @@ public class Client implements AutoCloseable {
          * @param value - socket keep alive option
          */
         public Builder setSocketKeepAlive(boolean value) {
-            this.configuration.put(ClientSettings.SOCKET_KEEPALIVE_OPT, String.valueOf(value));
+            this.configuration.put(ClientConfigProperties.SOCKET_KEEPALIVE_OPT, String.valueOf(value));
             return this;
         }
 
@@ -500,7 +500,7 @@ public class Client implements AutoCloseable {
          * @param value - socket tcp no delay option
          */
         public Builder setSocketTcpNodelay(boolean value) {
-            this.configuration.put(ClientSettings.SOCKET_TCP_NO_DELAY_OPT, String.valueOf(value));
+            this.configuration.put(ClientConfigProperties.SOCKET_TCP_NO_DELAY_OPT, String.valueOf(value));
             return this;
         }
 
@@ -510,7 +510,7 @@ public class Client implements AutoCloseable {
          * @param secondsToWait - socket linger time in seconds
          */
         public Builder setSocketLinger(int secondsToWait) {
-            this.configuration.put(ClientSettings.SOCKET_LINGER_OPT, String.valueOf(secondsToWait));
+            this.configuration.put(ClientConfigProperties.SOCKET_LINGER_OPT, String.valueOf(secondsToWait));
             return this;
         }
 
@@ -521,7 +521,7 @@ public class Client implements AutoCloseable {
          * @param enabled - indicates if server response compression is enabled
          */
         public Builder compressServerResponse(boolean enabled) {
-            this.configuration.put(ClientSettings.COMPRESS_SERVER_RESPONSE, String.valueOf(enabled));
+            this.configuration.put(ClientConfigProperties.COMPRESS_SERVER_RESPONSE, String.valueOf(enabled));
             return this;
         }
 
@@ -532,7 +532,7 @@ public class Client implements AutoCloseable {
          * @param enabled - indicates if client request compression is enabled
          */
         public Builder compressClientRequest(boolean enabled) {
-            this.configuration.put(ClientSettings.COMPRESS_CLIENT_REQUEST, String.valueOf(enabled));
+            this.configuration.put(ClientConfigProperties.COMPRESS_CLIENT_REQUEST, String.valueOf(enabled));
             return this;
         }
 
@@ -545,7 +545,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder useHttpCompression(boolean enabled) {
-            this.configuration.put(ClientSettings.USE_HTTP_COMPRESSION, String.valueOf(enabled));
+            this.configuration.put(ClientConfigProperties.USE_HTTP_COMPRESSION, String.valueOf(enabled));
             return this;
         }
 
@@ -558,7 +558,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setLZ4UncompressedBufferSize(int size) {
-            this.configuration.put(ClientSettings.COMPRESSION_LZ4_UNCOMPRESSED_BUF_SIZE, String.valueOf(size));
+            this.configuration.put(ClientConfigProperties.COMPRESSION_LZ4_UNCOMPRESSED_BUF_SIZE, String.valueOf(size));
             return this;
         }
 
@@ -567,7 +567,7 @@ public class Client implements AutoCloseable {
          * @param database - actual default database name.
          */
         public Builder setDefaultDatabase(String database) {
-            this.configuration.put(ClientSettings.DATABASE, database);
+            this.configuration.put(ClientConfigProperties.DATABASE, database);
             return this;
         }
 
@@ -576,9 +576,9 @@ public class Client implements AutoCloseable {
             ValidationUtils.checkNonBlank(host, "host");
             ValidationUtils.checkRange(port, 1, ValidationUtils.TCP_PORT_NUMBER_MAX, "port");
 
-            this.configuration.put(ClientSettings.PROXY_TYPE, type.name());
-            this.configuration.put(ClientSettings.PROXY_HOST, host);
-            this.configuration.put(ClientSettings.PROXY_PORT, String.valueOf(port));
+            this.configuration.put(ClientConfigProperties.PROXY_TYPE, type.name());
+            this.configuration.put(ClientConfigProperties.PROXY_HOST, host);
+            this.configuration.put(ClientConfigProperties.PROXY_PORT, String.valueOf(port));
             return this;
         }
 
@@ -595,7 +595,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setExecutionTimeout(long timeout, ChronoUnit timeUnit) {
-            this.configuration.put(ClientSettings.MAX_EXECUTION_TIME, String.valueOf(Duration.of(timeout, timeUnit).toMillis()));
+            this.configuration.put(ClientConfigProperties.MAX_EXECUTION_TIME, String.valueOf(Duration.of(timeout, timeUnit).toMillis()));
             return this;
         }
 
@@ -623,7 +623,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setSSLTrustStore(String path) {
-            this.configuration.put(ClientSettings.SSL_TRUST_STORE, path);
+            this.configuration.put(ClientConfigProperties.SSL_TRUST_STORE, path);
             return this;
         }
 
@@ -634,7 +634,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setSSLTrustStorePassword(String password) {
-            this.configuration.put(ClientSettings.SSL_KEY_STORE_PASSWORD, password);
+            this.configuration.put(ClientConfigProperties.SSL_KEY_STORE_PASSWORD, password);
             return this;
         }
 
@@ -645,7 +645,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setSSLTrustStoreType(String type) {
-            this.configuration.put(ClientSettings.SSL_KEYSTORE_TYPE, type);
+            this.configuration.put(ClientConfigProperties.SSL_KEYSTORE_TYPE, type);
             return this;
         }
 
@@ -658,7 +658,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setRootCertificate(String path) {
-            this.configuration.put(ClientSettings.CA_CERTIFICATE, path);
+            this.configuration.put(ClientConfigProperties.CA_CERTIFICATE, path);
             return this;
         }
 
@@ -668,7 +668,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setClientCertificate(String path) {
-            this.configuration.put(ClientSettings.SSL_CERTIFICATE, path);
+            this.configuration.put(ClientConfigProperties.SSL_CERTIFICATE, path);
             return this;
         }
 
@@ -678,7 +678,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setClientKey(String path) {
-            this.configuration.put(ClientSettings.SSL_KEY, path);
+            this.configuration.put(ClientConfigProperties.SSL_KEY, path);
             return this;
         }
 
@@ -690,7 +690,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder useServerTimeZone(boolean useServerTimeZone) {
-            this.configuration.put(ClientSettings.USE_SERVER_TIMEZONE, String.valueOf(useServerTimeZone));
+            this.configuration.put(ClientConfigProperties.USE_SERVER_TIMEZONE, String.valueOf(useServerTimeZone));
             return this;
         }
 
@@ -702,7 +702,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder useTimeZone(String timeZone) {
-            this.configuration.put(ClientSettings.USE_TIMEZONE, timeZone);
+            this.configuration.put(ClientConfigProperties.USE_TIMEZONE, timeZone);
             return this;
         }
 
@@ -713,7 +713,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setServerTimeZone(String timeZone) {
-            this.configuration.put(ClientSettings.SERVER_TIMEZONE, timeZone);
+            this.configuration.put(ClientConfigProperties.SERVER_TIMEZONE, timeZone);
             return this;
         }
 
@@ -729,7 +729,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder useAsyncRequests(boolean async) {
-            this.configuration.put(ClientSettings.ASYNC_OPERATIONS, String.valueOf(async));
+            this.configuration.put(ClientConfigProperties.ASYNC_OPERATIONS, String.valueOf(async));
             return this;
         }
 
@@ -754,7 +754,7 @@ public class Client implements AutoCloseable {
          * @return
          */
         public Builder setClientNetworkBufferSize(int size) {
-            this.configuration.put(ClientSettings.CLIENT_NETWORK_BUFFER_SIZE, String.valueOf(size));
+            this.configuration.put(ClientConfigProperties.CLIENT_NETWORK_BUFFER_SIZE, String.valueOf(size));
             return this;
         }
 
@@ -777,7 +777,7 @@ public class Client implements AutoCloseable {
         }
 
         public Builder setMaxRetries(int maxRetries) {
-            this.configuration.put(ClientSettings.RETRY_ON_FAILURE, String.valueOf(maxRetries));
+            this.configuration.put(ClientConfigProperties.RETRY_ON_FAILURE, String.valueOf(maxRetries));
             return this;
         }
 
@@ -810,7 +810,7 @@ public class Client implements AutoCloseable {
          * @return same instance of the builder
          */
         public Builder httpHeader(String key, String value) {
-            this.configuration.put(ClientSettings.HTTP_HEADER_PREFIX + key, value);
+            this.configuration.put(ClientConfigProperties.HTTP_HEADER_PREFIX + key, value);
             return this;
         }
 
@@ -821,7 +821,7 @@ public class Client implements AutoCloseable {
          * @return same instance of the builder
          */
         public Builder httpHeader(String key, Collection<String> values) {
-            this.configuration.put(ClientSettings.HTTP_HEADER_PREFIX + key, ClientSettings.commaSeparated(values));
+            this.configuration.put(ClientConfigProperties.HTTP_HEADER_PREFIX + key, ClientConfigProperties.commaSeparated(values));
             return this;
         }
 
@@ -848,7 +848,7 @@ public class Client implements AutoCloseable {
          * @return same instance of the builder
          */
         public Builder serverSetting(String name, String value) {
-            this.configuration.put(ClientSettings.SERVER_SETTING_PREFIX + name, value);
+            this.configuration.put(ClientConfigProperties.SERVER_SETTING_PREFIX + name, value);
             return this;
         }
 
@@ -859,7 +859,7 @@ public class Client implements AutoCloseable {
          * @return same instance of the builder
          */
         public Builder serverSetting(String name,  Collection<String> values) {
-            this.configuration.put(ClientSettings.SERVER_SETTING_PREFIX + name, ClientSettings.commaSeparated(values));
+            this.configuration.put(ClientConfigProperties.SERVER_SETTING_PREFIX + name, ClientConfigProperties.commaSeparated(values));
             return this;
         }
 
@@ -881,7 +881,7 @@ public class Client implements AutoCloseable {
          * is the only option here.
          */
         public Builder useHTTPBasicAuth(boolean useBasicAuth) {
-            this.configuration.put(ClientSettings.HTTP_USE_BASIC_AUTH, String.valueOf(useBasicAuth));
+            this.configuration.put(ClientConfigProperties.HTTP_USE_BASIC_AUTH, String.valueOf(useBasicAuth));
             return this;
         }
 
@@ -905,19 +905,19 @@ public class Client implements AutoCloseable {
             }
 
             if (this.configuration.containsKey("ssl_authentication") &&
-                !this.configuration.containsKey(ClientSettings.SSL_CERTIFICATE)) {
+                !this.configuration.containsKey(ClientConfigProperties.SSL_CERTIFICATE)) {
                 throw new IllegalArgumentException("SSL authentication requires a client certificate");
             }
 
-            if (this.configuration.containsKey(ClientSettings.SSL_TRUST_STORE) &&
-                this.configuration.containsKey(ClientSettings.SSL_CERTIFICATE)) {
+            if (this.configuration.containsKey(ClientConfigProperties.SSL_TRUST_STORE) &&
+                this.configuration.containsKey(ClientConfigProperties.SSL_CERTIFICATE)) {
                 throw new IllegalArgumentException("Trust store and certificates cannot be used together");
             }
 
             // Check timezone settings
-            String useTimeZoneValue = this.configuration.get(ClientSettings.USE_TIMEZONE);
-            String serverTimeZoneValue = this.configuration.get(ClientSettings.SERVER_TIMEZONE);
-            boolean useServerTimeZone = MapUtils.getFlag(this.configuration, ClientSettings.USE_SERVER_TIMEZONE);
+            String useTimeZoneValue = this.configuration.get(ClientConfigProperties.USE_TIMEZONE);
+            String serverTimeZoneValue = this.configuration.get(ClientConfigProperties.SERVER_TIMEZONE);
+            boolean useServerTimeZone = MapUtils.getFlag(this.configuration, ClientConfigProperties.USE_SERVER_TIMEZONE);
             if (useTimeZoneValue != null) {
                 if (useServerTimeZone) {
                     throw new IllegalArgumentException("USE_TIME_ZONE option cannot be used when using server timezone");
@@ -950,16 +950,16 @@ public class Client implements AutoCloseable {
         private void setDefaults() {
 
             // set default database name if not specified
-            if (!configuration.containsKey(ClientSettings.DATABASE)) {
+            if (!configuration.containsKey(ClientConfigProperties.DATABASE)) {
                 setDefaultDatabase((String) "default");
             }
 
-            if (!configuration.containsKey(ClientSettings.MAX_EXECUTION_TIME)) {
+            if (!configuration.containsKey(ClientConfigProperties.MAX_EXECUTION_TIME)) {
                 setExecutionTimeout(0, MILLIS);
             }
 
-            if (!configuration.containsKey(ClientSettings.MAX_THREADS_PER_CLIENT)) {
-                configuration.put(ClientSettings.MAX_THREADS_PER_CLIENT,
+            if (!configuration.containsKey(ClientConfigProperties.MAX_THREADS_PER_CLIENT)) {
+                configuration.put(ClientConfigProperties.MAX_THREADS_PER_CLIENT,
                         String.valueOf(0));
             }
 
@@ -967,19 +967,19 @@ public class Client implements AutoCloseable {
                 setLZ4UncompressedBufferSize(ClickHouseLZ4OutputStream.UNCOMPRESSED_BUFF_SIZE);
             }
 
-            if (!configuration.containsKey(ClientSettings.USE_SERVER_TIMEZONE)) {
+            if (!configuration.containsKey(ClientConfigProperties.USE_SERVER_TIMEZONE)) {
                 useServerTimeZone(true);
             }
 
-            if (!configuration.containsKey(ClientSettings.SERVER_TIMEZONE)) {
+            if (!configuration.containsKey(ClientConfigProperties.SERVER_TIMEZONE)) {
                 setServerTimeZone("UTC");
             }
 
-            if (!configuration.containsKey(ClientSettings.ASYNC_OPERATIONS)) {
+            if (!configuration.containsKey(ClientConfigProperties.ASYNC_OPERATIONS)) {
                 useAsyncRequests(false);
             }
 
-            if (!configuration.containsKey(ClientSettings.HTTP_MAX_OPEN_CONNECTIONS)) {
+            if (!configuration.containsKey(ClientConfigProperties.HTTP_MAX_OPEN_CONNECTIONS)) {
                 setMaxConnections(10);
             }
 
@@ -1007,7 +1007,7 @@ public class Client implements AutoCloseable {
                 setClientNetworkBufferSize(DEFAULT_NETWORK_BUFFER_SIZE);
             }
 
-            if (!configuration.containsKey(ClientSettings.RETRY_ON_FAILURE)) {
+            if (!configuration.containsKey(ClientConfigProperties.RETRY_ON_FAILURE)) {
                 setMaxRetries(3);
             }
 
@@ -1019,7 +1019,7 @@ public class Client implements AutoCloseable {
                 columnToMethodMatchingStrategy = DefaultColumnToMethodMatchingStrategy.INSTANCE;
             }
 
-            if (!configuration.containsKey(ClientSettings.HTTP_USE_BASIC_AUTH)) {
+            if (!configuration.containsKey(ClientConfigProperties.HTTP_USE_BASIC_AUTH)) {
                 useHTTPBasicAuth(true);
             }
         }
@@ -1243,10 +1243,10 @@ public class Client implements AutoCloseable {
 
 
         if (useNewImplementation) {
-            String retry = configuration.get(ClientSettings.RETRY_ON_FAILURE);
+            String retry = configuration.get(ClientConfigProperties.RETRY_ON_FAILURE);
             final int maxRetries = retry == null ? 0 : Integer.parseInt(retry);
 
-            settings.setOption(ClientSettings.INPUT_OUTPUT_FORMAT, format.name());
+            settings.setOption(ClientConfigProperties.INPUT_OUTPUT_FORMAT, format.name());
             final InsertSettings finalSettings = settings;
             Supplier<InsertResponse> supplier = () -> {
                 // Selecting some node
@@ -1369,17 +1369,17 @@ public class Client implements AutoCloseable {
         Supplier<InsertResponse> responseSupplier;
         if (useNewImplementation) {
 
-            String retry = configuration.get(ClientSettings.RETRY_ON_FAILURE);
+            String retry = configuration.get(ClientConfigProperties.RETRY_ON_FAILURE);
             final int maxRetries = retry == null ? 0 : Integer.parseInt(retry);
             final int writeBufferSize = settings.getInputStreamCopyBufferSize() <= 0 ?
-                    Integer.parseInt(configuration.getOrDefault(ClientSettings.CLIENT_NETWORK_BUFFER_SIZE, "8192")) :
+                    Integer.parseInt(configuration.getOrDefault(ClientConfigProperties.CLIENT_NETWORK_BUFFER_SIZE, "8192")) :
                     settings.getInputStreamCopyBufferSize();
 
             if (writeBufferSize <= 0) {
                 throw new IllegalArgumentException("Buffer size must be greater than 0");
             }
 
-            settings.setOption(ClientSettings.INPUT_OUTPUT_FORMAT, format.name());
+            settings.setOption(ClientConfigProperties.INPUT_OUTPUT_FORMAT, format.name());
             final InsertSettings finalSettings = settings;
             responseSupplier = () -> {
                 // Selecting some node
@@ -1550,7 +1550,7 @@ public class Client implements AutoCloseable {
         Supplier<QueryResponse> responseSupplier;
 
         if (useNewImplementation) {
-            String retry = configuration.get(ClientSettings.RETRY_ON_FAILURE);
+            String retry = configuration.get(ClientConfigProperties.RETRY_ON_FAILURE);
             final int maxRetries = retry == null ? 0 : Integer.parseInt(retry);
 
             if (queryParams != null) {
@@ -1920,24 +1920,24 @@ public class Client implements AutoCloseable {
     private void applyDefaults(QuerySettings settings) {
         Map<String, Object> settingsMap = settings.getAllSettings();
 
-        String key = ClientSettings.USE_SERVER_TIMEZONE;
+        String key = ClientConfigProperties.USE_SERVER_TIMEZONE;
         if (!settingsMap.containsKey(key) && configuration.containsKey(key)) {
             settings.setOption(key, MapUtils.getFlag(configuration, key));
         }
 
-        key = ClientSettings.USE_TIMEZONE;
+        key = ClientConfigProperties.USE_TIMEZONE;
         if ( !settings.getUseServerTimeZone() && !settingsMap.containsKey(key) && configuration.containsKey(key)) {
             settings.setOption(key, TimeZone.getTimeZone(configuration.get(key)));
         }
 
-        key = ClientSettings.SERVER_TIMEZONE;
+        key = ClientConfigProperties.SERVER_TIMEZONE;
         if (!settingsMap.containsKey(key) && configuration.containsKey(key)) {
             settings.setOption(key, TimeZone.getTimeZone(configuration.get(key)));
         }
     }
 
     private <T> CompletableFuture<T> runAsyncOperation(Supplier<T> resultSupplier, Map<String, Object> requestSettings) {
-        boolean isAsync = MapUtils.getFlag(configuration, requestSettings, ClientSettings.ASYNC_OPERATIONS);
+        boolean isAsync = MapUtils.getFlag(configuration, requestSettings, ClientConfigProperties.ASYNC_OPERATIONS);
         return isAsync ? CompletableFuture.supplyAsync(resultSupplier, sharedOperationExecutor) : CompletableFuture.completedFuture(resultSupplier.get());
     }
 
@@ -1957,7 +1957,7 @@ public class Client implements AutoCloseable {
 
     /** Returns operation timeout in seconds */
     protected int getOperationTimeout() {
-        return Integer.parseInt(configuration.get(ClientSettings.MAX_EXECUTION_TIME));
+        return Integer.parseInt(configuration.get(ClientConfigProperties.MAX_EXECUTION_TIME));
     }
 
     /**
@@ -1974,10 +1974,10 @@ public class Client implements AutoCloseable {
      * @param dbRoles
      */
     public void setDBRoles(Collection<String> dbRoles) {
-        this.configuration.put(ClientSettings.SESSION_DB_ROLES, ClientSettings.commaSeparated(dbRoles));
+        this.configuration.put(ClientConfigProperties.SESSION_DB_ROLES, ClientConfigProperties.commaSeparated(dbRoles));
         this.unmodifiableDbRolesView =
-                Collections.unmodifiableCollection(ClientSettings.valuesFromCommaSeparated(
-                        this.configuration.get(ClientSettings.SESSION_DB_ROLES)));
+                Collections.unmodifiableCollection(ClientConfigProperties.valuesFromCommaSeparated(
+                        this.configuration.get(ClientConfigProperties.SESSION_DB_ROLES)));
     }
 
     private Collection<String> unmodifiableDbRolesView = Collections.emptyList();

--- a/client-v2/src/main/java/com/clickhouse/client/api/ClientConfigProperties.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/ClientConfigProperties.java
@@ -1,8 +1,5 @@
 package com.clickhouse.client.api;
 
-import com.clickhouse.client.api.internal.SettingsConverter;
-import com.clickhouse.client.api.metrics.ClientMetrics;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -13,7 +10,7 @@ import java.util.stream.Collectors;
  * All known client settings at current version.
  *
  */
-public class ClientSettings {
+public class ClientConfigProperties {
 
     public static final String HTTP_HEADER_PREFIX = "http_header_";
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/ClientConfigProperties.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/ClientConfigProperties.java
@@ -7,14 +7,130 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 /**
- * All known client settings at current version.
- *
+ * Enumerates all client properties that are known at release.
  */
-public class ClientConfigProperties {
+public enum ClientConfigProperties {
+
+    SESSION_DB_ROLES("session_db_roles"),
+
+    SETTING_LOG_COMMENT(serverSetting("log_comment")),
+
+    HTTP_USE_BASIC_AUTH("http_use_basic_auth"),
+
+    USER("user"),
+
+    PASSWORD("password"),
+
+    /**
+     * Maximum number of active connection in internal connection pool.
+     */
+    HTTP_MAX_OPEN_CONNECTIONS("max_open_connections"),
+
+    /**
+     * HTTP keep-alive timeout override.
+     */
+    HTTP_KEEP_ALIVE_TIMEOUT("http_keep_alive_timeout"),
+
+    USE_SERVER_TIMEZONE("use_server_time_zone"),
+
+    USE_TIMEZONE("use_time_zone"),
+
+    SERVER_TIMEZONE("server_time_zone"),
+
+    ASYNC_OPERATIONS("async"),
+
+    CONNECTION_TTL("connection_ttl"),
+
+    CONNECTION_TIMEOUT("connection_timeout"),
+
+    CONNECTION_REUSE_STRATEGY("connection_reuse_strategy"),
+
+    SOCKET_OPERATION_TIMEOUT("socket_timeout"),
+
+    SOCKET_RCVBUF_OPT("socket_rcvbuf"),
+
+    SOCKET_SNDBUF_OPT("socket_sndbuf"),
+
+    SOCKET_REUSEADDR_OPT("socket_reuseaddr"),
+
+    SOCKET_KEEPALIVE_OPT("socket_keepalive"),
+
+    SOCKET_TCP_NO_DELAY_OPT("socket_tcp_nodelay"),
+
+    SOCKET_LINGER_OPT("socket_linger"),
+
+    DATABASE("database"),
+
+    COMPRESS_SERVER_RESPONSE("compress"), // actually a server setting, but has client effect too
+
+    COMPRESS_CLIENT_REQUEST("decompress"), // actually a server setting, but has client effect too
+
+    USE_HTTP_COMPRESSION("client.use_http_compression"),
+
+    COMPRESSION_LZ4_UNCOMPRESSED_BUF_SIZE("compression.lz4.uncompressed_buffer_size"),
+
+    PROXY_TYPE("proxy_type"), // "http"
+
+    PROXY_HOST("proxy_host"),
+
+    PROXY_PORT("proxy_port"),
+
+    PROXY_USER("proxy_user"),
+
+    PROXY_PASSWORD("proxy_password"),
+
+    MAX_EXECUTION_TIME("max_execution_time"),
+
+    SSL_TRUST_STORE("trust_store"),
+
+    SSL_KEYSTORE_TYPE("key_store_type"),
+
+    SSL_KEY_STORE("ssl_key_store"),
+
+    SSL_KEY_STORE_PASSWORD("key_store_password"),
+
+    SSL_KEY("ssl_key"),
+
+    CA_CERTIFICATE("sslrootcert"),
+
+    SSL_CERTIFICATE("sslcert"),
+
+    RETRY_ON_FAILURE("retry"),
+
+    INPUT_OUTPUT_FORMAT("format"),
+
+    MAX_THREADS_PER_CLIENT("max_threads_per_client"),
+
+    QUERY_ID("query_id"), // actually a server setting, but has client effect too
+
+    CLIENT_NETWORK_BUFFER_SIZE("client_network_buffer_size"),
+
+
+    ACCESS_TOKEN("access_token"), SSL_AUTH("ssl_authentication"),
+
+    CONNECTION_POOL_ENABLED("connection_pool_enabled"),
+
+    CONNECTION_REQUEST_TIMEOUT("connection_request_timeout"),
+
+    CLIENT_RETRY_ON_FAILURE("client_retry_on_failures");
+
+    private String key;
+
+    ClientConfigProperties(String key) {
+        this.key = key;
+    }
+
+    public String getKey() {
+        return key;
+    }
 
     public static final String HTTP_HEADER_PREFIX = "http_header_";
 
     public static final String SERVER_SETTING_PREFIX = "clickhouse_setting_";
+
+    public static String serverSetting(String key) {
+        return SERVER_SETTING_PREFIX + key;
+    }
 
     public static String commaSeparated(Collection<?> values) {
         StringBuilder sb = new StringBuilder();
@@ -33,111 +149,4 @@ public class ClientConfigProperties {
         return Arrays.stream(value.split("(?<!\\\\),")).map(s -> s.replaceAll("\\\\,", ","))
                 .collect(Collectors.toList());
     }
-
-    public static final String SESSION_DB_ROLES = "session_db_roles";
-
-    public static final String SETTING_LOG_COMMENT = SERVER_SETTING_PREFIX + "log_comment";
-
-    public static final String HTTP_USE_BASIC_AUTH = "http_use_basic_auth";
-
-    public static final String USER = "user";
-
-    public static final String PASSWORD = "password";
-
-    /**
-     * Maximum number of active connection in internal connection pool.
-     */
-    public static final String HTTP_MAX_OPEN_CONNECTIONS = "max_open_connections";
-
-    /**
-     * HTTP keep-alive timeout override.
-     */
-    public static final String HTTP_KEEP_ALIVE_TIMEOUT = "http_keep_alive_timeout";
-
-    public static final String USE_SERVER_TIMEZONE = "use_server_time_zone";
-
-    public static final String USE_TIMEZONE = "use_time_zone";
-
-    public static final String SERVER_TIMEZONE = "server_time_zone";
-
-    public static final String ASYNC_OPERATIONS = "async";
-
-    public static final String CONNECTION_TTL = "connection_ttl";
-
-    public static final String CONNECTION_TIMEOUT = "connection_timeout";
-
-    public static final String CONNECTION_REUSE_STRATEGY = "connection_reuse_strategy";
-
-    public static final String SOCKET_OPERATION_TIMEOUT = "socket_timeout";
-
-    public static final String SOCKET_RCVBUF_OPT = "socket_rcvbuf";
-
-    public static final String SOCKET_SNDBUF_OPT = "socket_sndbuf";
-
-    public static final String SOCKET_REUSEADDR_OPT = "socket_reuseaddr";
-
-    public static final String SOCKET_KEEPALIVE_OPT = "socket_keepalive";
-
-    public static final String SOCKET_TCP_NO_DELAY_OPT = "socket_tcp_nodelay";
-
-    public static final String SOCKET_LINGER_OPT = "socket_linger";
-
-    public static final String DATABASE = "database";
-
-    public static final String COMPRESS_SERVER_RESPONSE = "compress"; // actually a server setting
-
-    public static final String COMPRESS_CLIENT_REQUEST = "decompress"; // actually a server setting
-
-    public static final String USE_HTTP_COMPRESSION = "client.use_http_compression";
-
-    public static final String COMPRESSION_LZ4_UNCOMPRESSED_BUF_SIZE = "compression.lz4.uncompressed_buffer_size";
-
-    public static final String PROXY_TYPE = "proxy_type"; // "http"
-
-    public static final String PROXY_HOST = "proxy_host";
-
-    public static final String PROXY_PORT = "proxy_port";
-
-    public static final String PROXY_USER = "proxy_user";
-
-    public static final String PROXY_PASSWORD = "proxy_password";
-
-    public static final String MAX_EXECUTION_TIME = "max_execution_time";
-
-    public static final String SSL_TRUST_STORE = "trust_store";
-
-    public static final String SSL_KEYSTORE_TYPE = "key_store_type";
-
-    public static final String SSL_KEY_STORE = "ssl_key_store";
-
-    public static final String SSL_KEY_STORE_PASSWORD = "key_store_password";
-
-    public static final String SSL_KEY =  "ssl_key";
-
-    public static final String CA_CERTIFICATE = "sslrootcert";
-
-    public static final String SSL_CERTIFICATE = "sslcert";
-
-    public static final String RETRY_ON_FAILURE = "retry";
-
-    public static final String INPUT_OUTPUT_FORMAT = "format";
-
-    public static final String MAX_THREADS_PER_CLIENT = "max_threads_per_client";
-
-    public static final String QUERY_ID = "query_id"; // actually a server setting
-
-    public static final String CLIENT_NETWORK_BUFFER_SIZE = "client_network_buffer_size";
-
-    // -- Experimental features --
-
-    /**
-     * Server will expect a string in JSON format and parse it into a JSON object.
-     */
-    public static final String INPUT_FORMAT_BINARY_READ_JSON_AS_STRING = "input_format_binary_read_json_as_string";
-
-    /**
-     * Server will return a JSON object as a string.
-     */
-    public static final String OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING = "output_format_binary_write_json_as_string";
-
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/ClientSettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/ClientSettings.java
@@ -51,4 +51,14 @@ public class ClientSettings {
      * Server will return a JSON object as a string.
      */
     public static final String OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING = "output_format_binary_write_json_as_string";
+
+    /**
+     * Maximum number of active connection in internal connection pool.
+     */
+    public static final String HTTP_MAX_OPEN_CONNECTIONS = "max_open_connections";
+
+    /**
+     * HTTP keep-alive timeout override.
+     */
+    public static final String HTTP_KEEP_ALIVE_TIMEOUT = "http_keep_alive_timeout";
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/ClientSettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/ClientSettings.java
@@ -1,5 +1,8 @@
 package com.clickhouse.client.api;
 
+import com.clickhouse.client.api.internal.SettingsConverter;
+import com.clickhouse.client.api.metrics.ClientMetrics;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -40,6 +43,94 @@ public class ClientSettings {
 
     public static final String HTTP_USE_BASIC_AUTH = "http_use_basic_auth";
 
+    public static final String USER = "user";
+
+    public static final String PASSWORD = "password";
+
+    /**
+     * Maximum number of active connection in internal connection pool.
+     */
+    public static final String HTTP_MAX_OPEN_CONNECTIONS = "max_open_connections";
+
+    /**
+     * HTTP keep-alive timeout override.
+     */
+    public static final String HTTP_KEEP_ALIVE_TIMEOUT = "http_keep_alive_timeout";
+
+    public static final String USE_SERVER_TIMEZONE = "use_server_time_zone";
+
+    public static final String USE_TIMEZONE = "use_time_zone";
+
+    public static final String SERVER_TIMEZONE = "server_time_zone";
+
+    public static final String ASYNC_OPERATIONS = "async";
+
+    public static final String CONNECTION_TTL = "connection_ttl";
+
+    public static final String CONNECTION_TIMEOUT = "connection_timeout";
+
+    public static final String CONNECTION_REUSE_STRATEGY = "connection_reuse_strategy";
+
+    public static final String SOCKET_OPERATION_TIMEOUT = "socket_timeout";
+
+    public static final String SOCKET_RCVBUF_OPT = "socket_rcvbuf";
+
+    public static final String SOCKET_SNDBUF_OPT = "socket_sndbuf";
+
+    public static final String SOCKET_REUSEADDR_OPT = "socket_reuseaddr";
+
+    public static final String SOCKET_KEEPALIVE_OPT = "socket_keepalive";
+
+    public static final String SOCKET_TCP_NO_DELAY_OPT = "socket_tcp_nodelay";
+
+    public static final String SOCKET_LINGER_OPT = "socket_linger";
+
+    public static final String DATABASE = "database";
+
+    public static final String COMPRESS_SERVER_RESPONSE = "compress"; // actually a server setting
+
+    public static final String COMPRESS_CLIENT_REQUEST = "decompress"; // actually a server setting
+
+    public static final String USE_HTTP_COMPRESSION = "client.use_http_compression";
+
+    public static final String COMPRESSION_LZ4_UNCOMPRESSED_BUF_SIZE = "compression.lz4.uncompressed_buffer_size";
+
+    public static final String PROXY_TYPE = "proxy_type"; // "http"
+
+    public static final String PROXY_HOST = "proxy_host";
+
+    public static final String PROXY_PORT = "proxy_port";
+
+    public static final String PROXY_USER = "proxy_user";
+
+    public static final String PROXY_PASSWORD = "proxy_password";
+
+    public static final String MAX_EXECUTION_TIME = "max_execution_time";
+
+    public static final String SSL_TRUST_STORE = "trust_store";
+
+    public static final String SSL_KEYSTORE_TYPE = "key_store_type";
+
+    public static final String SSL_KEY_STORE = "ssl_key_store";
+
+    public static final String SSL_KEY_STORE_PASSWORD = "key_store_password";
+
+    public static final String SSL_KEY =  "ssl_key";
+
+    public static final String CA_CERTIFICATE = "sslrootcert";
+
+    public static final String SSL_CERTIFICATE = "sslcert";
+
+    public static final String RETRY_ON_FAILURE = "retry";
+
+    public static final String INPUT_OUTPUT_FORMAT = "format";
+
+    public static final String MAX_THREADS_PER_CLIENT = "max_threads_per_client";
+
+    public static final String QUERY_ID = "query_id"; // actually a server setting
+
+    public static final String CLIENT_NETWORK_BUFFER_SIZE = "client_network_buffer_size";
+
     // -- Experimental features --
 
     /**
@@ -52,13 +143,4 @@ public class ClientSettings {
      */
     public static final String OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING = "output_format_binary_write_json_as_string";
 
-    /**
-     * Maximum number of active connection in internal connection pool.
-     */
-    public static final String HTTP_MAX_OPEN_CONNECTIONS = "max_open_connections";
-
-    /**
-     * HTTP keep-alive timeout override.
-     */
-    public static final String HTTP_KEEP_ALIVE_TIMEOUT = "http_keep_alive_timeout";
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
@@ -1,7 +1,7 @@
 package com.clickhouse.client.api.data_formats.internal;
 
 import com.clickhouse.client.api.ClientException;
-import com.clickhouse.client.api.ClientSettings;
+import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatReader;
 import com.clickhouse.client.api.internal.MapUtils;
 import com.clickhouse.client.api.metadata.TableSchema;
@@ -66,14 +66,14 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
                                          BinaryStreamReader.ByteBufferAllocator byteBufferAllocator) {
         this.input = inputStream;
         this.settings = querySettings == null ? Collections.emptyMap() : new HashMap<>(querySettings.getAllSettings());
-        Boolean useServerTimeZone = (Boolean) this.settings.get(ClientSettings.USE_SERVER_TIMEZONE);
+        Boolean useServerTimeZone = (Boolean) this.settings.get(ClientConfigProperties.USE_SERVER_TIMEZONE);
         TimeZone timeZone = useServerTimeZone == Boolean.TRUE && querySettings != null ? querySettings.getServerTimeZone() :
-                (TimeZone) this.settings.get(ClientSettings.USE_TIMEZONE);
+                (TimeZone) this.settings.get(ClientConfigProperties.USE_TIMEZONE);
         if (timeZone == null) {
             throw new ClientException("Time zone is not set. (useServerTimezone:" + useServerTimeZone + ")");
         }
         boolean jsonAsString = MapUtils.getFlag(this.settings,
-                ClientSettings.SERVER_SETTING_PREFIX + ClientSettings.OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING, false);
+                ClientConfigProperties.SERVER_SETTING_PREFIX + ClientConfigProperties.OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING, false);
         this.binaryStreamReader = new BinaryStreamReader(inputStream, timeZone, LOG, byteBufferAllocator, jsonAsString);
         if (schema != null) {
             setSchema(schema);

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
@@ -8,7 +8,6 @@ import com.clickhouse.client.api.metadata.TableSchema;
 import com.clickhouse.client.api.query.NullValueException;
 import com.clickhouse.client.api.query.POJOSetter;
 import com.clickhouse.client.api.query.QuerySettings;
-import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.value.ClickHouseBitmap;
 import com.clickhouse.data.value.ClickHouseGeoMultiPolygonValue;
@@ -34,10 +33,8 @@ import java.time.ZonedDateTime;
 import java.time.temporal.ChronoUnit;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -69,9 +66,9 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
                                          BinaryStreamReader.ByteBufferAllocator byteBufferAllocator) {
         this.input = inputStream;
         this.settings = querySettings == null ? Collections.emptyMap() : new HashMap<>(querySettings.getAllSettings());
-        Boolean useServerTimeZone = (Boolean) this.settings.get(ClickHouseClientOption.USE_SERVER_TIME_ZONE.getKey());
+        Boolean useServerTimeZone = (Boolean) this.settings.get(ClientSettings.USE_SERVER_TIMEZONE);
         TimeZone timeZone = useServerTimeZone == Boolean.TRUE && querySettings != null ? querySettings.getServerTimeZone() :
-                (TimeZone) this.settings.get(ClickHouseClientOption.USE_TIME_ZONE.getKey());
+                (TimeZone) this.settings.get(ClientSettings.USE_TIMEZONE);
         if (timeZone == null) {
             throw new ClientException("Time zone is not set. (useServerTimezone:" + useServerTimeZone + ")");
         }

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
@@ -4,6 +4,7 @@ import com.clickhouse.client.api.ClientException;
 import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatReader;
 import com.clickhouse.client.api.internal.MapUtils;
+import com.clickhouse.client.api.internal.ServerSettings;
 import com.clickhouse.client.api.metadata.TableSchema;
 import com.clickhouse.client.api.query.NullValueException;
 import com.clickhouse.client.api.query.POJOSetter;
@@ -66,14 +67,14 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
                                          BinaryStreamReader.ByteBufferAllocator byteBufferAllocator) {
         this.input = inputStream;
         this.settings = querySettings == null ? Collections.emptyMap() : new HashMap<>(querySettings.getAllSettings());
-        Boolean useServerTimeZone = (Boolean) this.settings.get(ClientConfigProperties.USE_SERVER_TIMEZONE);
+        Boolean useServerTimeZone = (Boolean) this.settings.get(ClientConfigProperties.USE_SERVER_TIMEZONE.getKey());
         TimeZone timeZone = useServerTimeZone == Boolean.TRUE && querySettings != null ? querySettings.getServerTimeZone() :
-                (TimeZone) this.settings.get(ClientConfigProperties.USE_TIMEZONE);
+                (TimeZone) this.settings.get(ClientConfigProperties.USE_TIMEZONE.getKey());
         if (timeZone == null) {
             throw new ClientException("Time zone is not set. (useServerTimezone:" + useServerTimeZone + ")");
         }
         boolean jsonAsString = MapUtils.getFlag(this.settings,
-                ClientConfigProperties.SERVER_SETTING_PREFIX + ClientConfigProperties.OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING, false);
+                ClientConfigProperties.serverSetting(ServerSettings.OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING), false);
         this.binaryStreamReader = new BinaryStreamReader(inputStream, timeZone, LOG, byteBufferAllocator, jsonAsString);
         if (schema != null) {
             setSchema(schema);

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -84,6 +84,7 @@ public class BinaryStreamReader {
      * @param <T> - target type of the value
      * @throws IOException when IO error occurs
      */
+    @SuppressWarnings("unchecked")
     public <T> T readValue(ClickHouseColumn column, Class<?> typeHint) throws IOException {
         if (column.isNullable()) {
             int isNull = readByteOrEOF(input);

--- a/client-v2/src/main/java/com/clickhouse/client/api/http/ClickHouseHttpProto.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/http/ClickHouseHttpProto.java
@@ -1,0 +1,61 @@
+package com.clickhouse.client.api.http;
+
+public class ClickHouseHttpProto {
+
+
+    public static final String HEADER_SRV_DISPLAY_NAME = "X-ClickHouse-Server-Display-Name";
+
+    /**
+     * Response only header to indicate a query id
+     * Cannot be used in request.
+     */
+    public static final String HEADER_QUERY_ID = "X-ClickHouse-Query-Id";
+
+    public static final String HEADER_SRV_SUMMARY = "X-ClickHouse-Summary";
+
+    /**
+     * Response only header to indicate the format of the data.
+     * Cannot be used in request.
+     */
+    public static final String HEADER_FORMAT = "X-ClickHouse-Format";
+
+    public static final String HEADER_TIMEZONE = "X-ClickHouse-Timezone";
+
+    /**
+     * Response only header to indicate the error code.
+     * Cannot be used in request.
+     */
+    public static final String HEADER_EXCEPTION_CODE = "X-ClickHouse-Exception-Code";
+
+    /**
+     * Response only header to indicate a query progress.
+     * Cannot be used in request.
+     */
+    public static final String HEADER_PROGRESS = "X-ClickHouse-Progress";
+
+
+    /**
+     * Name of default database to be used if not specified in a table name.
+     */
+    public static final String HEADER_DATABASE = "X-ClickHouse-Database";
+
+    /**
+     * Name of user to be used to authenticate
+     */
+    public static final String HEADER_DB_USER = "X-ClickHouse-User";
+
+    /**
+     * Password of user to be used to authenticate. Note: header value should be unencoded, so using
+     * special characters might cause issues. It is recommended to use the Basic Authentication instead.
+     */
+    public static final String HEADER_DB_PASSWORD = "X-ClickHouse-Key";
+
+    public static final String HEADER_SSL_CERT_AUTH = "x-clickhouse-ssl-certificate-auth";
+
+    /**
+     * Query parameter to specify the query ID.
+     */
+    public static final String QPARAM_QUERY_ID = "query_id";
+
+    public static final String QPARAM_ROLE = "role";
+}

--- a/client-v2/src/main/java/com/clickhouse/client/api/insert/InsertResponse.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/insert/InsertResponse.java
@@ -1,6 +1,5 @@
 package com.clickhouse.client.api.insert;
 
-import com.clickhouse.client.ClickHouseClient;
 import com.clickhouse.client.ClickHouseResponse;
 import com.clickhouse.client.api.internal.ClientStatisticsHolder;
 import com.clickhouse.client.api.internal.ClientV1AdaptorHelper;

--- a/client-v2/src/main/java/com/clickhouse/client/api/insert/InsertSettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/insert/InsertSettings.java
@@ -189,7 +189,7 @@ public class InsertSettings {
      * @return same instance of the builder
      */
     public InsertSettings serverSetting(String name, String value) {
-        rawSettings.put(ClientConfigProperties.SERVER_SETTING_PREFIX + name, value);
+        rawSettings.put(ClientConfigProperties.serverSetting(name), value);
         return this;
     }
 
@@ -200,7 +200,7 @@ public class InsertSettings {
      * @return same instance of the builder
      */
     public InsertSettings serverSetting(String name, Collection<String> values) {
-        rawSettings.put(ClientConfigProperties.SERVER_SETTING_PREFIX + name, ClientConfigProperties.commaSeparated(values));
+        rawSettings.put(ClientConfigProperties.serverSetting(name), ClientConfigProperties.commaSeparated(values));
         return this;
     }
 
@@ -210,7 +210,7 @@ public class InsertSettings {
      * @param dbRoles
      */
     public InsertSettings setDBRoles(Collection<String> dbRoles) {
-        rawSettings.put(ClientConfigProperties.SESSION_DB_ROLES, dbRoles);
+        rawSettings.put(ClientConfigProperties.SESSION_DB_ROLES.getKey(), dbRoles);
         return this;
     }
 
@@ -220,7 +220,7 @@ public class InsertSettings {
      * @return list of DB roles
      */
     public Collection<String> getDBRoles() {
-        return (Collection<String>) rawSettings.get(ClientConfigProperties.SESSION_DB_ROLES);
+        return (Collection<String>) rawSettings.get(ClientConfigProperties.SESSION_DB_ROLES.getKey());
     }
 
     /**
@@ -231,7 +231,7 @@ public class InsertSettings {
     public InsertSettings logComment(String logComment) {
         this.logComment = logComment;
         if (logComment != null && !logComment.isEmpty()) {
-            rawSettings.put(ClientConfigProperties.SETTING_LOG_COMMENT, logComment);
+            rawSettings.put(ClientConfigProperties.SETTING_LOG_COMMENT.getKey(), logComment);
         }
         return this;
     }

--- a/client-v2/src/main/java/com/clickhouse/client/api/insert/InsertSettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/insert/InsertSettings.java
@@ -2,9 +2,7 @@ package com.clickhouse.client.api.insert;
 
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ClientSettings;
-import com.clickhouse.client.api.command.CommandSettings;
 import com.clickhouse.client.api.internal.ValidationUtils;
-import com.clickhouse.client.api.query.QuerySettings;
 import com.clickhouse.client.config.ClickHouseClientOption;
 
 import java.util.Collection;

--- a/client-v2/src/main/java/com/clickhouse/client/api/insert/InsertSettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/insert/InsertSettings.java
@@ -1,7 +1,7 @@
 package com.clickhouse.client.api.insert;
 
 import com.clickhouse.client.api.Client;
-import com.clickhouse.client.api.ClientSettings;
+import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.client.api.internal.ValidationUtils;
 import com.clickhouse.client.config.ClickHouseClientOption;
 
@@ -153,7 +153,7 @@ public class InsertSettings {
      * @return same instance of the builder
      */
     public InsertSettings httpHeader(String key, String value) {
-        rawSettings.put(ClientSettings.HTTP_HEADER_PREFIX + key, value);
+        rawSettings.put(ClientConfigProperties.HTTP_HEADER_PREFIX + key, value);
         return this;
     }
 
@@ -164,7 +164,7 @@ public class InsertSettings {
      * @return same instance of the builder
      */
     public InsertSettings httpHeader(String key, Collection<String> values) {
-        rawSettings.put(ClientSettings.HTTP_HEADER_PREFIX + key, ClientSettings.commaSeparated(values));
+        rawSettings.put(ClientConfigProperties.HTTP_HEADER_PREFIX + key, ClientConfigProperties.commaSeparated(values));
         return this;
     }
 
@@ -189,7 +189,7 @@ public class InsertSettings {
      * @return same instance of the builder
      */
     public InsertSettings serverSetting(String name, String value) {
-        rawSettings.put(ClientSettings.SERVER_SETTING_PREFIX + name, value);
+        rawSettings.put(ClientConfigProperties.SERVER_SETTING_PREFIX + name, value);
         return this;
     }
 
@@ -200,7 +200,7 @@ public class InsertSettings {
      * @return same instance of the builder
      */
     public InsertSettings serverSetting(String name, Collection<String> values) {
-        rawSettings.put(ClientSettings.SERVER_SETTING_PREFIX + name, ClientSettings.commaSeparated(values));
+        rawSettings.put(ClientConfigProperties.SERVER_SETTING_PREFIX + name, ClientConfigProperties.commaSeparated(values));
         return this;
     }
 
@@ -210,7 +210,7 @@ public class InsertSettings {
      * @param dbRoles
      */
     public InsertSettings setDBRoles(Collection<String> dbRoles) {
-        rawSettings.put(ClientSettings.SESSION_DB_ROLES, dbRoles);
+        rawSettings.put(ClientConfigProperties.SESSION_DB_ROLES, dbRoles);
         return this;
     }
 
@@ -220,7 +220,7 @@ public class InsertSettings {
      * @return list of DB roles
      */
     public Collection<String> getDBRoles() {
-        return (Collection<String>) rawSettings.get(ClientSettings.SESSION_DB_ROLES);
+        return (Collection<String>) rawSettings.get(ClientConfigProperties.SESSION_DB_ROLES);
     }
 
     /**
@@ -231,7 +231,7 @@ public class InsertSettings {
     public InsertSettings logComment(String logComment) {
         this.logComment = logComment;
         if (logComment != null && !logComment.isEmpty()) {
-            rawSettings.put(ClientSettings.SETTING_LOG_COMMENT, logComment);
+            rawSettings.put(ClientConfigProperties.SETTING_LOG_COMMENT, logComment);
         }
         return this;
     }

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/ClientV1AdaptorHelper.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/ClientV1AdaptorHelper.java
@@ -11,7 +11,6 @@ import com.clickhouse.client.api.insert.InsertSettings;
 import com.clickhouse.client.api.metrics.OperationMetrics;
 import com.clickhouse.client.api.metrics.ServerMetrics;
 import com.clickhouse.client.config.ClickHouseClientOption;
-import com.clickhouse.client.config.ClickHouseProxyType;
 import com.clickhouse.config.ClickHouseOption;
 
 import java.io.Serializable;

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
@@ -12,10 +12,9 @@ import com.clickhouse.client.api.ConnectionReuseStrategy;
 import com.clickhouse.client.api.ServerException;
 import com.clickhouse.client.api.data_formats.internal.SerializerUtils;
 import com.clickhouse.client.api.enums.ProxyType;
+import com.clickhouse.client.api.http.ClickHouseHttpProto;
 import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.client.config.ClickHouseDefaults;
-import com.clickhouse.client.http.ClickHouseHttpProto;
-import com.clickhouse.client.http.config.ClickHouseHttpOption;
 import org.apache.hc.client5.http.ConnectTimeoutException;
 import org.apache.hc.client5.http.classic.methods.HttpPost;
 import org.apache.hc.client5.http.config.ConnectionConfig;
@@ -198,7 +197,7 @@ public class HttpAPIClientHelper {
 
         connMgrBuilder.setDefaultConnectionConfig(createConnectionConfig());
         connMgrBuilder.setMaxConnTotal(Integer.MAX_VALUE); // as we do not know how many routes we will have
-        MapUtils.applyInt(chConfiguration, ClickHouseHttpOption.MAX_OPEN_CONNECTIONS.getKey(),
+        MapUtils.applyInt(chConfiguration, ClientSettings.HTTP_MAX_OPEN_CONNECTIONS,
                 connMgrBuilder::setMaxConnPerRoute);
 
 
@@ -266,7 +265,7 @@ public class HttpAPIClientHelper {
         } else {
             clientBuilder.setConnectionManager(basicConnectionManager(sslContext, socketConfig));
         }
-        long keepAliveTimeout = MapUtils.getLong(chConfiguration, ClickHouseHttpOption.KEEP_ALIVE_TIMEOUT.getKey());
+        long keepAliveTimeout = MapUtils.getLong(chConfiguration, ClientSettings.HTTP_KEEP_ALIVE_TIMEOUT);
         if (keepAliveTimeout > 0) {
             clientBuilder.setKeepAliveStrategy((response, context) -> TimeValue.ofMilliseconds(keepAliveTimeout));
         }
@@ -468,10 +467,6 @@ public class HttpAPIClientHelper {
             }
         }
 
-        if (requestConfig.containsKey(ClickHouseHttpOption.WAIT_END_OF_QUERY.getKey())) {
-            req.addParameter(ClickHouseHttpOption.WAIT_END_OF_QUERY.getKey(),
-                    requestConfig.get(ClickHouseHttpOption.WAIT_END_OF_QUERY.getKey()).toString());
-        }
         if (requestConfig.containsKey(ClickHouseClientOption.QUERY_ID.getKey())) {
             req.addParameter(ClickHouseHttpProto.QPARAM_QUERY_ID, requestConfig.get(ClickHouseClientOption.QUERY_ID.getKey()).toString());
         }

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
@@ -97,8 +97,8 @@ public class HttpAPIClientHelper {
 
         this.baseRequestConfig = reqConfBuilder.build();
 
-        boolean usingClientCompression=  chConfiguration.getOrDefault(ClientConfigProperties.COMPRESS_CLIENT_REQUEST, "false").equalsIgnoreCase("true");
-        boolean usingServerCompression=  chConfiguration.getOrDefault(ClientConfigProperties.COMPRESS_SERVER_RESPONSE, "false").equalsIgnoreCase("true");
+        boolean usingClientCompression=  chConfiguration.getOrDefault(ClientConfigProperties.COMPRESS_CLIENT_REQUEST.getKey(), "false").equalsIgnoreCase("true");
+        boolean usingServerCompression=  chConfiguration.getOrDefault(ClientConfigProperties.COMPRESS_SERVER_RESPONSE.getKey(), "false").equalsIgnoreCase("true");
         boolean useHttpCompression = chConfiguration.getOrDefault("client.use_http_compression", "false").equalsIgnoreCase("true");
         LOG.info("client compression: {}, server compression: {}, http compression: {}", usingClientCompression, usingServerCompression, useHttpCompression);
 
@@ -120,26 +120,26 @@ public class HttpAPIClientHelper {
             throw new ClientException("Failed to create default SSL context", e);
         }
         ClickHouseSslContextProvider sslContextProvider = ClickHouseSslContextProvider.getProvider();
-        String trustStorePath = chConfiguration.get(ClientConfigProperties.SSL_TRUST_STORE);
+        String trustStorePath = chConfiguration.get(ClientConfigProperties.SSL_TRUST_STORE.getKey());
         if (trustStorePath != null ) {
             try {
                 sslContext = sslContextProvider.getSslContextFromKeyStore(
                         trustStorePath,
-                        chConfiguration.get(ClientConfigProperties.SSL_KEY_STORE_PASSWORD),
-                        chConfiguration.get(ClientConfigProperties.SSL_KEYSTORE_TYPE)
+                        chConfiguration.get(ClientConfigProperties.SSL_KEY_STORE_PASSWORD.getKey()),
+                        chConfiguration.get(ClientConfigProperties.SSL_KEYSTORE_TYPE.getKey())
                 );
             } catch (SSLException e) {
                 throw new ClientMisconfigurationException("Failed to create SSL context from a keystore", e);
             }
-        } else if (chConfiguration.get(ClientConfigProperties.CA_CERTIFICATE) != null ||
-                chConfiguration.get(ClientConfigProperties.SSL_CERTIFICATE) != null ||
-                chConfiguration.get(ClientConfigProperties.SSL_KEY) != null) {
+        } else if (chConfiguration.get(ClientConfigProperties.CA_CERTIFICATE.getKey()) != null ||
+                chConfiguration.get(ClientConfigProperties.SSL_CERTIFICATE.getKey()) != null ||
+                chConfiguration.get(ClientConfigProperties.SSL_KEY.getKey()) != null) {
 
             try {
                 sslContext = sslContextProvider.getSslContextFromCerts(
-                        chConfiguration.get(ClientConfigProperties.SSL_CERTIFICATE),
-                        chConfiguration.get(ClientConfigProperties.SSL_KEY),
-                        chConfiguration.get(ClientConfigProperties.CA_CERTIFICATE)
+                        chConfiguration.get(ClientConfigProperties.SSL_CERTIFICATE.getKey()),
+                        chConfiguration.get(ClientConfigProperties.SSL_KEY.getKey()),
+                        chConfiguration.get(ClientConfigProperties.CA_CERTIFICATE.getKey())
                 );
             } catch (SSLException e) {
                 throw new ClientMisconfigurationException("Failed to create SSL context from certificates", e);
@@ -152,9 +152,9 @@ public class HttpAPIClientHelper {
 
     private ConnectionConfig createConnectionConfig() {
         ConnectionConfig.Builder connConfig = ConnectionConfig.custom();
-        connConfig.setTimeToLive(MapUtils.getLong(chConfiguration, ClientConfigProperties.CONNECTION_TTL),
+        connConfig.setTimeToLive(MapUtils.getLong(chConfiguration, ClientConfigProperties.CONNECTION_TTL.getKey()),
                 TimeUnit.MILLISECONDS);
-        connConfig.setConnectTimeout(MapUtils.getLong(chConfiguration, ClientConfigProperties.CONNECTION_TIMEOUT),
+        connConfig.setConnectTimeout(MapUtils.getLong(chConfiguration, ClientConfigProperties.CONNECTION_TIMEOUT.getKey()),
                 TimeUnit.MILLISECONDS);
         connConfig.setValidateAfterInactivity(CONNECTION_INACTIVITY_CHECK, TimeUnit.MILLISECONDS); // non-configurable for now
 
@@ -195,7 +195,7 @@ public class HttpAPIClientHelper {
 
         connMgrBuilder.setDefaultConnectionConfig(createConnectionConfig());
         connMgrBuilder.setMaxConnTotal(Integer.MAX_VALUE); // as we do not know how many routes we will have
-        MapUtils.applyInt(chConfiguration, ClientConfigProperties.HTTP_MAX_OPEN_CONNECTIONS,
+        MapUtils.applyInt(chConfiguration, ClientConfigProperties.HTTP_MAX_OPEN_CONNECTIONS.getKey(),
                 connMgrBuilder::setMaxConnPerRoute);
 
 
@@ -221,24 +221,24 @@ public class HttpAPIClientHelper {
 
         // Socket configuration
         SocketConfig.Builder soCfgBuilder = SocketConfig.custom();
-        MapUtils.applyInt(chConfiguration, ClientConfigProperties.SOCKET_OPERATION_TIMEOUT,
+        MapUtils.applyInt(chConfiguration, ClientConfigProperties.SOCKET_OPERATION_TIMEOUT.getKey(),
                 (t) -> soCfgBuilder.setSoTimeout(t, TimeUnit.MILLISECONDS));
-        MapUtils.applyInt(chConfiguration, ClientConfigProperties.SOCKET_RCVBUF_OPT,
+        MapUtils.applyInt(chConfiguration, ClientConfigProperties.SOCKET_RCVBUF_OPT.getKey(),
                 soCfgBuilder::setRcvBufSize);
-        MapUtils.applyInt(chConfiguration, ClientConfigProperties.SOCKET_SNDBUF_OPT,
+        MapUtils.applyInt(chConfiguration, ClientConfigProperties.SOCKET_SNDBUF_OPT.getKey(),
                 soCfgBuilder::setSndBufSize);
-        MapUtils.applyInt(chConfiguration, ClientConfigProperties.SOCKET_LINGER_OPT,
+        MapUtils.applyInt(chConfiguration, ClientConfigProperties.SOCKET_LINGER_OPT.getKey(),
                     (v) -> soCfgBuilder.setSoLinger(v, TimeUnit.SECONDS));
 
         // Proxy
-        String proxyHost = chConfiguration.get(ClientConfigProperties.PROXY_HOST);
-        String proxyPort = chConfiguration.get(ClientConfigProperties.PROXY_PORT);
+        String proxyHost = chConfiguration.get(ClientConfigProperties.PROXY_HOST.getKey());
+        String proxyPort = chConfiguration.get(ClientConfigProperties.PROXY_PORT.getKey());
         HttpHost proxy = null;
         if (proxyHost != null && proxyPort != null) {
             proxy = new HttpHost(proxyHost, Integer.parseInt(proxyPort));
         }
 
-        String proxyTypeVal = chConfiguration.get(ClientConfigProperties.PROXY_TYPE);
+        String proxyTypeVal = chConfiguration.get(ClientConfigProperties.PROXY_TYPE.getKey());
         ProxyType proxyType = proxyTypeVal == null ? null : ProxyType.valueOf(proxyTypeVal);
         if (proxyType == ProxyType.HTTP) {
             clientBuilder.setProxy(proxy);
@@ -263,7 +263,7 @@ public class HttpAPIClientHelper {
         } else {
             clientBuilder.setConnectionManager(basicConnectionManager(sslContext, socketConfig));
         }
-        long keepAliveTimeout = MapUtils.getLong(chConfiguration, ClientConfigProperties.HTTP_KEEP_ALIVE_TIMEOUT);
+        long keepAliveTimeout = MapUtils.getLong(chConfiguration, ClientConfigProperties.HTTP_KEEP_ALIVE_TIMEOUT.getKey());
         if (keepAliveTimeout > 0) {
             clientBuilder.setKeepAliveStrategy((response, context) -> TimeValue.ofMilliseconds(keepAliveTimeout));
         }
@@ -388,42 +388,38 @@ public class HttpAPIClientHelper {
     private void addHeaders(HttpPost req, Map<String, String> chConfig, Map<String, Object> requestConfig) {
         req.addHeader(HttpHeaders.CONTENT_TYPE, CONTENT_TYPE.getMimeType());
         if (requestConfig != null) {
-            if (requestConfig.containsKey(ClientConfigProperties.INPUT_OUTPUT_FORMAT)) {
-                req.addHeader(ClickHouseHttpProto.HEADER_FORMAT, requestConfig.get(ClientConfigProperties.INPUT_OUTPUT_FORMAT));
+            if (requestConfig.containsKey(ClientConfigProperties.INPUT_OUTPUT_FORMAT.getKey())) {
+                req.addHeader(ClickHouseHttpProto.HEADER_FORMAT, requestConfig.get(ClientConfigProperties.INPUT_OUTPUT_FORMAT.getKey()));
             }
-            if (requestConfig.containsKey(ClientConfigProperties.QUERY_ID)) {
-                req.addHeader(ClickHouseHttpProto.HEADER_QUERY_ID, requestConfig.get(ClientConfigProperties.QUERY_ID).toString());
+
+            if (requestConfig.containsKey(ClientConfigProperties.QUERY_ID.getKey())) {
+                req.addHeader(ClickHouseHttpProto.HEADER_QUERY_ID, requestConfig.get(ClientConfigProperties.QUERY_ID.getKey()).toString());
             }
-            if(requestConfig.containsKey(ClientConfigProperties.DATABASE)) {
-                req.addHeader(ClickHouseHttpProto.HEADER_DATABASE, requestConfig.get(ClientConfigProperties.DATABASE));
-            }else {
-                req.addHeader(ClickHouseHttpProto.HEADER_DATABASE, chConfig.get(ClientConfigProperties.DATABASE));
-            }
-            if (requestConfig.containsKey(ClientConfigProperties.INPUT_OUTPUT_FORMAT)) {
-                req.addHeader(ClickHouseHttpProto.HEADER_FORMAT, requestConfig.get(ClientConfigProperties.DATABASE));
-            }
-            if (requestConfig.containsKey(ClientConfigProperties.QUERY_ID)) {
-                req.addHeader(ClickHouseHttpProto.HEADER_QUERY_ID, requestConfig.get(ClientConfigProperties.QUERY_ID).toString());
+
+            if(requestConfig.containsKey(ClientConfigProperties.DATABASE.getKey())) {
+                req.addHeader(ClickHouseHttpProto.HEADER_DATABASE, requestConfig.get(ClientConfigProperties.DATABASE.getKey()));
+            } else {
+                req.addHeader(ClickHouseHttpProto.HEADER_DATABASE, chConfig.get(ClientConfigProperties.DATABASE.getKey()));
             }
         }
 
         if (MapUtils.getFlag(chConfig, "ssl_authentication", false)) {
-            req.addHeader(ClickHouseHttpProto.HEADER_DB_USER, chConfig.get(ClientConfigProperties.USER));
+            req.addHeader(ClickHouseHttpProto.HEADER_DB_USER, chConfig.get(ClientConfigProperties.USER.getKey()));
             req.addHeader(ClickHouseHttpProto.HEADER_SSL_CERT_AUTH, "on");
-        } else if (chConfig.getOrDefault(ClientConfigProperties.HTTP_USE_BASIC_AUTH, "true").equalsIgnoreCase("true")) {
+        } else if (chConfig.getOrDefault(ClientConfigProperties.HTTP_USE_BASIC_AUTH.getKey(), "true").equalsIgnoreCase("true")) {
             req.addHeader(HttpHeaders.AUTHORIZATION, "Basic " + Base64.getEncoder().encodeToString(
-                    (chConfig.get(ClientConfigProperties.USER) + ":" + chConfig.get(ClientConfigProperties.PASSWORD)).getBytes(StandardCharsets.UTF_8)));
+                    (chConfig.get(ClientConfigProperties.USER.getKey()) + ":" + chConfig.get(ClientConfigProperties.PASSWORD.getKey())).getBytes(StandardCharsets.UTF_8)));
         } else {
-            req.addHeader(ClickHouseHttpProto.HEADER_DB_USER, chConfig.get(ClientConfigProperties.USER));
-            req.addHeader(ClickHouseHttpProto.HEADER_DB_PASSWORD, chConfig.get(ClientConfigProperties.PASSWORD));
+            req.addHeader(ClickHouseHttpProto.HEADER_DB_USER, chConfig.get(ClientConfigProperties.USER.getKey()));
+            req.addHeader(ClickHouseHttpProto.HEADER_DB_PASSWORD, chConfig.get(ClientConfigProperties.PASSWORD.getKey()));
 
         }
         if (proxyAuthHeaderValue != null) {
             req.addHeader(HttpHeaders.PROXY_AUTHORIZATION, proxyAuthHeaderValue);
         }
 
-        boolean serverCompression = chConfiguration.getOrDefault(ClientConfigProperties.COMPRESS_SERVER_RESPONSE, "false").equalsIgnoreCase("true");
-        boolean clientCompression = chConfiguration.getOrDefault(ClientConfigProperties.COMPRESS_CLIENT_REQUEST, "false").equalsIgnoreCase("true");
+        boolean serverCompression = chConfiguration.getOrDefault(ClientConfigProperties.COMPRESS_SERVER_RESPONSE.getKey(), "false").equalsIgnoreCase("true");
+        boolean clientCompression = chConfiguration.getOrDefault(ClientConfigProperties.COMPRESS_CLIENT_REQUEST.getKey(), "false").equalsIgnoreCase("true");
         boolean useHttpCompression = chConfiguration.getOrDefault("client.use_http_compression", "false").equalsIgnoreCase("true");
 
         if (useHttpCompression) {
@@ -465,8 +461,8 @@ public class HttpAPIClientHelper {
             }
         }
 
-        if (requestConfig.containsKey(ClientConfigProperties.QUERY_ID)) {
-            req.addParameter(ClickHouseHttpProto.QPARAM_QUERY_ID, requestConfig.get(ClientConfigProperties.QUERY_ID).toString());
+        if (requestConfig.containsKey(ClientConfigProperties.QUERY_ID.getKey())) {
+            req.addParameter(ClickHouseHttpProto.QPARAM_QUERY_ID, requestConfig.get(ClientConfigProperties.QUERY_ID.getKey()).toString());
         }
         if (requestConfig.containsKey("statement_params")) {
             Map<String, Object> params = (Map<String, Object>) requestConfig.get("statement_params");
@@ -475,8 +471,8 @@ public class HttpAPIClientHelper {
             }
         }
 
-        boolean serverCompression = chConfiguration.getOrDefault(ClientConfigProperties.COMPRESS_SERVER_RESPONSE, "false").equalsIgnoreCase("true");
-        boolean clientCompression = chConfiguration.getOrDefault(ClientConfigProperties.COMPRESS_CLIENT_REQUEST, "false").equalsIgnoreCase("true");
+        boolean serverCompression = chConfiguration.getOrDefault(ClientConfigProperties.COMPRESS_SERVER_RESPONSE.getKey(), "false").equalsIgnoreCase("true");
+        boolean clientCompression = chConfiguration.getOrDefault(ClientConfigProperties.COMPRESS_CLIENT_REQUEST.getKey(), "false").equalsIgnoreCase("true");
         boolean useHttpCompression = chConfiguration.getOrDefault("client.use_http_compression", "false").equalsIgnoreCase("true");
 
 
@@ -494,8 +490,8 @@ public class HttpAPIClientHelper {
             }
         }
 
-        Collection<String> sessionRoles = (Collection<String>) requestConfig.getOrDefault(ClientConfigProperties.SESSION_DB_ROLES,
-                ClientConfigProperties.valuesFromCommaSeparated(chConfiguration.getOrDefault(ClientConfigProperties.SESSION_DB_ROLES, "")));
+        Collection<String> sessionRoles = (Collection<String>) requestConfig.getOrDefault(ClientConfigProperties.SESSION_DB_ROLES.getKey(),
+                ClientConfigProperties.valuesFromCommaSeparated(chConfiguration.getOrDefault(ClientConfigProperties.SESSION_DB_ROLES.getKey(), "")));
         if (!sessionRoles.isEmpty()) {
 
             sessionRoles.forEach(r -> req.addParameter(ClickHouseHttpProto.QPARAM_ROLE, r));
@@ -509,8 +505,8 @@ public class HttpAPIClientHelper {
     }
 
     private HttpEntity wrapEntity(HttpEntity httpEntity, int httpStatus, boolean isResponse) {
-        boolean serverCompression = MapUtils.getFlag(chConfiguration, ClientConfigProperties.COMPRESS_SERVER_RESPONSE, false);
-        boolean clientCompression = MapUtils.getFlag(chConfiguration, ClientConfigProperties.COMPRESS_CLIENT_REQUEST,  false);
+        boolean serverCompression = MapUtils.getFlag(chConfiguration, ClientConfigProperties.COMPRESS_SERVER_RESPONSE.getKey(), false);
+        boolean clientCompression = MapUtils.getFlag(chConfiguration, ClientConfigProperties.COMPRESS_CLIENT_REQUEST.getKey(),  false);
 
         if (serverCompression || clientCompression) {
             // Server doesn't compress certain errors like 403

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/ServerSettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/ServerSettings.java
@@ -1,0 +1,12 @@
+package com.clickhouse.client.api.internal;
+
+
+/**
+ * Incomplete list of server side settings.
+ * This class is not intended to list all possible settings, but only those that are commonly used.
+ *
+ */
+public final class ServerSettings {
+
+    public static final String WAIT_END_OF_QUERY = "wait_end_of_query";
+}

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/ServerSettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/ServerSettings.java
@@ -9,4 +9,17 @@ package com.clickhouse.client.api.internal;
 public final class ServerSettings {
 
     public static final String WAIT_END_OF_QUERY = "wait_end_of_query";
+
+    // -- Experimental features --
+
+    /**
+     * Server will expect a string in JSON format and parse it into a JSON object.
+     */
+    public static final String INPUT_FORMAT_BINARY_READ_JSON_AS_STRING = "input_format_binary_read_json_as_string";
+
+    /**
+     * Server will return a JSON object as a string.
+     */
+    public static final String OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING = "output_format_binary_write_json_as_string";
+
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/SettingsConverter.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/SettingsConverter.java
@@ -1,18 +1,22 @@
 package com.clickhouse.client.api.internal;
 
-import com.clickhouse.client.config.ClickHouseClientOption;
-import com.clickhouse.client.http.config.ClickHouseHttpOption;
+import com.clickhouse.client.config.ClickHouseDefaults;
+import com.clickhouse.client.config.ClickHouseHealthCheckMethod;
+import com.clickhouse.client.config.ClickHouseProxyType;
+import com.clickhouse.client.config.ClickHouseSslMode;
 import com.clickhouse.config.ClickHouseOption;
+import com.clickhouse.data.ClickHouseChecker;
+import com.clickhouse.data.ClickHouseCompression;
+import com.clickhouse.data.ClickHouseDataConfig;
 
 import java.io.Serializable;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.regex.Pattern;
 
 public class SettingsConverter {
@@ -103,66 +107,684 @@ public class SettingsConverter {
         Map<String, ClickHouseOption> map = new HashMap<>();
 
 
-        Arrays.asList(ClickHouseClientOption.FORMAT,
-                        ClickHouseClientOption.MAX_EXECUTION_TIME,
-                        ClickHouseHttpOption.CUSTOM_PARAMS,
-                        ClickHouseClientOption.AUTO_DISCOVERY,
-                        ClickHouseClientOption.CUSTOM_SETTINGS,
-                        ClickHouseClientOption.CUSTOM_SOCKET_FACTORY,
-                        ClickHouseClientOption.CUSTOM_SOCKET_FACTORY_OPTIONS,
-                        ClickHouseClientOption.CLIENT_NAME,
-                        ClickHouseClientOption.DECOMPRESS,
-                        ClickHouseClientOption.DECOMPRESS_ALGORITHM,
-                        ClickHouseClientOption.DECOMPRESS_LEVEL,
-                        ClickHouseClientOption.COMPRESS,
-                        ClickHouseClientOption.COMPRESS_ALGORITHM,
-                        ClickHouseClientOption.COMPRESS_LEVEL,
-                        ClickHouseClientOption.CONNECTION_TIMEOUT,
-                        ClickHouseClientOption.DATABASE,
-                        ClickHouseClientOption.MAX_BUFFER_SIZE,
-                        ClickHouseClientOption.BUFFER_SIZE,
-                        ClickHouseClientOption.BUFFER_QUEUE_VARIATION,
-                        ClickHouseClientOption.READ_BUFFER_SIZE,
-                        ClickHouseClientOption.WRITE_BUFFER_SIZE,
-                        ClickHouseClientOption.REQUEST_CHUNK_SIZE,
-                        ClickHouseClientOption.REQUEST_BUFFERING,
-                        ClickHouseClientOption.RESPONSE_BUFFERING,
-                        ClickHouseClientOption.MAX_MAPPER_CACHE,
-                        ClickHouseClientOption.MAX_QUEUED_BUFFERS,
-                        ClickHouseClientOption.MAX_QUEUED_REQUESTS,
-                        ClickHouseClientOption.MAX_RESULT_ROWS,
-                        ClickHouseClientOption.MAX_THREADS_PER_CLIENT,
-                        ClickHouseClientOption.PRODUCT_NAME,
-                        ClickHouseClientOption.NODE_CHECK_INTERVAL,
-                        ClickHouseClientOption.FAILOVER,
-                        ClickHouseClientOption.RETRY,
-                        ClickHouseClientOption.REPEAT_ON_SESSION_LOCK,
-                        ClickHouseClientOption.REUSE_VALUE_WRAPPER,
-                        ClickHouseClientOption.SERVER_TIME_ZONE,
-                        ClickHouseClientOption.SERVER_VERSION,
-                        ClickHouseClientOption.SESSION_TIMEOUT,
-                        ClickHouseClientOption.SESSION_CHECK,
-                        ClickHouseClientOption.SOCKET_TIMEOUT,
-                        ClickHouseClientOption.SSL,
-                        ClickHouseClientOption.SSL_MODE,
-                        ClickHouseClientOption.SSL_ROOT_CERTIFICATE,
-                        ClickHouseClientOption.SSL_CERTIFICATE,
-                        ClickHouseClientOption.SSL_KEY,
-                        ClickHouseClientOption.KEY_STORE_TYPE,
-                        ClickHouseClientOption.TRUST_STORE,
-                        ClickHouseClientOption.KEY_STORE_PASSWORD,
-                        ClickHouseClientOption.TRANSACTION_TIMEOUT,
-                        ClickHouseClientOption.WIDEN_UNSIGNED_TYPES,
-                        ClickHouseClientOption.USE_BINARY_STRING,
-                        ClickHouseClientOption.USE_BLOCKING_QUEUE,
-                        ClickHouseClientOption.USE_COMPILATION,
-                        ClickHouseClientOption.USE_OBJECTS_IN_ARRAYS,
-                        ClickHouseClientOption.USE_SERVER_TIME_ZONE,
-                        ClickHouseClientOption.USE_SERVER_TIME_ZONE_FOR_DATES,
-                        ClickHouseClientOption.SERVER_TIME_ZONE,
-                        ClickHouseClientOption.USE_TIME_ZONE)
+        Arrays.asList(OldClientOptions.FORMAT,
+                        OldClientOptions.MAX_EXECUTION_TIME,
+                        OldClientOptions.CUSTOM_PARAMS,
+                        OldClientOptions.AUTO_DISCOVERY,
+                        OldClientOptions.CUSTOM_SETTINGS,
+                        OldClientOptions.CUSTOM_SOCKET_FACTORY,
+                        OldClientOptions.CUSTOM_SOCKET_FACTORY_OPTIONS,
+                        OldClientOptions.CLIENT_NAME,
+                        OldClientOptions.DECOMPRESS,
+                        OldClientOptions.DECOMPRESS_ALGORITHM,
+                        OldClientOptions.DECOMPRESS_LEVEL,
+                        OldClientOptions.COMPRESS,
+                        OldClientOptions.COMPRESS_ALGORITHM,
+                        OldClientOptions.COMPRESS_LEVEL,
+                        OldClientOptions.CONNECTION_TIMEOUT,
+                        OldClientOptions.DATABASE,
+                        OldClientOptions.MAX_BUFFER_SIZE,
+                        OldClientOptions.BUFFER_SIZE,
+                        OldClientOptions.BUFFER_QUEUE_VARIATION,
+                        OldClientOptions.READ_BUFFER_SIZE,
+                        OldClientOptions.WRITE_BUFFER_SIZE,
+                        OldClientOptions.REQUEST_CHUNK_SIZE,
+                        OldClientOptions.REQUEST_BUFFERING,
+                        OldClientOptions.RESPONSE_BUFFERING,
+                        OldClientOptions.MAX_MAPPER_CACHE,
+                        OldClientOptions.MAX_QUEUED_BUFFERS,
+                        OldClientOptions.MAX_QUEUED_REQUESTS,
+                        OldClientOptions.MAX_RESULT_ROWS,
+                        OldClientOptions.MAX_THREADS_PER_CLIENT,
+                        OldClientOptions.PRODUCT_NAME,
+                        OldClientOptions.NODE_CHECK_INTERVAL,
+                        OldClientOptions.FAILOVER,
+                        OldClientOptions.RETRY,
+                        OldClientOptions.REPEAT_ON_SESSION_LOCK,
+                        OldClientOptions.REUSE_VALUE_WRAPPER,
+                        OldClientOptions.SERVER_TIME_ZONE,
+                        OldClientOptions.SERVER_VERSION,
+                        OldClientOptions.SESSION_TIMEOUT,
+                        OldClientOptions.SESSION_CHECK,
+                        OldClientOptions.SOCKET_TIMEOUT,
+                        OldClientOptions.SSL,
+                        OldClientOptions.SSL_MODE,
+                        OldClientOptions.SSL_ROOT_CERTIFICATE,
+                        OldClientOptions.SSL_CERTIFICATE,
+                        OldClientOptions.SSL_KEY,
+                        OldClientOptions.KEY_STORE_TYPE,
+                        OldClientOptions.TRUST_STORE,
+                        OldClientOptions.KEY_STORE_PASSWORD,
+                        OldClientOptions.TRANSACTION_TIMEOUT,
+                        OldClientOptions.WIDEN_UNSIGNED_TYPES,
+                        OldClientOptions.USE_BINARY_STRING,
+                        OldClientOptions.USE_BLOCKING_QUEUE,
+                        OldClientOptions.USE_COMPILATION,
+                        OldClientOptions.USE_OBJECTS_IN_ARRAYS,
+                        OldClientOptions.USE_SERVER_TIME_ZONE,
+                        OldClientOptions.USE_SERVER_TIME_ZONE_FOR_DATES,
+                        OldClientOptions.SERVER_TIME_ZONE,
+                        OldClientOptions.USE_TIME_ZONE)
                 .forEach(option -> map.put(option.getKey(), option));
 
         return Collections.unmodifiableMap(map);
+    }
+
+    // copy from old client 
+    public enum OldClientOptions implements ClickHouseOption {
+
+        CUSTOM_PARAMS("custom_http_params", "", "Custom HTTP query parameters."),
+        
+        /**
+         * Whether the client should run in async mode(e.g.
+         * {@link com.clickhouse.client.ClickHouseClient#execute(com.clickhouse.client.ClickHouseRequest)}
+         * in a separate thread).
+         */
+        ASYNC("async", ClickHouseDataConfig.DEFAULT_ASYNC, "Whether the client should run in async mode."),
+        /**
+         * Whether the client should discover more nodes from system tables and/or
+         * clickhouse-keeper/zookeeper.
+         */
+        AUTO_DISCOVERY("auto_discovery", false,
+                "Whether the client should discover more nodes from system tables and/or clickhouse-keeper/zookeeper."),
+        /**
+         * Custom server settings for all queries.
+         */
+        CUSTOM_SETTINGS("custom_settings", "", "Comma separated custom server settings for all queries."),
+        /**
+         * Custom socket factory.
+         */
+        CUSTOM_SOCKET_FACTORY("custom_socket_factory", "",
+                "Full qualified class name of custom socket factory. This is only supported by TCP client and Apache Http Client."),
+        /**
+         * Additional socket factory options. Only useful only when
+         * {@link #CUSTOM_SOCKET_FACTORY} is set.
+         */
+        CUSTOM_SOCKET_FACTORY_OPTIONS("custom_socket_factory_options", "",
+                "Comma separated options for custom socket factory."),
+        /**
+         * Load balancing policy.
+         */
+        LOAD_BALANCING_POLICY("load_balancing_policy", "",
+                "Load balancing policy, can be one of '', 'firstAlive', 'random', 'roundRobin', or full qualified class name implementing ClickHouseLoadBalancingPolicy."),
+        /**
+         * Load balancing tags for filtering out nodes.
+         */
+        LOAD_BALANCING_TAGS("load_balancing_tags", "", "Load balancing tags for filtering out nodes."),
+        /**
+         * Health check interval in milliseconds.
+         */
+        HEALTH_CHECK_INTERVAL("health_check_interval", 0,
+                "Health check interval in milliseconds, zero or negative value means one-time."),
+        /**
+         * Health check method.
+         */
+        HEALTH_CHECK_METHOD("health_check_method", ClickHouseHealthCheckMethod.SELECT_ONE, "Health check method."),
+        /**
+         * Node discovery interval in milliseconds.
+         */
+        NODE_DISCOVERY_INTERVAL("node_discovery_interval", 0,
+                "Node discovery interval in milliseconds, zero or negative value means one-time discovery."),
+        /**
+         * Maximum number of nodes can be discovered at a time.
+         */
+        NODE_DISCOVERY_LIMIT("node_discovery_limit", 100,
+                "Maximum number of nodes can be discovered at a time, zero or negative value means no limit."),
+        /**
+         * Node check interval in milliseconds.
+         */
+        NODE_CHECK_INTERVAL("node_check_interval", 0,
+                "Node check interval in milliseconds, negative number is treated as zero."),
+        /**
+         * Maximum number of nodes can be used for operation at a time.
+         */
+        NODE_GROUP_SIZE("node_group_size", 50,
+                "Maximum number of nodes can be used for operation at a time, zero or negative value means all."),
+        /**
+         * Whether to perform health check against all nodes or just faulty ones.
+         */
+        CHECK_ALL_NODES("check_all_nodes", false,
+                "Whether to perform health check against all nodes or just faulty ones."),
+        /**
+         * Default buffer size in byte for both request and response. It will be reset
+         * to {@link #MAX_BUFFER_SIZE} if it's too large.
+         */
+        BUFFER_SIZE("buffer_size", ClickHouseDataConfig.DEFAULT_BUFFER_SIZE,
+                "Default buffer size in byte for both request and response."),
+        /**
+         * Number of times the buffer queue is filled up before increasing capacity of
+         * buffer queue. Zero or negative value means the queue length is fixed.
+         */
+        BUFFER_QUEUE_VARIATION("buffer_queue_variation", ClickHouseDataConfig.DEFAULT_BUFFER_QUEUE_VARIATION,
+                "Number of times the buffer queue is filled up before increasing capacity of buffer queue. Zero or negative value means the queue length is fixed."),
+        /**
+         * Read buffer size in byte. It's mainly for input stream(e.g. reading data from
+         * server response). Its value defaults to {@link #BUFFER_SIZE}, and it will be
+         * reset to {@link #MAX_BUFFER_SIZE} when it's too large.
+         */
+        READ_BUFFER_SIZE("read_buffer_size", 0,
+                "Read buffer size in byte, zero or negative value means same as buffer_size"),
+        /**
+         * Write buffer size in byte. It's mainly for output stream(e.g. writing data
+         * into request). Its value defaults to {@link #BUFFER_SIZE}, and it will
+         * be reset to {@link #MAX_BUFFER_SIZE} when it's too large.
+         */
+        WRITE_BUFFER_SIZE("write_buffer_size", 0,
+                "Write buffer size in byte, zero or negative value means same as buffer_size"),
+        /**
+         * Maximum request chunk size in byte.
+         */
+        REQUEST_CHUNK_SIZE("request_chunk_size", 0,
+                "Maximum request chunk size in byte, zero or negative value means same as write_buffer_size"),
+        /**
+         * Request buffering mode.
+         */
+        REQUEST_BUFFERING("request_buffering", ClickHouseDefaults.BUFFERING.getDefaultValue(),
+                "Request buffering mode"),
+        /**
+         * Response buffering mode.
+         */
+        RESPONSE_BUFFERING("response_buffering", ClickHouseDefaults.BUFFERING.getDefaultValue(),
+                "Response buffering mode."),
+        /**
+         * Client name.
+         */
+        CLIENT_NAME("client_name", "ClickHouse Java Client",
+                "Client name, which is either 'client_name' or 'http_user_agent' shows up in system.query_log table."),
+        /**
+         * Whether server will compress response to client or not.
+         */
+        COMPRESS("compress", true, "Whether the server will compress response it sends to client."),
+        /**
+         * Whether server will decompress request from client or not.
+         */
+        DECOMPRESS("decompress", false, "Whether the server will decompress request from client."),
+        /**
+         * Compression algorithm server will use to compress response, when
+         * {@link #COMPRESS} is {@code true}.
+         */
+        COMPRESS_ALGORITHM("compress_algorithm", ClickHouseCompression.LZ4,
+                "Algorithm used for server to compress response."),
+        /**
+         * Compression algorithm server will use to decompress request, when
+         * {@link #DECOMPRESS} is {@code true}.
+         */
+        DECOMPRESS_ALGORITHM("decompress_algorithm", ClickHouseCompression.LZ4,
+                "Algorithm for server to decompress request."),
+        /**
+         * Compression level for compressing server response.
+         */
+        COMPRESS_LEVEL("compress_level", ClickHouseDataConfig.DEFAULT_READ_COMPRESS_LEVEL,
+                "Compression level for response, -1 standards for default"),
+        /**
+         * Compression level for decompress client request.
+         */
+        DECOMPRESS_LEVEL("decompress_level", ClickHouseDataConfig.DEFAULT_WRITE_COMPRESS_LEVEL,
+                "Compression level for request, -1 standards for default"),
+
+        /**
+         * Connection timeout in milliseconds.
+         */
+        CONNECTION_TIMEOUT("connect_timeout", 5000,
+                "Connection timeout in milliseconds. It's also used for waiting a connection being closed."),
+        /**
+         * Default database.
+         */
+        DATABASE("database", "", "Default database."),
+        /**
+         * Maximum number of times failover can happen for a request.
+         */
+        FAILOVER("failover", 0,
+                "Maximum number of times failover can happen for a request, zero or negative value means no failover."),
+        /**
+         * Default format.
+         */
+        FORMAT("format", ClickHouseDataConfig.DEFAULT_FORMAT, "Default format."),
+        /**
+         * Whether to log leading comment(as log_comment in system.query_log) of the
+         * query.
+         */
+        LOG_LEADING_COMMENT("log_leading_comment", false,
+                "Whether to log leading comment(as log_comment in system.query_log) of the query."),
+        /**
+         * Maximum buffer size in byte can be used for streaming. It's not supposed to
+         * be larger than {@code Integer.MAX_VALUE - 8}.
+         */
+        MAX_BUFFER_SIZE("max_buffer_size", ClickHouseDataConfig.DEFAULT_MAX_BUFFER_SIZE,
+                "Maximum buffer size in byte can be used for streaming."),
+        /**
+         * Maximum number of mappers can be cached.
+         */
+        MAX_MAPPER_CACHE("max_mapper_cache", ClickHouseDataConfig.DEFAULT_MAX_MAPPER_CACHE,
+                "Maximum number of mappers can be cached."),
+        /**
+         * Maximum query execution time in seconds.
+         */
+        MAX_EXECUTION_TIME("max_execution_time", 0, "Maximum query execution time in seconds, 0 means no limit."),
+        /**
+         * Maximum queued in-memory buffers.
+         */
+        MAX_QUEUED_BUFFERS("max_queued_buffers", ClickHouseDataConfig.DEFAULT_MAX_QUEUED_BUFFERS,
+                "Maximum queued in-memory buffers, 0 or negative number means no limit."),
+        /**
+         * Maxium queued requests. When {@link #MAX_THREADS_PER_CLIENT} is greater than
+         * zero, this will also be applied to client's thread pool as well.
+         */
+        MAX_QUEUED_REQUESTS("max_queued_requests", 0, "Maximum queued requests, 0 or negative number means no limit."),
+        /**
+         * Maximum rows allowed in the result.
+         */
+        MAX_RESULT_ROWS("max_result_rows", 0L,
+                "Limit on the number of rows in the result. "
+                        + "Also checked for subqueries, and on remote servers when running parts of a distributed query."),
+        /**
+         * Maximum size of thread pool for each client.
+         */
+        MAX_THREADS_PER_CLIENT("max_threads_per_client", 0,
+                "Size of thread pool for each client instance, 0 or negative number means the client will use shared thread pool."),
+        /**
+         * Product name usered in user agent.
+         */
+        PRODUCT_NAME("product_name", "ClickHouse-JavaClient", "Product name used in user agent."),
+        /**
+         * Method to rename response columns.
+         */
+        RENAME_RESPONSE_COLUMN("rename_response_column", ClickHouseDataConfig.DEFAULT_COLUMN_RENAME_METHOD,
+                "Method to rename response columns."),
+        /**
+         * Maximum number of times retry can happen for a request.
+         */
+        RETRY("retry", 0,
+                "Maximum number of times retry can happen for a request, zero or negative value means no retry."),
+        /**
+         * Whether to repeat execution when session is locked, until timed out(according
+         * to {@link #SESSION_TIMEOUT} or {@link #CONNECTION_TIMEOUT}).
+         */
+        REPEAT_ON_SESSION_LOCK("repeat_on_session_lock", true,
+                "Whether to repeat execution when session is locked, until timed out(according to 'session_timeout' or 'connect_timeout')."),
+        /**
+         * Whether to reuse wrapper of value(e.g. ClickHouseValue or
+         * ClickHouseRecord) for memory efficiency.
+         */
+        REUSE_VALUE_WRAPPER("reuse_value_wrapper", ClickHouseDataConfig.DEFAULT_REUSE_VALUE_WRAPPER,
+                "Whether to reuse wrapper of value(e.g. ClickHouseValue or ClickHouseRecord) for memory efficiency."),
+        /**
+         * Server revision.
+         */
+        SERVER_REVISION("server_revision", 54442, "Server revision."),
+        /**
+         * Server timezone.
+         */
+        SERVER_TIME_ZONE("server_time_zone", "", "Server timezone."),
+        /**
+         * Server version.
+         */
+        SERVER_VERSION("server_version", "", "Server version."),
+        /**
+         * Session id.
+         */
+        SESSION_ID("session_id", "", "Session id"),
+        /**
+         * Whether to check if session id is validate.
+         */
+        SESSION_CHECK("session_check", false, "Whether to check if existence of session id."),
+        /**
+         * Session timeout in seconds.
+         */
+        SESSION_TIMEOUT("session_timeout", 0,
+                "Session timeout in seconds. 0 or negative number means same as server default."),
+        /**
+         * Socket timeout in milliseconds.
+         */
+        SOCKET_TIMEOUT("socket_timeout", ClickHouseDataConfig.DEFAULT_TIMEOUT, "Socket timeout in milliseconds."),
+        /**
+         * Whether allows for the reuse of local addresses and ports. See
+         * {@link java.net.StandardSocketOptions#SO_REUSEADDR}.
+         */
+        SOCKET_REUSEADDR("socket_reuseaddr", false,
+                "Whether allows for the reuse of local addresses and ports. "
+                        + "Only works for client using custom Socket(e.g. TCP client or HTTP provider with custom SocketFactory etc.)."),
+        /**
+         * Whether to enable keep-alive packets for a socket connection. See
+         * {@link java.net.StandardSocketOptions#SO_KEEPALIVE}.
+         */
+        SOCKET_KEEPALIVE("socket_keepalive", false,
+                "Whether to enable keep-alive packets for a socket connection. Only works for client using custom Socket."),
+        /**
+         * Seconds to wait while data is being transmitted before closing the socket.
+         * Use negative number to disable the option. See
+         * {@link java.net.StandardSocketOptions#SO_LINGER}.
+         */
+        SOCKET_LINGER("socket_linger", -1,
+                "Seconds to wait while data is being transmitted before closing the socket. Use negative number to disable the option. "
+                        + "Only works for client using custom Socket(e.g. TCP client or HTTP provider with custom SocketFactory etc.)."),
+        /**
+         * Type-of-service(TOS) or traffic class field in the IP header for a socket.
+         * See {@link java.net.StandardSocketOptions#IP_TOS}.
+         */
+        SOCKET_IP_TOS("socket_ip_tos", 0,
+                "Socket IP_TOS option which indicates IP package priority. Only works for client using custom Socket."),
+        /**
+         * See {@link java.net.StandardSocketOptions#TCP_NODELAY}.
+         */
+        SOCKET_TCP_NODELAY("socket_tcp_nodelay", false, ""),
+        /**
+         * Size of the socket receive buffer in bytes. See
+         * {@link java.net.StandardSocketOptions#SO_RCVBUF}.
+         */
+        SOCKET_RCVBUF("socket_rcvbuf", 0,
+                "Size of the socket receive buffer in bytes. Only works for client using custom Socket."),
+        /**
+         * Size of the socket send buffer in bytes. See
+         * {@link java.net.StandardSocketOptions#SO_SNDBUF}.
+         */
+        SOCKET_SNDBUF("socket_sndbuf", 0,
+                "Size of the socket send buffer in bytes. Only works for client using custom Socket."),
+        // TODO: new and extended socket options(e.g SO_REUSEPORT and TCP_QUICKACK etc.)
+
+        /**
+         * Whether to enable SSL for the connection.
+         */
+        SSL("ssl", false, "Whether to enable SSL/TLS for the connection."),
+        /**
+         * SSL mode.
+         */
+        SSL_MODE("sslmode", ClickHouseSslMode.STRICT, "verify or not certificate: none (don't verify), strict (verify)"),
+        /**
+         * SSL root certificiate.
+         */
+        SSL_ROOT_CERTIFICATE("sslrootcert", "", "SSL/TLS root certificates."),
+        /**
+         * SSL certificiate.
+         */
+        SSL_CERTIFICATE("sslcert", "", "SSL/TLS certificate."),
+        /**
+         * SSL key.
+         */
+        SSL_KEY("sslkey", "", "RSA key in PKCS#8 format.", true),
+        /**
+         * Key Store type.
+         */
+        KEY_STORE_TYPE("key_store_type", "", "Specifies the type or format of the keystore/truststore file used for SSL/TLS configuration, such as \"JKS\" (Java KeyStore) or \"PKCS12.\"", true),
+        /**
+         * Trust Store.
+         */
+        TRUST_STORE("trust_store", "", "Path to the truststore file", true),
+        /**
+         * Trust Store password.
+         */
+        KEY_STORE_PASSWORD("key_store_password", "", "Password needed to access the keystore file specified in the keystore config", true),
+        /**
+         * Transaction timeout in seconds.
+         */
+        TRANSACTION_TIMEOUT("transaction_timeout", 0,
+                "Transaction timeout in seconds. 0 or negative number means same as session_timeout."),
+        /**
+         * Whether to convert unsigned types to the next widest type(e.g. use
+         * {@code short} for UInt8 instead of {@code byte}, and {@code UnsignedLong} for
+         * UInt64).
+         */
+        WIDEN_UNSIGNED_TYPES("widen_unsigned_types", ClickHouseDataConfig.DEFAULT_WIDEN_UNSIGNED_TYPE,
+                "Whether to convert unsigned types to the next widest type(e.g. use short for UInt8 instead of byte, and UnsignedLong for UInt64)."),
+        /**
+         * Whether to support binary string. Enable this option to treat
+         * {@code FixedString} and {@code String} as byte array.
+         */
+        USE_BINARY_STRING("use_binary_string", ClickHouseDataConfig.DEFAULT_USE_BINARY_STRING,
+                "Whether to support binary string. Enable this option to treat FixedString and String as byte array."),
+        /**
+         * Whether to use blocking queue for buffering.
+         */
+        USE_BLOCKING_QUEUE("use_blocking_queue", ClickHouseDataConfig.DEFAULT_USE_BLOCKING_QUEUE,
+                "Whether to use blocking queue for buffering."),
+        /**
+         * Whether to use compilation(generated byte code) in object mapping and
+         * serialization.
+         */
+        USE_COMPILATION("use_compilation", ClickHouseDataConfig.DEFAULT_USE_COMPILATION,
+                "Whether to use compilation(generated byte code) in object mapping and serialization."),
+        /**
+         * Whether Object[] should be used instead of primitive arrays.
+         */
+        USE_OBJECTS_IN_ARRAYS("use_objects_in_arrays", ClickHouseDataConfig.DEFAULT_USE_OBJECT_IN_ARRAY,
+                "Whether Object[] should be used instead of primitive arrays."),
+        /**
+         * Type of proxy can be used to access ClickHouse server. To use an HTTP/SOCKS
+         * proxy, you must specify the {@link #PROXY_HOST} and {@link #PROXY_PORT}.
+         */
+        PROXY_TYPE("proxy_type", ClickHouseProxyType.IGNORE,
+                "Type of proxy can be used to access ClickHouse server. To use an HTTP/SOCKS proxy, you must specify proxy_host and proxy_port."),
+        /**
+         * Set Clickhouse proxy hostname.
+         */
+        PROXY_HOST("proxy_host", "", "Set ClickHouse server proxy hostname."),
+        /**
+         * Set ClickHouse proxy port.
+         */
+        PROXY_PORT("proxy_port", -1, "Set ClickHouse server proxy port."),
+        /**
+         * Set Clickhouse proxy username.
+         */
+        PROXY_USERNAME("proxy_username", "", "Set ClickHouse server proxy username."),
+        /**
+         * Set ClickHouse proxy password.
+         */
+        PROXY_PASSWORD("proxy_password", "", "Set ClickHouse server proxy password."),
+        /**
+         * Whether to use server time zone.
+         */
+        USE_SERVER_TIME_ZONE("use_server_time_zone", true,
+                "Whether to use server time zone. On connection init select timezone() will be executed"),
+        /**
+         * Whether to use time zone from server for Date.
+         */
+        USE_SERVER_TIME_ZONE_FOR_DATES("use_server_time_zone_for_dates", false,
+                "Whether to use timezone from server on Date parsing in getDate(). "
+                        + "If false, Date returned is a wrapper of a timestamp at start of the day in client timezone. "
+                        + "If true - at start of the day in server or use_time_zone timezone."),
+        /**
+         * Custom time zone. Only works when {@code use_server_time_zone} is set to
+         * false.
+         */
+        USE_TIME_ZONE("use_time_zone", "", "Time zone of all DateTime* values. "
+                + "Only used when use_server_time_zone is false. Empty value means client time zone."),
+
+        /**
+         * Query ID to be attached to an operation
+         */
+        QUERY_ID("query_id", "", "Query id"),
+
+
+        /**
+         * Connection time to live in milliseconds. 0 or negative number means no limit.
+         * Can be used to override keep-alive time suggested by a server.
+         */
+        CONNECTION_TTL("connection_ttl", 0L,
+                "Connection time to live in milliseconds. 0 or negative number means no limit."),
+        ;
+
+        private final String key;
+        private final Serializable defaultValue;
+        private final Class<? extends Serializable> clazz;
+        private final String description;
+        private final boolean sensitive;
+
+        private static final Map<String, OldClientOptions> options;
+
+        static final String UNKNOWN = "unknown";
+        public static final String LATEST_KNOWN_VERSION = "0.6.3";
+
+        /**
+         * Semantic version of the product.
+         */
+        public static final String PRODUCT_VERSION;
+        /**
+         * Revision(shortened git commit hash) of the product.
+         */
+        public static final String PRODUCT_REVISION;
+        /**
+         * Client O/S information in format of {@code <o/s name>/<o/s version>}.
+         */
+        public static final String CLIENT_OS_INFO;
+        /**
+         * Client JVM information in format of {@code <jvm name>/<jvm version>}.
+         */
+        public static final String CLIENT_JVM_INFO;
+        /**
+         * Client user name.
+         */
+        public static final String CLIENT_USER;
+        /**
+         * Client host name.
+         */
+        public static final String CLIENT_HOST;
+
+        static {
+            Map<String, OldClientOptions> map = new HashMap<>();
+            for (OldClientOptions o : values()) {
+                if (map.put(o.getKey(), o) != null) {
+                    throw new IllegalStateException("Duplicated key found: " + o.getKey());
+                }
+            }
+            options = Collections.unmodifiableMap(map);
+
+            // <artifact-id> <version> (revision: <revision>)
+            String ver = OldClientOptions.class.getPackage().getImplementationVersion();
+            String[] parts = ver == null || ver.isEmpty() ? null : ver.split("\\s");
+            if (parts != null && parts.length == 4 && parts[1].length() > 0 && parts[3].length() > 1
+                    && ver.charAt(ver.length() - 1) == ')') {
+                PRODUCT_VERSION = parts[1];
+                ver = parts[3];
+                PRODUCT_REVISION = ver.substring(0, ver.length() - 1);
+            } else { // perhaps try harder by checking version from pom.xml?
+                PRODUCT_VERSION = LATEST_KNOWN_VERSION;
+                PRODUCT_REVISION = UNKNOWN;
+            }
+
+
+            CLIENT_OS_INFO = new StringBuilder().append(getSystemConfig("os.name", "O/S")).append('/')
+                    .append(getSystemConfig("os.version", UNKNOWN)).toString();
+            String javaVersion = System.getProperty("java.vendor.version");
+            if (javaVersion == null || javaVersion.isEmpty() || javaVersion.indexOf(' ') >= 0) {
+                javaVersion = getSystemConfig("java.vm.version", getSystemConfig("java.version", UNKNOWN));
+            }
+            CLIENT_JVM_INFO = new StringBuilder().append(getSystemConfig("java.vm.name", "Java")).append('/')
+                    .append(javaVersion).toString();
+            CLIENT_USER = getSystemConfig("user.name", UNKNOWN);
+            try {
+                ver = InetAddress.getLocalHost().getHostName();
+            } catch (UnknownHostException e1) {
+                // ignore
+            }
+            CLIENT_HOST = ver == null || ver.isEmpty() ? UNKNOWN : ver;
+        }
+
+        /**
+         * Builds user-agent based on given product name. The user-agent will be
+         * something look like
+         * {@code <product name>/<product version> (<o/s name>/<o/s version>; <jvm name>/<jvm version>[; <additionalProperty>]; rv:<product revision>)}.
+         *
+         * @param productName        product name, null or blank string is treated as
+         *                           {@code ClickHouse Java Client}
+         * @param additionalProperty additional property if any
+         * @return non-empty user-agent
+         */
+        public static String buildUserAgent(String productName, String additionalProperty) {
+            productName = productName == null || productName.isEmpty() ? (String) PRODUCT_NAME.getEffectiveDefaultValue() : productName.trim();
+            StringBuilder builder = new StringBuilder(productName).append(PRODUCT_VERSION.isEmpty() ? "" : "/" + PRODUCT_VERSION);
+
+            if (!String.valueOf(PRODUCT_NAME.getDefaultValue()).equals(productName)) {//Append if someone changed the original value
+                builder.append(" ").append(PRODUCT_NAME.getDefaultValue()).append(LATEST_KNOWN_VERSION);
+            }
+            builder.append(" (").append(CLIENT_JVM_INFO);
+            if (additionalProperty != null && !additionalProperty.isEmpty()) {
+                builder.append("; ").append(additionalProperty.trim());
+            }
+            return builder.append(")").toString();
+        }
+
+        /**
+         * Gets system property and fall back to the given value as needed.
+         *
+         * @param propertyName non-null property name
+         * @param defaultValue default value, only useful if it's not null
+         * @return property value
+         */
+        public static String getSystemConfig(String propertyName, String defaultValue) {
+            final String propertyValue = System.getProperty(propertyName);
+            if (defaultValue == null) {
+                return propertyValue;
+            }
+
+            return propertyValue == null || propertyValue.isEmpty() ? defaultValue : propertyValue;
+        }
+
+        /**
+         * Gets client option by key.
+         *
+         * @param key key of the option
+         * @return client option object, or null if not found
+         */
+        public static OldClientOptions fromKey(String key) {
+            return options.get(key);
+        }
+
+        /**
+         * Constructor of an option for client.
+         *
+         * @param <T>          type of the value, usually either String or Number(e.g.
+         *                     int, long etc.)
+         * @param key          non-null key, better use snake_case instead of camelCase
+         *                     for consistency
+         * @param defaultValue non-null default value
+         * @param description  non-null description of this option
+         */
+        <T extends Serializable> OldClientOptions(String key, T defaultValue, String description) {
+            this(key, defaultValue, description, false);
+        }
+
+        /**
+         * Constructor of client option.
+         *
+         * @param <T>          type of the value, usually either String or Number(e.g.
+         *                     int, long etc.)
+         * @param key          non-null key, better use snake_case instead of camelCase
+         *                     for consistency
+         * @param defaultValue non-null default value
+         * @param description  non-null description of this option
+         * @param sensitive    whether the option is sensitive or not
+         */
+        <T extends Serializable> OldClientOptions(String key, T defaultValue, String description, boolean sensitive) {
+            this.key = ClickHouseChecker.nonNull(key, "key");
+            this.defaultValue = ClickHouseChecker.nonNull(defaultValue, "defaultValue");
+            this.clazz = defaultValue.getClass();
+            this.description = ClickHouseChecker.nonNull(description, "description");
+            this.sensitive = sensitive;
+        }
+
+        @Override
+        public Serializable getDefaultValue() {
+            return defaultValue;
+        }
+
+        @Override
+        public String getDescription() {
+            return description;
+        }
+
+        @Override
+        public String getKey() {
+            return key;
+        }
+
+        @Override
+        public Class<? extends Serializable> getValueType() {
+            return clazz;
+        }
+
+        @Override
+        public boolean isSensitive() {
+            return sensitive;
+        }
     }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/TableSchemaParser.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/TableSchemaParser.java
@@ -1,6 +1,5 @@
 package com.clickhouse.client.api.internal;
 
-import com.clickhouse.client.ClickHouseResponse;
 import com.clickhouse.client.api.metadata.TableSchema;
 
 import java.io.BufferedReader;
@@ -12,28 +11,7 @@ import java.util.Properties;
 
 public class TableSchemaParser {
 
-    public TableSchemaParser() {
-    }
-
-    public TableSchema createFromBinaryResponse(ClickHouseResponse response, String tableName, String databaseName) {
-        TableSchema schema = new TableSchema();
-        schema.setTableName(tableName);
-        schema.setDatabaseName(databaseName);
-        Properties p = new Properties();
-        response.records().forEach(record -> {
-            String values = record.getValue(0).asString().replaceAll("\t", "\n");
-            try {
-                p.clear();
-                p.load(new StringReader(values));
-                schema.addColumn(p.getProperty("name"), p.getProperty("type"), p.getProperty("default_type"));
-            } catch (IOException e) {
-                throw new RuntimeException("Failed to parse table schema", e);
-            }
-        });
-        return schema;
-    }
-
-    public TableSchema readTSKV(InputStream content, String table, String sqlQuery, String database) {
+    public static TableSchema readTSKV(InputStream content, String table, String sqlQuery, String database) {
         TableSchema schema = new TableSchema();
         schema.setTableName(table);
         schema.setQuery(sqlQuery);

--- a/client-v2/src/main/java/com/clickhouse/client/api/metrics/OperationMetrics.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/metrics/OperationMetrics.java
@@ -1,6 +1,5 @@
 package com.clickhouse.client.api.metrics;
 
-import com.clickhouse.client.ClickHouseResponseSummary;
 import com.clickhouse.client.api.internal.ClientStatisticsHolder;
 import com.clickhouse.client.api.internal.Gauge;
 import com.clickhouse.client.api.internal.StopWatch;

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/QueryResponse.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/QueryResponse.java
@@ -7,7 +7,7 @@ import com.clickhouse.client.api.internal.ClientV1AdaptorHelper;
 import com.clickhouse.client.api.metrics.OperationMetrics;
 import com.clickhouse.client.api.metrics.ServerMetrics;
 import com.clickhouse.client.config.ClickHouseClientOption;
-import com.clickhouse.client.http.ClickHouseHttpProto;
+import com.clickhouse.client.api.http.ClickHouseHttpProto;
 import com.clickhouse.data.ClickHouseFormat;
 import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.Header;

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
@@ -131,29 +131,29 @@ public class QuerySettings {
     }
 
     public QuerySettings setUseServerTimeZone(Boolean useServerTimeZone) {
-        if (rawSettings.containsKey(ClientConfigProperties.USE_TIMEZONE)) {
-            throw new ValidationUtils.SettingsValidationException(ClientConfigProperties.USE_SERVER_TIMEZONE,
+        if (rawSettings.containsKey(ClientConfigProperties.USE_TIMEZONE.getKey())) {
+            throw new ValidationUtils.SettingsValidationException(ClientConfigProperties.USE_SERVER_TIMEZONE.getKey(),
                     "Cannot set both use_time_zone and use_server_time_zone");
         }
-        rawSettings.put(ClientConfigProperties.USE_SERVER_TIMEZONE, useServerTimeZone);
+        rawSettings.put(ClientConfigProperties.USE_SERVER_TIMEZONE.getKey(), useServerTimeZone);
         return this;
     }
 
     public Boolean getUseServerTimeZone() {
-        return (Boolean) rawSettings.get(ClientConfigProperties.USE_SERVER_TIMEZONE);
+        return (Boolean) rawSettings.get(ClientConfigProperties.USE_SERVER_TIMEZONE.getKey());
     }
 
     public QuerySettings setUseTimeZone(String timeZone) {
-        if (rawSettings.containsKey(ClientConfigProperties.USE_SERVER_TIMEZONE)) {
-            throw new ValidationUtils.SettingsValidationException(ClientConfigProperties.USE_TIMEZONE,
+        if (rawSettings.containsKey(ClientConfigProperties.USE_SERVER_TIMEZONE.getKey())) {
+            throw new ValidationUtils.SettingsValidationException(ClientConfigProperties.USE_TIMEZONE.getKey(),
                     "Cannot set both use_time_zone and use_server_time_zone");
         }
-        rawSettings.put(ClientConfigProperties.USE_TIMEZONE, TimeZone.getTimeZone(timeZone));
+        rawSettings.put(ClientConfigProperties.USE_TIMEZONE.getKey(), TimeZone.getTimeZone(timeZone));
         return this;
     }
 
     public TimeZone getServerTimeZone() {
-        return (TimeZone) rawSettings.get(ClientConfigProperties.SERVER_TIMEZONE);
+        return (TimeZone) rawSettings.get(ClientConfigProperties.SERVER_TIMEZONE.getKey());
     }
 
     /**
@@ -202,7 +202,7 @@ public class QuerySettings {
      * @return same instance of the builder
      */
     public QuerySettings serverSetting(String name, String value) {
-        rawSettings.put(ClientConfigProperties.SERVER_SETTING_PREFIX + name, value);
+        rawSettings.put(ClientConfigProperties.serverSetting(name), value);
         return this;
     }
 
@@ -213,7 +213,7 @@ public class QuerySettings {
      * @return same instance of the builder
      */
     public QuerySettings serverSetting(String name, Collection<String> values) {
-        rawSettings.put(ClientConfigProperties.SERVER_SETTING_PREFIX + name, ClientConfigProperties.commaSeparated(values));
+        rawSettings.put(ClientConfigProperties.serverSetting(name), ClientConfigProperties.commaSeparated(values));
         return this;
     }
 
@@ -223,7 +223,7 @@ public class QuerySettings {
      * @param dbRoles
      */
     public QuerySettings setDBRoles(Collection<String> dbRoles) {
-        rawSettings.put(ClientConfigProperties.SESSION_DB_ROLES, dbRoles);
+        rawSettings.put(ClientConfigProperties.SESSION_DB_ROLES.getKey(), dbRoles);
         return this;
     }
 
@@ -233,7 +233,7 @@ public class QuerySettings {
      * @return list of DB roles
      */
     public Collection<String> getDBRoles() {
-        return (Collection<String>) rawSettings.get(ClientConfigProperties.SESSION_DB_ROLES);
+        return (Collection<String>) rawSettings.get(ClientConfigProperties.SESSION_DB_ROLES.getKey());
     }
 
     /**
@@ -244,7 +244,7 @@ public class QuerySettings {
     public QuerySettings logComment(String logComment) {
         this.logComment = logComment;
         if (logComment != null && !logComment.isEmpty()) {
-            rawSettings.put(ClientConfigProperties.SETTING_LOG_COMMENT, logComment);
+            rawSettings.put(ClientConfigProperties.SETTING_LOG_COMMENT.getKey(), logComment);
         }
         return this;
     }

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
@@ -2,7 +2,7 @@ package com.clickhouse.client.api.query;
 
 
 import com.clickhouse.client.api.Client;
-import com.clickhouse.client.api.ClientSettings;
+import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.client.api.internal.ServerSettings;
 import com.clickhouse.client.api.internal.ValidationUtils;
 import com.clickhouse.data.ClickHouseFormat;
@@ -131,29 +131,29 @@ public class QuerySettings {
     }
 
     public QuerySettings setUseServerTimeZone(Boolean useServerTimeZone) {
-        if (rawSettings.containsKey(ClientSettings.USE_TIMEZONE)) {
-            throw new ValidationUtils.SettingsValidationException(ClientSettings.USE_SERVER_TIMEZONE,
+        if (rawSettings.containsKey(ClientConfigProperties.USE_TIMEZONE)) {
+            throw new ValidationUtils.SettingsValidationException(ClientConfigProperties.USE_SERVER_TIMEZONE,
                     "Cannot set both use_time_zone and use_server_time_zone");
         }
-        rawSettings.put(ClientSettings.USE_SERVER_TIMEZONE, useServerTimeZone);
+        rawSettings.put(ClientConfigProperties.USE_SERVER_TIMEZONE, useServerTimeZone);
         return this;
     }
 
     public Boolean getUseServerTimeZone() {
-        return (Boolean) rawSettings.get(ClientSettings.USE_SERVER_TIMEZONE);
+        return (Boolean) rawSettings.get(ClientConfigProperties.USE_SERVER_TIMEZONE);
     }
 
     public QuerySettings setUseTimeZone(String timeZone) {
-        if (rawSettings.containsKey(ClientSettings.USE_SERVER_TIMEZONE)) {
-            throw new ValidationUtils.SettingsValidationException(ClientSettings.USE_TIMEZONE,
+        if (rawSettings.containsKey(ClientConfigProperties.USE_SERVER_TIMEZONE)) {
+            throw new ValidationUtils.SettingsValidationException(ClientConfigProperties.USE_TIMEZONE,
                     "Cannot set both use_time_zone and use_server_time_zone");
         }
-        rawSettings.put(ClientSettings.USE_TIMEZONE, TimeZone.getTimeZone(timeZone));
+        rawSettings.put(ClientConfigProperties.USE_TIMEZONE, TimeZone.getTimeZone(timeZone));
         return this;
     }
 
     public TimeZone getServerTimeZone() {
-        return (TimeZone) rawSettings.get(ClientSettings.SERVER_TIMEZONE);
+        return (TimeZone) rawSettings.get(ClientConfigProperties.SERVER_TIMEZONE);
     }
 
     /**
@@ -166,7 +166,7 @@ public class QuerySettings {
      * @return same instance of the builder
      */
     public QuerySettings httpHeader(String key, String value) {
-        rawSettings.put(ClientSettings.HTTP_HEADER_PREFIX + key, value);
+        rawSettings.put(ClientConfigProperties.HTTP_HEADER_PREFIX + key, value);
         return this;
     }
 
@@ -177,7 +177,7 @@ public class QuerySettings {
      * @return same instance of the builder
      */
     public QuerySettings httpHeader(String key, Collection<String> values) {
-        rawSettings.put(ClientSettings.HTTP_HEADER_PREFIX + key, ClientSettings.commaSeparated(values));
+        rawSettings.put(ClientConfigProperties.HTTP_HEADER_PREFIX + key, ClientConfigProperties.commaSeparated(values));
         return this;
     }
 
@@ -202,7 +202,7 @@ public class QuerySettings {
      * @return same instance of the builder
      */
     public QuerySettings serverSetting(String name, String value) {
-        rawSettings.put(ClientSettings.SERVER_SETTING_PREFIX + name, value);
+        rawSettings.put(ClientConfigProperties.SERVER_SETTING_PREFIX + name, value);
         return this;
     }
 
@@ -213,7 +213,7 @@ public class QuerySettings {
      * @return same instance of the builder
      */
     public QuerySettings serverSetting(String name, Collection<String> values) {
-        rawSettings.put(ClientSettings.SERVER_SETTING_PREFIX + name, ClientSettings.commaSeparated(values));
+        rawSettings.put(ClientConfigProperties.SERVER_SETTING_PREFIX + name, ClientConfigProperties.commaSeparated(values));
         return this;
     }
 
@@ -223,7 +223,7 @@ public class QuerySettings {
      * @param dbRoles
      */
     public QuerySettings setDBRoles(Collection<String> dbRoles) {
-        rawSettings.put(ClientSettings.SESSION_DB_ROLES, dbRoles);
+        rawSettings.put(ClientConfigProperties.SESSION_DB_ROLES, dbRoles);
         return this;
     }
 
@@ -233,7 +233,7 @@ public class QuerySettings {
      * @return list of DB roles
      */
     public Collection<String> getDBRoles() {
-        return (Collection<String>) rawSettings.get(ClientSettings.SESSION_DB_ROLES);
+        return (Collection<String>) rawSettings.get(ClientConfigProperties.SESSION_DB_ROLES);
     }
 
     /**
@@ -244,7 +244,7 @@ public class QuerySettings {
     public QuerySettings logComment(String logComment) {
         this.logComment = logComment;
         if (logComment != null && !logComment.isEmpty()) {
-            rawSettings.put(ClientSettings.SETTING_LOG_COMMENT, logComment);
+            rawSettings.put(ClientConfigProperties.SETTING_LOG_COMMENT, logComment);
         }
         return this;
     }

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
@@ -6,6 +6,7 @@ import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ClientSettings;
 import com.clickhouse.client.api.command.CommandSettings;
 import com.clickhouse.client.api.insert.InsertSettings;
+import com.clickhouse.client.api.internal.ServerSettings;
 import com.clickhouse.client.api.internal.ValidationUtils;
 import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.data.ClickHouseFormat;
@@ -130,7 +131,7 @@ public class QuerySettings {
      * Requests the server to wait for the and of the query before sending response. Useful for getting accurate summary.
      */
     public QuerySettings waitEndOfQuery(Boolean waitEndOfQuery) {
-        rawSettings.put("wait_end_of_query", waitEndOfQuery);
+        serverSetting(ServerSettings.WAIT_END_OF_QUERY,  waitEndOfQuery ? "1" : "0");
         return this;
     }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
@@ -1,17 +1,12 @@
 package com.clickhouse.client.api.query;
 
 
-import com.clickhouse.client.ClickHouseNode;
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ClientSettings;
-import com.clickhouse.client.api.command.CommandSettings;
-import com.clickhouse.client.api.insert.InsertSettings;
 import com.clickhouse.client.api.internal.ServerSettings;
 import com.clickhouse.client.api.internal.ValidationUtils;
-import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.data.ClickHouseFormat;
 
-import javax.management.Query;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
@@ -136,31 +131,30 @@ public class QuerySettings {
     }
 
     public QuerySettings setUseServerTimeZone(Boolean useServerTimeZone) {
-        if (rawSettings.containsKey(ClickHouseClientOption.USE_TIME_ZONE.getKey())) {
-            throw new ValidationUtils.SettingsValidationException("use_server_timezone",
+        if (rawSettings.containsKey(ClientSettings.USE_TIMEZONE)) {
+            throw new ValidationUtils.SettingsValidationException(ClientSettings.USE_SERVER_TIMEZONE,
                     "Cannot set both use_time_zone and use_server_time_zone");
         }
-        rawSettings.put("use_server_time_zone", useServerTimeZone);
+        rawSettings.put(ClientSettings.USE_SERVER_TIMEZONE, useServerTimeZone);
         return this;
     }
 
     public Boolean getUseServerTimeZone() {
-        return (Boolean) rawSettings.get("use_server_time_zone");
+        return (Boolean) rawSettings.get(ClientSettings.USE_SERVER_TIMEZONE);
     }
 
     public QuerySettings setUseTimeZone(String timeZone) {
-        if (rawSettings.containsKey(ClickHouseClientOption.USE_SERVER_TIME_ZONE.getKey())) {
-            throw new ValidationUtils.SettingsValidationException("use_time_zone",
+        if (rawSettings.containsKey(ClientSettings.USE_SERVER_TIMEZONE)) {
+            throw new ValidationUtils.SettingsValidationException(ClientSettings.USE_TIMEZONE,
                     "Cannot set both use_time_zone and use_server_time_zone");
         }
-        rawSettings.put("use_time_zone", TimeZone.getTimeZone(timeZone));
+        rawSettings.put(ClientSettings.USE_TIMEZONE, TimeZone.getTimeZone(timeZone));
         return this;
     }
 
     public TimeZone getServerTimeZone() {
-        return (TimeZone) rawSettings.get(ClickHouseClientOption.SERVER_TIME_ZONE.getKey());
+        return (TimeZone) rawSettings.get(ClientSettings.SERVER_TIMEZONE);
     }
-
 
     /**
      * Defines list of headers that should be sent with current request. The Client will use a header value

--- a/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
@@ -517,7 +517,7 @@ public class HttpTransportTests extends BaseIntegrationTest {
                     .httpHeader("X-ClickHouse-Test", "test")
                     .httpHeader("X-ClickHouse-Test-2", Arrays.asList("test1", "test2"));
 
-            try (QueryResponse response = client.query("SELECT 1", querySettings).get(1, TimeUnit.SECONDS)) {
+            try (QueryResponse response = client.query("SELECT 1", querySettings).get(10, TimeUnit.SECONDS)) {
                 Assert.assertEquals(response.getReadBytes(), 10);
             } catch (Exception e) {
                 e.printStackTrace();

--- a/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
@@ -217,7 +217,7 @@ public class HttpTransportTests extends BaseIntegrationTest {
                 .setUsername("default")
                 .setPassword("")
                 .setRootCertificate("containers/clickhouse-server/certs/localhost.crt")
-                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "false").equals("true"))
+                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "true").equals("true"))
                 .build()) {
 
             List<GenericRecord> records = client.queryAll("SELECT timezone()");
@@ -729,7 +729,7 @@ public class HttpTransportTests extends BaseIntegrationTest {
         try (Client client = new Client.Builder().addEndpoint(Protocol.HTTP, "localhost",server.getPort(), false)
                 .setUsername("default")
                 .setPassword("")
-                .useNewImplementation(false)
+                .useNewImplementation(true)
                 .build()) {
 
             try (CommandResponse resp = client.execute("DROP TABLE IF EXISTS test_omm_table").get()) {

--- a/client-v2/src/test/java/com/clickhouse/client/ProxyTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/ProxyTests.java
@@ -181,7 +181,7 @@ public class ProxyTests extends BaseIntegrationTest{
                 .setUsername("default")
                 .setPassword("")
                 .useNewImplementation(onlyNewImplementation ? onlyNewImplementation :
-                        System.getProperty("client.tests.useNewImplementation", "false").equals("true"))
+                        System.getProperty("client.tests.useNewImplementation", "true").equals("true"))
                 .addProxy(ProxyType.HTTP, "localhost", proxyPort);
     }
 

--- a/client-v2/src/test/java/com/clickhouse/client/SettingsTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/SettingsTests.java
@@ -1,6 +1,6 @@
 package com.clickhouse.client;
 
-import com.clickhouse.client.api.ClientSettings;
+import com.clickhouse.client.api.ClientConfigProperties;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -12,8 +12,8 @@ public class SettingsTests {
     @Test
     void testClientSettings() {
         List<String> source = Arrays.asList("ROL1", "ROL2,☺", "Rol,3,3");
-        String listA = ClientSettings.commaSeparated(source);
-        List<String> listB = ClientSettings.valuesFromCommaSeparated(listA);
+        String listA = ClientConfigProperties.commaSeparated(source);
+        List<String> listB = ClientConfigProperties.valuesFromCommaSeparated(listA);
         Assert.assertEquals(listB, source);
     }
 }

--- a/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
@@ -5,13 +5,13 @@ import com.clickhouse.client.ClickHouseNode;
 import com.clickhouse.client.ClickHouseProtocol;
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ClientException;
-import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.client.api.command.CommandResponse;
 import com.clickhouse.client.api.command.CommandSettings;
 import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatReader;
 import com.clickhouse.client.api.enums.Protocol;
 import com.clickhouse.client.api.insert.InsertResponse;
 import com.clickhouse.client.api.insert.InsertSettings;
+import com.clickhouse.client.api.internal.ServerSettings;
 import com.clickhouse.client.api.metrics.ClientMetrics;
 import com.clickhouse.client.api.metrics.OperationMetrics;
 import com.clickhouse.client.api.metrics.ServerMetrics;
@@ -135,7 +135,7 @@ public class InsertTests extends BaseIntegrationTest {
         List<Object> data = Arrays.asList(pojo);
 
         InsertSettings insertSettings = new InsertSettings()
-                .serverSetting(ClientConfigProperties.INPUT_FORMAT_BINARY_READ_JSON_AS_STRING, "1");
+                .serverSetting(ServerSettings.INPUT_FORMAT_BINARY_READ_JSON_AS_STRING, "1");
         InsertResponse response = client.insert(tableName, data, insertSettings).get(EXECUTE_CMD_TIMEOUT, TimeUnit.SECONDS);
         assertEquals(response.getWrittenRows(), 1);
 

--- a/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
@@ -5,7 +5,7 @@ import com.clickhouse.client.ClickHouseNode;
 import com.clickhouse.client.ClickHouseProtocol;
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ClientException;
-import com.clickhouse.client.api.ClientSettings;
+import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.client.api.command.CommandResponse;
 import com.clickhouse.client.api.command.CommandSettings;
 import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatReader;
@@ -135,7 +135,7 @@ public class InsertTests extends BaseIntegrationTest {
         List<Object> data = Arrays.asList(pojo);
 
         InsertSettings insertSettings = new InsertSettings()
-                .serverSetting(ClientSettings.INPUT_FORMAT_BINARY_READ_JSON_AS_STRING, "1");
+                .serverSetting(ClientConfigProperties.INPUT_FORMAT_BINARY_READ_JSON_AS_STRING, "1");
         InsertResponse response = client.insert(tableName, data, insertSettings).get(EXECUTE_CMD_TIMEOUT, TimeUnit.SECONDS);
         assertEquals(response.getWrittenRows(), 1);
 

--- a/client-v2/src/test/java/com/clickhouse/client/metadata/MetadataTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/metadata/MetadataTests.java
@@ -53,33 +53,12 @@ public class MetadataTests extends BaseIntegrationTest {
 
     private void prepareDataSet(String tableName) {
 
-        try (ClickHouseClient client = ClickHouseClient.builder().config(new ClickHouseConfig())
-                .nodeSelector(ClickHouseNodeSelector.of(ClickHouseProtocol.HTTP))
-                .build()) {
+        try {
+            String sql = "CREATE TABLE IF NOT EXISTS default." + tableName + " (param1 UInt32, param2 UInt16) ENGINE = Memory";
+            client.execute(sql).get();
 
-            ClickHouseRequest request = client.read(getServer(ClickHouseProtocol.HTTP))
-                    .query("CREATE TABLE IF NOT EXISTS default." + tableName + " (param1 UInt32, param2 UInt16) ENGINE = Memory");
-            request.executeAndWait();
-
-            request = client.write(getServer(ClickHouseProtocol.HTTP))
-                    .query("INSERT INTO default." + tableName + " VALUES (1, 2), (3, 4), (5, 6)");
-            request.executeAndWait();
-
-
-            if (false) {
-                // debug check
-                ClickHouseResponse response = client.read(getServer(ClickHouseProtocol.HTTP))
-                        .query("SELECT * FROM default." + tableName + " ORDER BY param1 ASC")
-                        .executeAndWait();
-
-                Iterator<ClickHouseRecord> iter = response.records().iterator();
-                while (iter.hasNext()) {
-                    ClickHouseRecord r = iter.next();
-                    if (r.size() > 0) {
-                        System.out.println(r.getValue(0).asString());
-                    }
-                }
-            }
+            sql = "INSERT INTO default." + tableName + " VALUES (1, 2), (3, 4), (5, 6)";
+            client.execute(sql).get();
         } catch (Exception e) {
             Assert.fail("Failed to prepare data set", e);
         }

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -2,17 +2,12 @@ package com.clickhouse.client.query;
 
 
 import com.clickhouse.client.BaseIntegrationTest;
-import com.clickhouse.client.ClickHouseClient;
-import com.clickhouse.client.ClickHouseConfig;
 import com.clickhouse.client.ClickHouseException;
 import com.clickhouse.client.ClickHouseNode;
-import com.clickhouse.client.ClickHouseNodeSelector;
 import com.clickhouse.client.ClickHouseProtocol;
-import com.clickhouse.client.ClickHouseRequest;
-import com.clickhouse.client.ClickHouseResponse;
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ClientException;
-import com.clickhouse.client.api.ClientSettings;
+import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.client.api.DataTypeUtils;
 import com.clickhouse.client.api.ServerException;
 import com.clickhouse.client.api.command.CommandResponse;
@@ -1790,7 +1785,7 @@ public class QueryTests extends BaseIntegrationTest {
         }
 
         settings = new QuerySettings()
-                .serverSetting(ClientSettings.OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING, "1");
+                .serverSetting(ClientConfigProperties.OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING, "1");
         try (QueryResponse resp = client.query("SELECT json FROM test_json_values", settings).get(1, TimeUnit.SECONDS)) {
             ClickHouseBinaryFormatReader reader = client.newBinaryFormatReader(resp);
             Assert.assertNotNull(reader.next());

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -7,7 +7,6 @@ import com.clickhouse.client.ClickHouseNode;
 import com.clickhouse.client.ClickHouseProtocol;
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ClientException;
-import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.client.api.DataTypeUtils;
 import com.clickhouse.client.api.ServerException;
 import com.clickhouse.client.api.command.CommandResponse;
@@ -16,6 +15,7 @@ import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatReader;
 import com.clickhouse.client.api.enums.Protocol;
 import com.clickhouse.client.api.insert.InsertResponse;
 import com.clickhouse.client.api.insert.InsertSettings;
+import com.clickhouse.client.api.internal.ServerSettings;
 import com.clickhouse.client.api.metadata.TableSchema;
 import com.clickhouse.client.api.metrics.ClientMetrics;
 import com.clickhouse.client.api.metrics.OperationMetrics;
@@ -1785,7 +1785,7 @@ public class QueryTests extends BaseIntegrationTest {
         }
 
         settings = new QuerySettings()
-                .serverSetting(ClientConfigProperties.OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING, "1");
+                .serverSetting(ServerSettings.OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING, "1");
         try (QueryResponse resp = client.query("SELECT json FROM test_json_values", settings).get(1, TimeUnit.SECONDS)) {
             ClickHouseBinaryFormatReader reader = client.newBinaryFormatReader(resp);
             Assert.assertNotNull(reader.next());

--- a/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/ExperimentalJSONExample.java
+++ b/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/ExperimentalJSONExample.java
@@ -1,11 +1,11 @@
 package com.clickhouse.examples.client_v2;
 
 import com.clickhouse.client.api.Client;
-import com.clickhouse.client.api.ClientSettings;
 import com.clickhouse.client.api.command.CommandSettings;
 import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatReader;
 import com.clickhouse.client.api.insert.InsertResponse;
 import com.clickhouse.client.api.insert.InsertSettings;
+import com.clickhouse.client.api.internal.ServerSettings;
 import com.clickhouse.client.api.query.QueryResponse;
 import com.clickhouse.examples.client_v2.data.PojoWithJSON;
 import lombok.extern.slf4j.Slf4j;
@@ -29,8 +29,8 @@ public class ExperimentalJSONExample {
                 // allow experimental JSON type
                 .serverSetting("allow_experimental_json_type", "1")
                 // allow JSON transcoding as a string
-                .serverSetting(ClientSettings.INPUT_FORMAT_BINARY_READ_JSON_AS_STRING, "1")
-                .serverSetting(ClientSettings.OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING, "1")
+                .serverSetting(ServerSettings.INPUT_FORMAT_BINARY_READ_JSON_AS_STRING, "1")
+                .serverSetting(ServerSettings.OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING, "1")
                 .setDefaultDatabase(database);
 
         this.client = clientBuilder.build();
@@ -58,7 +58,7 @@ public class ExperimentalJSONExample {
         List<Object> data = Arrays.asList(pojo);
 
         InsertSettings insertSettings = new InsertSettings()
-                .serverSetting(ClientSettings.INPUT_FORMAT_BINARY_READ_JSON_AS_STRING, "1");
+                .serverSetting(ServerSettings.INPUT_FORMAT_BINARY_READ_JSON_AS_STRING, "1");
         try (InsertResponse response = client.insert(tableName, data, insertSettings).get(30, TimeUnit.SECONDS)) {
             log.info("Data write metrics: {}", response.getMetrics());
         } catch (Exception e) {

--- a/pom.xml
+++ b/pom.xml
@@ -39,9 +39,10 @@
     <modules>
         <!-- shared -->
         <module>clickhouse-data</module>
-        <!-- client -->
+        <!-- client v1 -->
         <module>clickhouse-client</module>
         <module>clickhouse-http-client</module>
+        <!-- client v2 -->
         <module>client-v2</module>
         <!-- driver -->
         <module>clickhouse-jdbc</module>


### PR DESCRIPTION
## Summary
Client-v2 still uses some classes from old client. This PR fixes this. 

Closes: https://github.com/ClickHouse/clickhouse-java/issues/1899
## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
