### PR TITLE
[client-v2] fixed calculating index in getters

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/NativeFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/NativeFormatReader.java
@@ -86,7 +86,7 @@ public class NativeFormatReader extends AbstractBinaryFormatReader {
 
     @Override
     public <T> T readValue(int colIndex) {
-        return (T) currentRecord.get(getSchema().indexToName(colIndex));
+        return (T) currentRecord.get(getSchema().columnIndexToName(colIndex));
     }
 
     @Override

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
@@ -155,8 +155,7 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
         if (colIndex < 1 || colIndex > getSchema().getColumns().size()) {
             throw new ClientException("Column index out of bounds: " + colIndex);
         }
-        colIndex = colIndex - 1;
-        return (T) currentRecord.get(getSchema().indexToName(colIndex));
+        return (T) currentRecord.get(getSchema().columnIndexToName(colIndex));
     }
 
     @Override
@@ -514,7 +513,7 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
 
     @Override
     public boolean hasValue(int colIndex) {
-        return currentRecord.containsKey(getSchema().indexToName(colIndex - 1));
+        return currentRecord.containsKey(getSchema().columnIndexToName(colIndex));
     }
 
     @Override
@@ -525,47 +524,47 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
 
     @Override
     public byte getByte(int index) {
-        return getByte(schema.indexToName(index - 1 ));
+        return getByte(schema.columnIndexToName(index));
     }
 
     @Override
     public short getShort(int index) {
-        return getShort(schema.indexToName(index - 1));
+        return getShort(schema.columnIndexToName(index));
     }
 
     @Override
     public int getInteger(int index) {
-        return getInteger(schema.indexToName(index - 1));
+        return getInteger(schema.columnIndexToName(index));
     }
 
     @Override
     public long getLong(int index) {
-        return getLong(schema.indexToName(index - 1));
+        return getLong(schema.columnIndexToName(index));
     }
 
     @Override
     public float getFloat(int index) {
-        return getFloat(schema.indexToName(index - 1));
+        return getFloat(schema.columnIndexToName(index));
     }
 
     @Override
     public double getDouble(int index) {
-        return getDouble(schema.indexToName(index - 1));
+        return getDouble(schema.columnIndexToName(index));
     }
 
     @Override
     public boolean getBoolean(int index) {
-        return getBoolean(schema.indexToName(index - 1));
+        return getBoolean(schema.columnIndexToName(index));
     }
 
     @Override
     public BigInteger getBigInteger(int index) {
-        return getBigInteger(schema.indexToName(index - 1));
+        return getBigInteger(schema.columnIndexToName(index));
     }
 
     @Override
     public BigDecimal getBigDecimal(int index) {
-        return getBigDecimal(schema.indexToName(index - 1));
+        return getBigDecimal(schema.columnIndexToName(index));
     }
 
     @Override
