### PR TITLE
Set wait-end-of-query to 0 in jdbc-v2 init

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/ConnectionImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/ConnectionImpl.java
@@ -33,6 +33,7 @@ import java.sql.ShardingKey;
 import java.sql.Statement;
 import java.sql.Struct;
 import java.sql.Types;
+import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -78,7 +79,7 @@ public class ConnectionImpl implements Connection, JdbcV2Wrapper {
         this.schema = client.getDefaultDatabase();
         this.defaultQuerySettings = new QuerySettings()
                 .serverSetting(ServerSettings.ASYNC_INSERT, "0")
-                .serverSetting(ServerSettings.WAIT_END_OF_QUERY, "1");
+                .serverSetting(ServerSettings.WAIT_END_OF_QUERY, "0");
 
         this.metadata = new com.clickhouse.jdbc.metadata.DatabaseMetaData(this, false, url);
     }


### PR DESCRIPTION
## Summary
Set wait-end-of-query to 0 in jdbc-v2 init i have left it on 0 in case clickhouse server will change the default 

## Checklist
Delete items not relevant to your PR:
- [ ] Closes issue <!-- Link to an issue to close on merge. -->
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
