### PR TITLE
[jdbc] Use credentials for health checking in ClickHouseNodes

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNode.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNode.java
@@ -762,6 +762,19 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
      * @return non-null node object
      */
     public static ClickHouseNode of(String uri, Map<?, ?> options) {
+        return of(uri, options, null);
+    }
+
+    /**
+     * Creates a node object using given URI. Same as
+     * {@code of(uri, ClickHouseProtocol.ANY)}.
+     *
+     * @param uri     non-empty URI
+     * @param options default options
+     * @param defaultCredentials will be used if not specified in uri (optional)
+     * @return non-null node object
+     */
+    public static ClickHouseNode of(String uri, Map<?, ?> options, ClickHouseCredentials defaultCredentials) {
         URI normalizedUri = normalize(uri, null);
 
         Map<String, String> params = new LinkedHashMap<>();
@@ -791,7 +804,7 @@ public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHou
                 && scheme.equalsIgnoreCase("https")) {
             params.put(ClickHouseClientOption.SSL.getKey(), "true");
         }
-        ClickHouseCredentials credentials = extract(normalizedUri.getRawUserInfo(), params, null);
+        ClickHouseCredentials credentials = extract(normalizedUri.getRawUserInfo(), params, defaultCredentials);
 
         return new ClickHouseNode(normalizedUri.getHost(), protocol, port, credentials, params, tags);
     }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodes.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodes.java
@@ -54,6 +54,19 @@ public class ClickHouseNodes implements ClickHouseNodeManager {
      * @return non-null list of nodes
      */
     static ClickHouseNodes create(String endpoints, Map<?, ?> defaultOptions) {
+        return create(endpoints, defaultOptions, null);
+    }
+
+    /**
+     * Creates list of managed {@link ClickHouseNode} for load balancing and
+     * fail-over.
+     *
+     * @param endpoints      non-empty URIs separated by comma
+     * @param defaultOptions default options
+     * @param credentials    will be used for health checking (optional)
+     * @return non-null list of nodes
+     */
+    static ClickHouseNodes create(String endpoints, Map<?, ?> defaultOptions, ClickHouseCredentials credentials) {
         int index = endpoints.indexOf(ClickHouseNode.SCHEME_DELIMITER);
         String defaultProtocol = ((ClickHouseProtocol) ClickHouseDefaults.PROTOCOL
                 .getEffectiveDefaultValue()).name();
@@ -145,7 +158,7 @@ public class ClickHouseNodes implements ClickHouseNodeManager {
         }
 
         ClickHouseNode defaultNode = ClickHouseNode.of(defaultProtocol + "://localhost" + defaultParams,
-                defaultOptions);
+                defaultOptions, credentials);
         List<ClickHouseNode> nodes = new LinkedList<>();
         for (String uri : list) {
             nodes.add(ClickHouseNode.of(uri, defaultNode));
@@ -273,12 +286,37 @@ public class ClickHouseNodes implements ClickHouseNodeManager {
      * and fail-over.
      *
      * @param endpoints non-empty URIs separated by comma
+     * @param credentials will be used for health checking (optional)
+     * @return non-null list of nodes
+     */
+    public static ClickHouseNodes of(String endpoints, ClickHouseCredentials credentials) {
+        return of(endpoints, Collections.emptyMap(), credentials);
+    }
+
+    /**
+     * Gets or creates list of managed {@link ClickHouseNode} for load balancing
+     * and fail-over.
+     *
+     * @param endpoints non-empty URIs separated by comma
      * @param options   default options
      * @return non-null list of nodes
      */
     public static ClickHouseNodes of(String endpoints, Map<?, ?> options) {
+        return of(endpoints, options, null);
+    }
+
+    /**
+     * Gets or creates list of managed {@link ClickHouseNode} for load balancing
+     * and fail-over.
+     *
+     * @param endpoints non-empty URIs separated by comma
+     * @param options   default options
+     * @param credentials will be used for health checking (optional)
+     * @return non-null list of nodes
+     */
+    public static ClickHouseNodes of(String endpoints, Map<?, ?> options, ClickHouseCredentials credentials) {
         return cache.computeIfAbsent(buildCacheKey(ClickHouseChecker.nonEmpty(endpoints, "Endpoints"), options),
-                k -> create(endpoints, options));
+                k -> create(endpoints, options, credentials));
     }
 
     /**


### PR DESCRIPTION
## Summary
Health check uses credentials from the class `ClickHouseNode` here: https://github.com/ClickHouse/clickhouse-java/blob/main/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodes.java#L587

But if `ClickHouseNode` was created using the function `ClickHouseNodes.of`, then `ClickHouseNode` contains default credentials and health check doesn't work. Currently there is no way to pass any valid credentials to `ClickHouseNodes`.

This PR extends the function `ClickHouseNodes.of` with the new input parameter `ClickHouseCredentials`. It's possible that this issue has the same cause: https://github.com/ClickHouse/clickhouse-java/issues/1384
