### PR TITLE
[jdbc] Incorrect DateTime results when writing numeric data with use_time_zone property

### DIFF
--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseDateTimeValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseDateTimeValue.java
@@ -285,9 +285,9 @@ public class ClickHouseDateTimeValue extends ClickHouseObjectValue<LocalDateTime
         if (value == null) {
             resetToNullOrEmpty();
         } else if (scale == 0) {
-            set(ClickHouseValues.convertToDateTime(new BigDecimal(value, 0)));
+            set(LocalDateTime.ofInstant(ClickHouseValues.convertToInstant(new BigDecimal(value, 0)), tz.toZoneId()));
         } else {
-            set(ClickHouseValues.convertToDateTime(new BigDecimal(value, scale)));
+            set(LocalDateTime.ofInstant(ClickHouseValues.convertToInstant(new BigDecimal(value, scale)), tz.toZoneId()));
         }
         return this;
     }
@@ -300,7 +300,7 @@ public class ClickHouseDateTimeValue extends ClickHouseObjectValue<LocalDateTime
             if (value.scale() != scale) {
                 value = value.setScale(scale, ClickHouseDataConfig.DEFAULT_ROUNDING_MODE);
             }
-            set(ClickHouseValues.convertToDateTime(value));
+            set(LocalDateTime.ofInstant(ClickHouseValues.convertToInstant(value), tz.toZoneId()));
         }
         return this;
     }

--- a/clickhouse-data/src/test/java/com/clickhouse/data/value/ClickHouseDateTimeValueTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/value/ClickHouseDateTimeValueTest.java
@@ -10,6 +10,7 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.ZoneOffset;
 import java.util.Arrays;
+import java.util.TimeZone;
 import java.util.UUID;
 
 import org.testng.Assert;
@@ -29,6 +30,9 @@ public class ClickHouseDateTimeValueTest extends BaseClickHouseValueTest {
                 LocalDateTime.ofEpochSecond(-1L, 999000000, ZoneOffset.UTC));
         Assert.assertEquals(ClickHouseDateTimeValue.ofNull(3, ClickHouseValues.UTC_TIMEZONE).update(-1.1F).getValue(),
                 LocalDateTime.ofEpochSecond(-2L, 900000000, ZoneOffset.UTC));
+        TimeZone customTimeZone = TimeZone.getTimeZone("Asia/Shanghai");
+        Assert.assertEquals(ClickHouseDateTimeValue.ofNull(0, customTimeZone).update(-1L).getValue(),
+                LocalDateTime.ofEpochSecond(-1L, 0, ZoneOffset.ofHours(8)));
 
         Assert.assertEquals(
                 ClickHouseDateTimeValue.ofNull(9, ClickHouseValues.UTC_TIMEZONE)
@@ -38,6 +42,10 @@ public class ClickHouseDateTimeValueTest extends BaseClickHouseValueTest {
                 ClickHouseDateTimeValue.ofNull(9, ClickHouseValues.UTC_TIMEZONE)
                         .update(new BigDecimal(BigInteger.valueOf(-1L), 9)).getValue(),
                 LocalDateTime.ofEpochSecond(-1L, 999999999, ZoneOffset.UTC));
+        Assert.assertEquals(
+                ClickHouseDateTimeValue.ofNull(9, customTimeZone)
+                        .update(new BigDecimal(BigInteger.valueOf(-1L), 9)).getValue(),
+                LocalDateTime.ofEpochSecond(-1L, 999999999, ZoneOffset.ofHours(8)));
     }
 
     @Test(groups = { "unit" })


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
Refer to #2065.
When I use ClickHouse JDBC to insert data, the server's time zone is UTC, while my client's time zone is UTC+8. The JDBC first converts my numeric data to a LocalDateTime in the UTC time zone. This time object is then treated as a LocalDateTime in the UTC+8 time zone when written into ClickHouse, resulting in the written result being 8 hours behind.

## Checklist
Delete items not relevant to your PR:
- [x] Closes issue #2065 
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
