### PR TITLE
[client-v2] Fix table name wrapping in insert statement

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -1534,7 +1534,7 @@ public class Client implements AutoCloseable {
 
             settings.setOption(ClientConfigProperties.INPUT_OUTPUT_FORMAT.getKey(), format.name());
             final InsertSettings finalSettings = settings;
-            final String sqlStmt = "INSERT INTO \"" + tableName + "\" FORMAT " + format.name();
+            final String sqlStmt = "INSERT INTO " + tableName + " FORMAT " + format.name();
             finalSettings.serverSetting(ClickHouseHttpProto.QPARAM_QUERY_STMT, sqlStmt);
             responseSupplier = () -> {
                 // Selecting some node

--- a/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
@@ -254,12 +254,9 @@ public class InsertTests extends BaseIntegrationTest {
         assertEquals(records.size(), 1000);
     }
 
-    @Test(groups = { "integration" }, enabled = true)
-    public void insertRawDataSimple() throws Exception {
-        insertRawDataSimple(1000);
-    }
-    public void insertRawDataSimple(int numberOfRecords) throws Exception {
-        final String tableName = "raw_data_table";
+    @Test(groups = { "integration" }, dataProvider = "insertRawDataSimpleDataProvider", dataProviderClass = InsertTests.class)
+    public void insertRawDataSimple(String tableName) throws Exception {
+//        final String tableName = "raw_data_table";
         final String createSql = String.format("CREATE TABLE IF NOT EXISTS %s " +
                 " (Id UInt32, event_ts Timestamp, name String, p1 Int64, p2 String) ENGINE = MergeTree() ORDER BY ()", tableName);
 
@@ -271,6 +268,7 @@ public class InsertTests extends BaseIntegrationTest {
                 .setInputStreamCopyBufferSize(8198 * 2);
         ByteArrayOutputStream data = new ByteArrayOutputStream();
         PrintWriter writer = new PrintWriter(data);
+        int numberOfRecords = 1000;
         for (int i = 0; i < numberOfRecords; i++) {
             writer.printf("%d\t%s\t%s\t%d\t%s\n", i, "2021-01-01 00:00:00", "name" + i, i, "p2");
         }
@@ -279,6 +277,15 @@ public class InsertTests extends BaseIntegrationTest {
                 ClickHouseFormat.TSV, settings).get(30, TimeUnit.SECONDS);
         OperationMetrics metrics = response.getMetrics();
         assertEquals((int)response.getWrittenRows(), numberOfRecords );
+    }
+
+    @DataProvider(name = "insertRawDataSimpleDataProvider")
+    public static Object[][] insertRawDataSimpleDataProvider() {
+        return new Object[][] {
+            {"raw_data_table"},
+            {"`raw_data_table`"},
+            {"`" + ClickHouseServerForTest.getDatabase() + ".raw_data_table`"},
+        };
     }
 
     @Test(groups = { "integration" })


### PR DESCRIPTION
## Summary
Table name was wrongly wrapped with `\"`. This should be up to user. 
## Checklist
Delete items not relevant to your PR:
- [ ] Closes issue <!-- Link to an issue to close on merge. -->
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
