### PR TITLE
[jdbc-v2] Adopt for non-compliant requests

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/ConnectionImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/ConnectionImpl.java
@@ -5,6 +5,7 @@ import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.client.api.query.GenericRecord;
 import com.clickhouse.client.api.query.QuerySettings;
 import com.clickhouse.jdbc.internal.ClientInfoProperties;
+import com.clickhouse.jdbc.internal.DriverProperties;
 import com.clickhouse.jdbc.internal.JdbcConfiguration;
 import com.clickhouse.jdbc.internal.ExceptionUtils;
 import org.slf4j.Logger;
@@ -102,6 +103,15 @@ public class ConnectionImpl implements Connection, JdbcV2Wrapper {
         return result.getString("server_version");
     }
 
+    /**
+     * Returns configuration for current connection. Changes made to the instance of configuration may have side effects.
+     * Application should avoid making changes to this object until it is documented.
+     * @return - reference to internal instance of JdbcConfiguration
+     */
+    public JdbcConfiguration getJdbcConfig() {
+        return this.config;
+    }
+
     @Override
     public Statement createStatement() throws SQLException {
         checkOpen();
@@ -130,7 +140,8 @@ public class ConnectionImpl implements Connection, JdbcV2Wrapper {
     @Override
     public void setAutoCommit(boolean autoCommit) throws SQLException {
         checkOpen();
-        if (!autoCommit) {
+
+        if (!config.isIgnoreUnsupportedRequests() && !autoCommit) {
             throw new SQLFeatureNotSupportedException("setAutoCommit = false not supported", ExceptionUtils.SQL_STATE_FEATURE_NOT_SUPPORTED);
         }
     }
@@ -143,12 +154,16 @@ public class ConnectionImpl implements Connection, JdbcV2Wrapper {
 
     @Override
     public void commit() throws SQLException {
-        throw new SQLFeatureNotSupportedException("Commit/Rollback not supported", ExceptionUtils.SQL_STATE_FEATURE_NOT_SUPPORTED);
+        if (!config.isIgnoreUnsupportedRequests() ) {
+            throw new SQLFeatureNotSupportedException("Commit/Rollback not supported", ExceptionUtils.SQL_STATE_FEATURE_NOT_SUPPORTED);
+        }
     }
 
     @Override
     public void rollback() throws SQLException {
-        throw new SQLFeatureNotSupportedException("Commit/Rollback not supported", ExceptionUtils.SQL_STATE_FEATURE_NOT_SUPPORTED);
+        if (!config.isIgnoreUnsupportedRequests()) {
+            throw new SQLFeatureNotSupportedException("Commit/Rollback not supported", ExceptionUtils.SQL_STATE_FEATURE_NOT_SUPPORTED);
+        }
     }
 
     @Override
@@ -280,7 +295,9 @@ public class ConnectionImpl implements Connection, JdbcV2Wrapper {
     @Override
     public void rollback(Savepoint savepoint) throws SQLException {
         checkOpen();
-        throw new SQLFeatureNotSupportedException("Commit/Rollback not supported", ExceptionUtils.SQL_STATE_FEATURE_NOT_SUPPORTED);
+        if (!config.isIgnoreUnsupportedRequests()) {
+            throw new SQLFeatureNotSupportedException("Commit/Rollback not supported", ExceptionUtils.SQL_STATE_FEATURE_NOT_SUPPORTED);
+        }
     }
 
     @Override

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/DriverProperties.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/DriverProperties.java
@@ -5,6 +5,8 @@ package com.clickhouse.jdbc.internal;
  */
 public enum DriverProperties {
 
+    IGNORE_UNSUPPORTED_VALUES("jdbc_ignore_unsupported_values", ""),
+    SCHEMA_TERM("jdbc_schema_term", ""),
     PLACEHOLDER("placeholder", "Placeholder for unknown properties");
 
     private final String key;
@@ -16,4 +18,7 @@ public enum DriverProperties {
         this.description = description;
     }
 
+    public String getKey() {
+        return key;
+    }
 }

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/JdbcConfiguration.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/JdbcConfiguration.java
@@ -49,15 +49,21 @@ public class JdbcConfiguration {
         return disableFrameworkDetection;
     }
 
+    private boolean isIgnoreUnsupportedRequests;
+
+    public boolean isIgnoreUnsupportedRequests() {
+        return isIgnoreUnsupportedRequests;
+    }
+
     public JdbcConfiguration(String url, Properties info) {
         this.allProperties = new ConcurrentHashMap<>();
         info.forEach((k, v) -> allProperties.put(k.toString(), v.toString()));
-
         this.jdbcUrl = url;//Raw URL
         this.url = cleanUrl(url);
         this.user = info.getProperty("user", "default");
         this.password = info.getProperty("password", "");
         this.disableFrameworkDetection = Boolean.parseBoolean(info.getProperty("disable_frameworks_detection", "false"));
+        this.isIgnoreUnsupportedRequests= Boolean.parseBoolean(getDriverProperty(DriverProperties.IGNORE_UNSUPPORTED_VALUES.getKey(), "false"));
     }
 
     public static boolean acceptsURL(String url) {
@@ -117,5 +123,9 @@ public class JdbcConfiguration {
         }
 
         return listOfProperties;
+    }
+
+    public String getDriverProperty(String key, String defaultValue) {
+        return allProperties.getOrDefault(key, defaultValue);
     }
 }

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaData.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaData.java
@@ -5,6 +5,7 @@ import com.clickhouse.jdbc.ConnectionImpl;
 import com.clickhouse.jdbc.Driver;
 import com.clickhouse.jdbc.JdbcV2Wrapper;
 import com.clickhouse.jdbc.internal.ClientInfoProperties;
+import com.clickhouse.jdbc.internal.DriverProperties;
 import com.clickhouse.jdbc.internal.JdbcUtils;
 import com.clickhouse.jdbc.internal.ExceptionUtils;
 import com.clickhouse.logging.Logger;
@@ -380,7 +381,7 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData, JdbcV2Wrappe
      */
     @Override
     public String getSchemaTerm() {
-        return "database";
+        return connection.getJdbcConfig().getDriverProperty(DriverProperties.SCHEMA_TERM.getKey(), "schema");
     }
 
     @Override
@@ -830,7 +831,7 @@ public class DatabaseMetaData implements java.sql.DatabaseMetaData, JdbcV2Wrappe
                 "table AS TABLE_NAME, " +
                 "name AS COLUMN_NAME, " +
                 JdbcUtils.generateSqlTypeEnum("system.columns.type") + " AS DATA_TYPE, " +
-                "replaceRegexpOne(type, '^Nullable\\(([\\\\w ,\\\\)\\\\(]+)\\)$', '\\\\1') AS TYPE_NAME, " +
+                "type AS TYPE_NAME, " +
                 JdbcUtils.generateSqlTypeSizes("system.columns.type") + " AS COLUMN_SIZE, " +
                 "toInt32(0) AS BUFFER_LENGTH, " +
                 "IF (numeric_scale == 0, NULL, numeric_scale) as DECIMAL_DIGITS,  " +

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/ConnectionTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/ConnectionTest.java
@@ -1,7 +1,10 @@
 package com.clickhouse.jdbc;
 
 import java.sql.*;
+import java.util.Properties;
+
 import com.clickhouse.jdbc.internal.ClientInfoProperties;
+import com.clickhouse.jdbc.internal.DriverProperties;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -50,29 +53,40 @@ public class ConnectionTest extends JdbcIntegrationTest {
 
     @Test(groups = { "integration" })
     public void setAutoCommitTest() throws SQLException {
-        Connection localConnection = this.getJdbcConnection();
-        assertThrows(SQLFeatureNotSupportedException.class, () -> localConnection.setAutoCommit(false));
-        localConnection.setAutoCommit(true);
+        try (Connection localConnection = this.getJdbcConnection()) {
+            assertThrows(SQLFeatureNotSupportedException.class, () -> localConnection.setAutoCommit(false));
+            Assert.assertTrue(localConnection.getAutoCommit());
+            localConnection.setAutoCommit(true);
+        }
+
+        Properties prop = new Properties();
+        prop.setProperty(DriverProperties.IGNORE_UNSUPPORTED_VALUES.getKey(), "true");
+        try (Connection localConnection = getJdbcConnection(prop)) {
+            localConnection.setAutoCommit(false);
+            Assert.assertTrue(localConnection.getAutoCommit());
+            localConnection.setAutoCommit(true);
+            Assert.assertTrue(localConnection.getAutoCommit());
+            localConnection.setAutoCommit(false);
+        }
     }
 
     @Test(groups = { "integration" })
-    public void getAutoCommitTest() throws SQLException {
-        Connection localConnection = this.getJdbcConnection();
-        Assert.assertTrue(localConnection.getAutoCommit());
+    public void testCommitRollback() throws SQLException {
+        try (Connection localConnection = this.getJdbcConnection()) {
+            assertThrows(SQLFeatureNotSupportedException.class, () -> localConnection.commit());
+            assertThrows(SQLFeatureNotSupportedException.class, () -> localConnection.rollback());
+            assertThrows(SQLFeatureNotSupportedException.class, () -> localConnection.rollback(null));
+        }
+
+        Properties prop = new Properties();
+        prop.setProperty(DriverProperties.IGNORE_UNSUPPORTED_VALUES.getKey(), "true");
+        try (Connection localConnection = this.getJdbcConnection(prop)) {
+            localConnection.commit();
+            localConnection.rollback();
+            localConnection.rollback(null);
+        }
     }
 
-    @Test(groups = { "integration" })
-    public void commitTest() throws SQLException {
-        Connection localConnection = this.getJdbcConnection();
-        assertThrows(SQLFeatureNotSupportedException.class, () -> localConnection.commit());
-    }
-
-    @Test(groups = { "integration" })
-    public void rollbackTest() throws SQLException {
-        Connection localConnection = this.getJdbcConnection();
-        assertThrows(SQLFeatureNotSupportedException.class, () -> localConnection.rollback());
-        assertThrows(SQLFeatureNotSupportedException.class, () -> localConnection.rollback(null));
-    }
 
     @Test(groups = { "integration" })
     public void closeTest() throws SQLException {

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/JdbcIntegrationTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/JdbcIntegrationTest.java
@@ -25,10 +25,17 @@ public abstract class JdbcIntegrationTest extends BaseIntegrationTest {
     }
 
     public Connection getJdbcConnection() throws SQLException {
+        return getJdbcConnection(null);
+    }
+
+    public Connection getJdbcConnection(Properties properties) throws SQLException {
         Properties info = new Properties();
         info.setProperty("user", "default");
         info.setProperty("password", ClickHouseServerForTest.getPassword());
         LOGGER.info("Connecting to {}", getEndpointString());
+        if (properties != null) {
+            info.putAll(properties);
+        }
 
         return new ConnectionImpl(getEndpointString(), info);
         //return DriverManager.getConnection(getEndpointString(), "default", ClickHouseServerForTest.getPassword());


### PR DESCRIPTION
## Summary
Some application want to ignore JDBC standard behavior. This PR adopts JDBC driver for such needs:
- schema term is configurable now. Default is `schema` in the meaning that schema is used over catalog.
- added property to control if `SQLFeatureNotSupportedException` should be thrown
- DatabaseMetaData#getColumns() returns full column data-type (with `Nullable`) 


## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
