### PR TITLE
add stale bot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,44 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: '30 0 * * *'
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      # https://github.com/marketplace/actions/close-stale-issues
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          debug-only: true
+          operations-per-run: 500
+          # oldest first https://github.com/marketplace/actions/close-stale-issues#ascending
+          ascending: true
+          days-before-issue-stale: 365
+          days-before-issue-close: 30
+          stale-issue-label: stale
+          exempt-issue-labels: type:Epic, no stalebot #, v2-feedback, client-api-v2
+          stale-issue-message: >
+            This issue has been automatically marked as stale because it has not had
+            activity in the last year. It will be closed in 30 days if no further activity occurs. Please
+            feel free to leave a comment if you believe the issue is still relevant.
+            Thank you for your contributions!
+          close-issue-message: >
+            This issue has been automatically closed because it has not had any further
+            activity in the last 30 days. Thank you for your contributions!
+          days-before-pr-stale: 30
+          days-before-pr-close: 14
+          stale-pr-label: stale
+          exempt-pr-labels: no stalebot
+          stale-pr-message: >
+            This pull request has been automatically marked as stale because it has not had
+            activity in the last 30 days. It will be closed in 2 weeks if no further activity occurs. Please
+            feel free to give a status update or ping for review. Thank you for your contributions!
+          close-pr-message: >
+            This pull request has been automatically closed because it has not had any further
+            activity in the last 2 weeks. Thank you for your contributions!


### PR DESCRIPTION
## Summary
Run [stalebot](https://github.com/marketplace/actions/close-stale-issues) daily to cleanup issues and PRs without activity.
Setup in [dry-run mode](https://github.com/marketplace/actions/close-stale-issues#debugging) to validate the output before enabling on the repo

Settings:
- mark an issue as `stale` after a year of inactivity, close in 30 days
- mark a PR as `stale` after a month of inactivity, close in 14 days