### PR TITLE
enable stalebot

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: actions/stale@v9
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          debug-only: true
           operations-per-run: 500
           # oldest first https://github.com/marketplace/actions/close-stale-issues#ascending
           ascending: true


### PR DESCRIPTION
follow-up on https://github.com/ClickHouse/clickhouse-java/pull/2037

Settings:
- mark an issue as stale after a year of inactivity, close in 30 days
- mark a PR as stale after a month of inactivity, close in 14 days
