### PR TITLE
BigDecimal will call .stripTrailingZeros()

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -455,7 +455,7 @@ public class BinaryStreamReader {
             v = new BigDecimal(readBigIntegerLE(INT256_SIZE, false), scale);
         }
 
-        return v;
+        return v.stripTrailingZeros();
     }
 
     public static byte[] readNBytes(InputStream inputStream, int len) throws IOException {


### PR DESCRIPTION
to keep the same result as clickhouse-client CLI

## Summary

clickhouse-client cli will auto `stripTrailingZeros()` when column is `Decimal`:

```sql
create table test (c1 Decimal64(3)) order by c1;
insert into test (c1) values (1.11000), (1.00000);
select * from test;
```

result:

```
Query id: 76ee323e-ec21-433b-b402-c2d87ba779d8

   ┌───c1─┐
1. │    1 │
2. │ 1.11 │
   └──────┘
```

But currently the java client v2 will returns `1.000` and `1.110`.

This feature will keep the same result as cli is.

Fix #1964
