### PR TITLE
Make clickhouse-r2dbc use jdbc-v2 explicitly

### DIFF
--- a/clickhouse-r2dbc/pom.xml
+++ b/clickhouse-r2dbc/pom.xml
@@ -68,7 +68,7 @@
         </dependency>
         <dependency>
             <groupId>com.clickhouse</groupId>
-            <artifactId>clickhouse-jdbc</artifactId>
+            <artifactId>jdbc-v2</artifactId>
             <version>${revision}</version>
             <scope>test</scope>
         </dependency>

--- a/clickhouse-r2dbc/src/test/java/com/clickhouse/r2dbc/spi/test/R2DBCTestKitImplTest.java
+++ b/clickhouse-r2dbc/src/test/java/com/clickhouse/r2dbc/spi/test/R2DBCTestKitImplTest.java
@@ -3,7 +3,6 @@ package com.clickhouse.r2dbc.spi.test;
 import com.clickhouse.client.ClickHouseException;
 import com.clickhouse.client.ClickHouseProtocol;
 import com.clickhouse.client.ClickHouseServerForTest;
-import com.clickhouse.jdbc.ClickHouseDriver;
 import com.zaxxer.hikari.HikariDataSource;
 import io.r2dbc.spi.Blob;
 import io.r2dbc.spi.Clob;
@@ -82,7 +81,7 @@ public class R2DBCTestKitImplTest implements TestKit<String> {
     private static JdbcTemplate jdbcTemplate(String database) throws SQLException {
         HikariDataSource source = new HikariDataSource();
 
-        Driver driver = new ClickHouseDriver();
+        Driver driver = new com.clickhouse.jdbc.Driver();
         DriverManager.registerDriver(driver);
         if (database == null) {
             source.setJdbcUrl(format("jdbc:clickhouse:%s://%s?%s", DEFAULT_PROTOCOL,


### PR DESCRIPTION
## Summary
`click house-r2dbc` uses the old driver explicitly so we can load according to testing. `jdbc-v2 `. I have replaced it with a new version.


## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