@@ -620,37 +619,37 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
 
     @Override
     public <T> List<T> getList(int index) {
-        return getList(schema.indexToName(index));
+        return getList(schema.columnIndexToName(index));
     }
 
     @Override
     public byte[] getByteArray(int index) {
-        return getPrimitiveArray(schema.indexToName(index));
+        return getPrimitiveArray(schema.columnIndexToName(index));
     }
 
     @Override
     public int[] getIntArray(int index) {
-        return getPrimitiveArray(schema.indexToName(index));
+        return getPrimitiveArray(schema.columnIndexToName(index));
     }
 
     @Override
     public long[] getLongArray(int index) {
-        return getPrimitiveArray(schema.indexToName(index));
+        return getPrimitiveArray(schema.columnIndexToName(index));
     }
 
     @Override
     public float[] getFloatArray(int index) {
-        return getPrimitiveArray(schema.indexToName(index));
+        return getPrimitiveArray(schema.columnIndexToName(index));
     }
 
     @Override
     public double[] getDoubleArray(int index) {
-        return getPrimitiveArray(schema.indexToName(index));
+        return getPrimitiveArray(schema.columnIndexToName(index));
     }
 
     @Override
     public boolean[] getBooleanArray(int index) {
-        return getPrimitiveArray(schema.indexToName(index));
+        return getPrimitiveArray(schema.columnIndexToName(index));
     }
 
     @Override

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/MapBackedRecord.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/MapBackedRecord.java
@@ -37,8 +37,8 @@ public class MapBackedRecord implements GenericRecord {
         if (colIndex < 1 || colIndex > schema.getColumns().size()) {
             throw new ClientException("Column index out of bounds: " + colIndex);
         }
-        colIndex = colIndex - 1;
-        return (T) record.get(schema.indexToName(colIndex));
+
+        return (T) record.get(schema.columnIndexToName(colIndex));
     }
 
     public <T> T readValue(String colName) {
@@ -133,8 +133,7 @@ public class MapBackedRecord implements GenericRecord {
 
     @Override
     public Instant getInstant(String colName) {
-        int colIndex = schema.nameToIndex(colName);
-        ClickHouseColumn column = schema.getColumns().get(colIndex);
+        ClickHouseColumn column =  schema.getColumnByName(colName);
         switch (column.getDataType()) {
             case Date:
             case Date32:
@@ -144,15 +143,13 @@ public class MapBackedRecord implements GenericRecord {
             case DateTime64:
                 LocalDateTime dateTime = readValue(colName);
                 return dateTime.toInstant(column.getTimeZone().toZoneId().getRules().getOffset(dateTime));
-
         }
         throw new ClientException("Column of type " + column.getDataType() + " cannot be converted to Instant");
     }
 
     @Override
     public ZonedDateTime getZonedDateTime(String colName) {
-        int colIndex = schema.nameToIndex(colName);
-        ClickHouseColumn column = schema.getColumns().get(colIndex);
+        ClickHouseColumn column = schema.getColumnByName(colName);
         switch (column.getDataType()) {
             case DateTime:
             case DateTime64:
@@ -166,8 +163,7 @@ public class MapBackedRecord implements GenericRecord {
 
     @Override
     public Duration getDuration(String colName) {
-        int colIndex = schema.nameToIndex(colName);
-        ClickHouseColumn column = schema.getColumns().get(colIndex);
+        ClickHouseColumn column = schema.getColumnByName(colName);
         BigInteger value = readValue(colName);
         try {
             switch (column.getDataType()) {
@@ -288,7 +284,7 @@ public class MapBackedRecord implements GenericRecord {
 
     @Override
     public boolean hasValue(int colIndex) {
-        return record.containsKey(schema.indexToName(colIndex));
+        return record.containsKey(schema.columnIndexToName(colIndex));
     }
 
     @Override
@@ -298,37 +294,37 @@ public class MapBackedRecord implements GenericRecord {
 
     @Override
     public byte getByte(int index) {
-        return getByte(schema.indexToName(index));
+        return getByte(schema.columnIndexToName(index));
     }
 
     @Override
     public short getShort(int index) {
-        return getShort(schema.indexToName(index));
+        return getShort(schema.columnIndexToName(index));
     }
 
     @Override
     public int getInteger(int index) {
-        return getInteger(schema.indexToName(index));
+        return getInteger(schema.columnIndexToName(index));
     }
 
     @Override
     public long getLong(int index) {
-        return getLong(schema.indexToName(index));
+        return getLong(schema.columnIndexToName(index));
     }
 
     @Override
     public float getFloat(int index) {
-        return getFloat(schema.indexToName(index));
+        return getFloat(schema.columnIndexToName(index));
     }
 
     @Override
     public double getDouble(int index) {
-        return getDouble(schema.indexToName(index));
+        return getDouble(schema.columnIndexToName(index));
     }
 
     @Override
     public boolean getBoolean(int index) {
-        return getBoolean(schema.indexToName(index));
+        return getBoolean(schema.columnIndexToName(index));
     }
 
     @Override
@@ -393,37 +389,37 @@ public class MapBackedRecord implements GenericRecord {
 
     @Override
     public <T> List<T> getList(int index) {
-        return getList(schema.indexToName(index));
+        return getList(schema.columnIndexToName(index));
     }
 
     @Override
     public byte[] getByteArray(int index) {
-        return getPrimitiveArray(schema.indexToName(index));
+        return getPrimitiveArray(schema.columnIndexToName(index));
     }
 
     @Override
     public int[] getIntArray(int index) {
-        return getPrimitiveArray(schema.indexToName(index));
+        return getPrimitiveArray(schema.columnIndexToName(index));
     }
 
     @Override
     public long[] getLongArray(int index) {
-        return getPrimitiveArray(schema.indexToName(index));
+        return getPrimitiveArray(schema.columnIndexToName(index));
     }
 
     @Override
     public float[] getFloatArray(int index) {
-        return getPrimitiveArray(schema.indexToName(index));
+        return getPrimitiveArray(schema.columnIndexToName(index));
     }
 
     @Override
     public double[] getDoubleArray(int index) {
-        return getPrimitiveArray(schema.indexToName(index));
+        return getPrimitiveArray(schema.columnIndexToName(index));
     }
 
     @Override
     public boolean[] getBooleanArray(int index) {
-        return getPrimitiveArray(schema.indexToName(index));
+        return getPrimitiveArray(schema.columnIndexToName(index));
     }
 
     @Override

--- a/client-v2/src/main/java/com/clickhouse/client/api/metadata/TableSchema.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/metadata/TableSchema.java
@@ -91,12 +91,29 @@ public class TableSchema {
         return columns.get(nameToIndex(name));
     }
 
+    /**
+     * Takes absolute index (starting from 0) and returns corresponding column.
+     *
+     * @param index - column index starting from 0
+     * @return - column name
+     */
     public String indexToName(int index) {
         try {
             return columns.get(index).getColumnName();
         } catch (IndexOutOfBoundsException e) {
             throw new NoSuchColumnException("Result has no column with index = " + index);
         }
+    }
+
+    /**
+     * Takes absolute index (starting from 1) and return corresponding column.
+     * Equals to {@code indexToName(index - 1}.
+     *
+     * @param index - column index starting from 1
+     * @return - column name.
+     */
+    public String columnIndexToName(int index) {
+        return indexToName(index - 1);
     }
 
     public int nameToIndex(String name) {

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -1235,11 +1235,14 @@ public class QueryTests extends BaseIntegrationTest {
                 client.queryAll("SELECT '100' as small_number, '100500' as number").get(0);
 
         Assert.assertEquals(record.getString("number"), "100500");
+        Assert.assertEquals(record.getString(2), "100500");
         Assert.assertEquals(record.getString("small_number"), "100");
         Assert.assertEquals(record.getByte("small_number"), 100);
         Assert.assertEquals(record.getShort("small_number"), 100);
+        Assert.assertEquals(record.getShort(1), 100);
         Assert.assertThrows(() -> record.getShort("number"));
         Assert.assertEquals(record.getInteger("number"), 100500);
+        Assert.assertEquals(record.getInteger(2), 100500);
         Assert.assertEquals(record.getLong("number"), 100500L);
         Assert.assertEquals(record.getFloat("number"), 100500.0F);
         Assert.assertEquals(record.getBigInteger("number"), BigInteger.valueOf(100500L));
@@ -1900,6 +1903,17 @@ public class QueryTests extends BaseIntegrationTest {
             ClickHouseBinaryFormatReader reader = client.newBinaryFormatReader(resp);
             Assert.assertNotNull(reader.next());
             Assert.assertEquals(reader.getString(1), "{\"a\":{\"b\":\"42\"},\"c\":[\"1\",\"2\",\"3\"]}");
+        }
+    }
+
+    @Test
+    public void testGetColumnsByIndex() throws Exception {
+
+        try (QueryResponse response = client.query("SELECT toInt8(1) as number, 'test' as string").get()) {
+            ClickHouseBinaryFormatReader reader = client.newBinaryFormatReader(response);
+            reader.next();
+            Assert.assertEquals(reader.getInteger(1), 1);
+            Assert.assertEquals(reader.getString(2), "test");
         }
     }
 

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/ResultSetImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/ResultSetImpl.java
@@ -1082,7 +1082,7 @@ public class ResultSetImpl implements ResultSet, JdbcV2Wrapper {
     @Override
     public java.sql.Array getArray(int columnIndex) throws SQLException {
         checkClosed();
-        return getArray(reader.getSchema().indexToName(columnIndex));
+        return getArray(reader.getSchema().columnIndexToName(columnIndex));
     }
 
     @Override


### PR DESCRIPTION
## Summary
- implements `com.clickhouse.client.api.metadata.TableSchema#columnIndexToName` to get column by natural index 
- fixes all places where old `com.clickhouse.client.api.metadata.TableSchema#indexToName` is used. 


## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
