### PR TITLE
Fixed overriding max_result_rows settings

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java
@@ -218,6 +218,8 @@ public enum ClickHouseClientOption implements ClickHouseOption {
     MAX_RESULT_ROWS("max_result_rows", 0L,
             "Limit on the number of rows in the result. "
                     + "Also checked for subqueries, and on remote servers when running parts of a distributed query."),
+
+    RESULT_OVERFLOW_MODE("result_overflow_mode", "throw","What to do if the result is overflowed."),
     /**
      * Maximum size of thread pool for each client.
      */

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
@@ -124,9 +124,11 @@ public abstract class ClickHouseHttpConnection implements AutoCloseable {
             appendQueryParameter(builder, settingKey, String.valueOf(config.getMaxResultRows()));
         } else if (hasRequestSetting) {
             // set on request level
-            Number value = (Number) settings.get(settingKey);
-            if (value.longValue() > 0L) {
-                appendQueryParameter(builder, settingKey, String.valueOf(value.longValue()));
+            Object value = settings.get(settingKey);
+            if (value instanceof Number && ((Number) value).longValue() > 0L) {
+                appendQueryParameter(builder, settingKey, String.valueOf(value));
+            } else if (value instanceof String && !(((String) value).isEmpty() || "0".equals(value))) {
+                appendQueryParameter(builder, settingKey, (String) value);
             }
         }
 

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseStatementImpl.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseStatementImpl.java
@@ -610,11 +610,9 @@ public class ClickHouseStatementImpl extends JdbcWrapper
 
         if (this.maxRows != max) {
             if (max == 0L || !connection.allowCustomSetting()) {
-                request.removeSetting(ClickHouseClientOption.MAX_RESULT_ROWS.getKey());
-                request.removeSetting("result_overflow_mode");
+                request.set(ClickHouseClientOption.MAX_RESULT_ROWS.getKey(), 0);
             } else {
                 request.set(ClickHouseClientOption.MAX_RESULT_ROWS.getKey(), max);
-                request.set("result_overflow_mode", "break");
             }
             this.maxRows = max;
         }

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseStatementTest.java
@@ -834,7 +834,9 @@ public class ClickHouseStatementTest extends JdbcIntegrationTest {
 
     @Test(groups = "integration")
     public void testQuerySystemLog() throws SQLException {
-        try (ClickHouseConnection conn = newConnection(new Properties())) {
+        Properties props = new Properties();
+        props.setProperty(ClickHouseClientOption.RESULT_OVERFLOW_MODE.getKey(), "break");
+        try (ClickHouseConnection conn = newConnection(props)) {
             ClickHouseStatement stmt = conn.createStatement();
             stmt.setMaxRows(10);
             stmt.setLargeMaxRows(11L);


### PR DESCRIPTION
## Summary
This PR fixes two problems: 
- force value for `result_overflow_mode` that was set to `break` and it was not possible to override it. Enforced in JDBC and in HTTP connection
- correct handling of `max_result_rows` - in attempt to make it 0 this setting was removed from request settings and because of this was set to client setting value what is wrong. It happens in ClickHouseHttpConnection. 

Closes: https://github.com/ClickHouse/clickhouse-java/issues/1932

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
