### PR TITLE
Add SimpleAggregateFunction support

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -210,7 +210,8 @@ public class BinaryStreamReader {
                     return (T) readTuple(column);
                 case Nothing:
                     return null;
-//                case SimpleAggregateFunction:
+                case SimpleAggregateFunction:
+                    return (T) readValue(column.getNestedColumns().get(0));
                 case AggregateFunction:
                     return (T) readBitmap( column);
                 default:


### PR DESCRIPTION
## Summary
Client V2 doesn't actually support SimpleAggregateFunction (though it's listed in the docs)

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
