### PR TITLE
[client-v2] Fix check for ConnectTimeoutException in shouldRetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ### New Features
 - Added basic auth support for proxies. Now you can specify username/password when connecting via a proxy that requires it with HttpURLConnection and Apache HttpClient.
 
+### Bug Fixes
+- Fix for retrying on `ConnectTimeoutException`
+
 ## 0.7.1-patch1
 
 ### Bug Fixes

--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -63,6 +63,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.ConnectException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
@@ -1408,7 +1409,7 @@ public class Client implements AutoCloseable {
                         metrics.operationComplete();
                         metrics.setQueryId(queryId);
                         return new InsertResponse(metrics);
-                    } catch ( NoHttpResponseException | ConnectionRequestTimeoutException | ConnectTimeoutException e) {
+                    } catch (NoHttpResponseException | ConnectionRequestTimeoutException | ConnectTimeoutException | ConnectException e) {
                         lastException = httpClientHelper.wrapException("Insert request initiation failed", e);
                         if (httpClientHelper.shouldRetry(e, finalSettings.getAllSettings())) {
                             LOG.warn("Retrying", e);
@@ -1536,7 +1537,7 @@ public class Client implements AutoCloseable {
                         metrics.operationComplete();
                         metrics.setQueryId(queryId);
                         return new InsertResponse(metrics);
-                    } catch ( NoHttpResponseException | ConnectionRequestTimeoutException | ConnectTimeoutException e) {
+                    } catch (NoHttpResponseException | ConnectionRequestTimeoutException | ConnectTimeoutException | ConnectException e) {
                         lastException = httpClientHelper.wrapException("Insert request initiation failed", e);
                         if (httpClientHelper.shouldRetry(e, finalSettings.getAllSettings())) {
                             LOG.warn("Retrying", e);
@@ -1702,7 +1703,7 @@ public class Client implements AutoCloseable {
 
                         return new QueryResponse(httpResponse, finalSettings.getFormat(), finalSettings, metrics);
 
-                    } catch ( NoHttpResponseException | ConnectionRequestTimeoutException | ConnectTimeoutException e) {
+                    } catch (NoHttpResponseException | ConnectionRequestTimeoutException | ConnectTimeoutException | ConnectException e) {
                         lastException = httpClientHelper.wrapException("Query request initiation failed", e);
                         if (httpClientHelper.shouldRetry(e, finalSettings.getAllSettings())) {
                             LOG.warn("Retrying.", e);

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
@@ -583,7 +583,7 @@ public class HttpAPIClientHelper {
             return retryCauses.contains(ClientFaultCause.NoHttpResponse);
         }
 
-        if (ex instanceof ConnectException) {
+        if (ex instanceof ConnectTimeoutException) {
             return retryCauses.contains(ClientFaultCause.ConnectTimeout);
         }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
@@ -583,7 +583,7 @@ public class HttpAPIClientHelper {
             return retryCauses.contains(ClientFaultCause.NoHttpResponse);
         }
 
-        if (ex instanceof ConnectTimeoutException) {
+        if (ex instanceof ConnectException || ex instanceof ConnectTimeoutException) {
             return retryCauses.contains(ClientFaultCause.ConnectTimeout);
         }
 
@@ -598,6 +598,7 @@ public class HttpAPIClientHelper {
     // ClientException will be also wrapped
     public ClientException wrapException(String message, Exception cause) {
         if (cause instanceof ConnectionRequestTimeoutException ||
+                cause instanceof NoHttpResponseException ||
                 cause instanceof ConnectTimeoutException ||
                 cause instanceof ConnectException) {
             return new ConnectionInitiationException(message, cause);


### PR DESCRIPTION
## Summary
The [catch block accepts `ConnectTimeoutException`](https://github.com/ClickHouse/clickhouse-java/blob/02542cc5b7a2f9ad09a816afd25308ea7da57519/client-v2/src/main/java/com/clickhouse/client/api/Client.java#L1411); however, `shouldRetry` checks for `ConnectException`.

I think the solution is for `shouldRetry` to test for `ConnectTimeoutException`, please let me know if that's incorrect so that i can adjust the `catch` clause instead.

It's also worth noting that `wrapException` tests for `ConnectException`; however, `wrapException` will never only ever be called with `NoHttpResponseException | ConnectionRequestTimeoutException | ConnectTimeoutException`, which makes me wonder if:
- `ConnectException` there should be replaced with `NoHttpResponseException`
- _or_ `ConnectException` should be added to the multi-catch

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
