### PR TITLE
Cleanup sql comments when detecting type

### DIFF
--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/StatementTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/StatementTest.java
@@ -404,4 +404,28 @@ public class StatementTest extends JdbcIntegrationTest {
             assertEquals(Arrays.stream(((Object[]) stringArray.getArray())).toList(), Arrays.asList("val1", "val2", "val3"));
         }
     }
+
+    @Test(groups = { "integration" })
+    public void testWithComments() throws Exception {
+        assertEquals(StatementImpl.parseStatementType("    /* INSERT TESTING */\n SELECT 1 AS num"), StatementImpl.StatementType.SELECT);
+        assertEquals(StatementImpl.parseStatementType("/* SELECT TESTING */\n INSERT INTO test_table VALUES (1)"), StatementImpl.StatementType.INSERT);
+        assertEquals(StatementImpl.parseStatementType("/* INSERT TESTING */\n\n\n UPDATE test_table SET num = 2"), StatementImpl.StatementType.UPDATE);
+        assertEquals(StatementImpl.parseStatementType("-- INSERT TESTING */\n SELECT 1 AS num"), StatementImpl.StatementType.SELECT);
+        assertEquals(StatementImpl.parseStatementType("     -- SELECT TESTING \n -- SELECT AGAIN \n INSERT INTO test_table VALUES (1)"), StatementImpl.StatementType.INSERT);
+        assertEquals(StatementImpl.parseStatementType(" SELECT 42    -- INSERT TESTING"), StatementImpl.StatementType.SELECT);
+        assertEquals(StatementImpl.parseStatementType("#! INSERT TESTING \n SELECT 1 AS num"), StatementImpl.StatementType.SELECT);
+        assertEquals(StatementImpl.parseStatementType("#!INSERT TESTING \n SELECT 1 AS num"), StatementImpl.StatementType.SELECT);
+        assertEquals(StatementImpl.parseStatementType("# INSERT TESTING \n SELECT 1 AS num"), StatementImpl.StatementType.SELECT);
+        assertEquals(StatementImpl.parseStatementType("#INSERT TESTING \n SELECT 1 AS num"), StatementImpl.StatementType.SELECT);
+        assertEquals(StatementImpl.parseStatementType("\nINSERT TESTING \n SELECT 1 AS num"), StatementImpl.StatementType.INSERT);
+        assertEquals(StatementImpl.parseStatementType("         \n          INSERT TESTING \n SELECT 1 AS num"), StatementImpl.StatementType.INSERT);
+        assertEquals(StatementImpl.parseStatementType("select 1 AS num"), StatementImpl.StatementType.SELECT);
+        assertEquals(StatementImpl.parseStatementType("insert into test_table values (1)"), StatementImpl.StatementType.INSERT);
+        assertEquals(StatementImpl.parseStatementType("update test_table set num = 2"), StatementImpl.StatementType.UPDATE);
+        assertEquals(StatementImpl.parseStatementType("delete from test_table where num = 2"), StatementImpl.StatementType.DELETE);
+        assertEquals(StatementImpl.parseStatementType("sElEcT 1 AS num"), StatementImpl.StatementType.SELECT);
+        assertEquals(StatementImpl.parseStatementType(null), StatementImpl.StatementType.OTHER);
+        assertEquals(StatementImpl.parseStatementType(""), StatementImpl.StatementType.OTHER);
+        assertEquals(StatementImpl.parseStatementType("      "), StatementImpl.StatementType.OTHER);
+    }
 }


### PR DESCRIPTION
## Summary
We weren't removing SQL comments before, this way we clean up the line before trying to analyze type

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
