### PR TITLE
Set JDBC v2 as default driver 

### DIFF
--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDriver.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDriver.java
@@ -48,32 +48,31 @@ public class ClickHouseDriver implements java.sql.Driver {
         return new ClickHouseDriver().isV2(null);
     }
     public boolean isV2(String url) {
-        log.debug("Checking if V2 driver is requested");
-        boolean v2Flag = Boolean.parseBoolean(System.getProperty("clickhouse.jdbc.v2", "false"));
-        if (v2Flag) {
-            log.info("V2 driver is requested through system property.");
-            return true;
+        log.debug("Checking if V1 driver is requested. V2 is the default driver.");
+        boolean v1Flag = Boolean.parseBoolean(System.getProperty("clickhouse.jdbc.v1", "false"));
+        if (v1Flag) {
+            log.info("V1 driver is requested through system property.");
+            return false;
         }
 
-        if (url != null && url.contains("clickhouse.jdbc.v2")) {
+        if (url != null && url.contains("clickhouse.jdbc.v1")) {
             urlFlagSent = true;
 
-            if (url.contains("clickhouse.jdbc.v2=true")) {
-                log.info("V2 driver is requested through URL.");
-                return true;
-            } else {
+            if (url.contains("clickhouse.jdbc.v1=true")) {
                 log.info("V1 driver is requested through URL.");
                 return false;
+            } else {
+                log.info("V2 driver is requested through URL.");
+                return true;
             }
         }
 
-        return false;
+        return true;
     }
 
 
     private java.sql.Driver getDriver(String url) {
         if (urlFlagSent && driver != null) {// if the URL flag was sent, we don't need to check the URL again
-
             return driver;
         }
 

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDriver.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDriver.java
@@ -55,10 +55,13 @@ public class ClickHouseDriver implements java.sql.Driver {
             return false;
         }
 
-        if (url != null && url.contains("clickhouse.jdbc.v1")) {
+        if (url != null && url.contains("clickhouse.jdbc.v")) {
             urlFlagSent = true;
 
             if (url.contains("clickhouse.jdbc.v1=true")) {
+                log.info("V1 driver is requested through URL.");
+                return false;
+            } if (url.contains("clickhouse.jdbc.v2=false")) {
                 log.info("V1 driver is requested through URL.");
                 return false;
             } else {

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/AccessManagementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/AccessManagementTest.java
@@ -6,6 +6,7 @@ import com.clickhouse.client.http.config.HttpConnectionProvider;
 import com.clickhouse.data.ClickHouseVersion;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -17,6 +18,10 @@ import java.util.Arrays;
 import java.util.Properties;
 
 public class AccessManagementTest extends JdbcIntegrationTest {
+    @BeforeMethod(groups = "integration")
+    public void setV1() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
     @Test(groups = "integration", dataProvider = "setRolesArgsForTestSetRole")
     public void testSetRoleDifferentConnections(String[] roles, String setRoleExpr, String[] activeRoles,
                                                 String connectionProvider) throws SQLException {

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/AccessManagementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/AccessManagementTest.java
@@ -5,6 +5,7 @@ import com.clickhouse.client.http.config.ClickHouseHttpOption;
 import com.clickhouse.client.http.config.HttpConnectionProvider;
 import com.clickhouse.data.ClickHouseVersion;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -16,6 +17,10 @@ import java.util.Arrays;
 import java.util.Properties;
 
 public class AccessManagementTest extends JdbcIntegrationTest {
+    @BeforeClass
+    public void setUp() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
 
     @Test(groups = "integration", dataProvider = "setRolesArgsForTestSetRole")
     public void testSetRoleDifferentConnections(String[] roles, String setRoleExpr, String[] activeRoles,

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/AccessManagementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/AccessManagementTest.java
@@ -17,11 +17,6 @@ import java.util.Arrays;
 import java.util.Properties;
 
 public class AccessManagementTest extends JdbcIntegrationTest {
-    @BeforeClass
-    public void setUp() {
-        System.setProperty("clickhouse.jdbc.v1","true");
-    }
-
     @Test(groups = "integration", dataProvider = "setRolesArgsForTestSetRole")
     public void testSetRoleDifferentConnections(String[] roles, String setRoleExpr, String[] activeRoles,
                                                 String connectionProvider) throws SQLException {

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseConnectionTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseConnectionTest.java
@@ -19,9 +19,14 @@ import com.clickhouse.data.value.UnsignedByte;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class ClickHouseConnectionTest extends JdbcIntegrationTest {
+    @BeforeMethod(groups = "integration")
+    public void setV1() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
     @Override
     public ClickHouseConnection newConnection(Properties properties) throws SQLException {
         return (ClickHouseConnection) newDataSource(properties).getConnection();

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseConnectionTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseConnectionTest.java
@@ -22,10 +22,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class ClickHouseConnectionTest extends JdbcIntegrationTest {
-    @BeforeClass
-    public void setUp() {
-        System.setProperty("clickhouse.jdbc.v1","true");
-    }
     @Override
     public ClickHouseConnection newConnection(Properties properties) throws SQLException {
         return (ClickHouseConnection) newDataSource(properties).getConnection();

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseConnectionTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseConnectionTest.java
@@ -18,9 +18,14 @@ import com.clickhouse.data.value.UnsignedByte;
 
 import org.testng.Assert;
 import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class ClickHouseConnectionTest extends JdbcIntegrationTest {
+    @BeforeClass
+    public void setUp() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
     @Override
     public ClickHouseConnection newConnection(Properties properties) throws SQLException {
         return (ClickHouseConnection) newDataSource(properties).getConnection();

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseDataSourceTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseDataSourceTest.java
@@ -10,6 +10,7 @@ import com.clickhouse.client.ClickHouseServerForTest;
 import junit.runner.Version;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
@@ -20,6 +21,10 @@ import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.client.config.ClickHouseDefaults;
 
 public class ClickHouseDataSourceTest extends JdbcIntegrationTest {
+    @BeforeMethod(groups = "integration")
+    public void setV1() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
     @Test(groups = "integration")
     public void testHighAvailabilityConfig() throws SQLException {
         if (isCloud() || ClickHouseDriver.isV2()) return; //TODO: testHighAvailabilityConfig - Revisit, see: https://github.com/ClickHouse/clickhouse-java/issues/1747

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseDataSourceTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseDataSourceTest.java
@@ -20,10 +20,6 @@ import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.client.config.ClickHouseDefaults;
 
 public class ClickHouseDataSourceTest extends JdbcIntegrationTest {
-    @BeforeClass
-    public void setUp() {
-        System.setProperty("clickhouse.jdbc.v1","true");
-    }
     @Test(groups = "integration")
     public void testHighAvailabilityConfig() throws SQLException {
         if (isCloud() || ClickHouseDriver.isV2()) return; //TODO: testHighAvailabilityConfig - Revisit, see: https://github.com/ClickHouse/clickhouse-java/issues/1747

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseDataSourceTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseDataSourceTest.java
@@ -9,6 +9,7 @@ import java.util.Properties;
 import com.clickhouse.client.ClickHouseServerForTest;
 import junit.runner.Version;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
@@ -19,6 +20,10 @@ import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.client.config.ClickHouseDefaults;
 
 public class ClickHouseDataSourceTest extends JdbcIntegrationTest {
+    @BeforeClass
+    public void setUp() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
     @Test(groups = "integration")
     public void testHighAvailabilityConfig() throws SQLException {
         if (isCloud() || ClickHouseDriver.isV2()) return; //TODO: testHighAvailabilityConfig - Revisit, see: https://github.com/ClickHouse/clickhouse-java/issues/1747

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseDatabaseMetaDataTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseDatabaseMetaDataTest.java
@@ -17,12 +17,13 @@ import com.clickhouse.logging.Logger;
 import com.clickhouse.logging.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class ClickHouseDatabaseMetaDataTest extends JdbcIntegrationTest {
-    @BeforeClass
-    public void setUp() {
+    @BeforeMethod(groups = "integration")
+    public void setV1() {
         System.setProperty("clickhouse.jdbc.v1","true");
     }
 

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseDatabaseMetaDataTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseDatabaseMetaDataTest.java
@@ -16,10 +16,15 @@ import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.logging.Logger;
 import com.clickhouse.logging.LoggerFactory;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class ClickHouseDatabaseMetaDataTest extends JdbcIntegrationTest {
+    @BeforeClass
+    public void setUp() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
 
     private static final Logger log = LoggerFactory.getLogger(ClickHouseDatabaseMetaDataTest.class);
     @DataProvider(name = "selectedColumns")

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseDriverTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseDriverTest.java
@@ -23,6 +23,7 @@ public class ClickHouseDriverTest extends JdbcIntegrationTest {
     @Test(groups = "integration")
     public void testConnect() throws SQLException {
         if (isCloud()) return; //TODO: testConnect - Revisit, see: https://github.com/ClickHouse/clickhouse-java/issues/1747
+        System.setProperty("clickhouse.jdbc.v1","true");
         String address = getServerAddress(ClickHouseProtocol.HTTP, true);
         ClickHouseDriver driver = new ClickHouseDriver();
         Connection conn = driver.connect("jdbc:clickhouse://" + address, null);

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseDriverTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseDriverTest.java
@@ -28,4 +28,16 @@ public class ClickHouseDriverTest extends JdbcIntegrationTest {
         Connection conn = driver.connect("jdbc:clickhouse://" + address, null);
         conn.close();
     }
+    @Test(groups = "integration")
+    public void testV2Driver() {
+        ClickHouseDriver driver = new ClickHouseDriver();
+        Boolean V1 = false;
+        Boolean V2 = true;
+        Assert.assertEquals(driver.isV2("jdbc:clickhouse://localhost:8123"), V2);
+        Assert.assertEquals(driver.isV2("jdbc:clickhouse://localhost:8123?clickhouse.jdbc.v1=true"), V1);
+        Assert.assertEquals(driver.isV2("jdbc:clickhouse://localhost:8123?clickhouse.jdbc.v1=false"), V2);
+        Assert.assertEquals(driver.isV2("jdbc:clickhouse://localhost:8123?clickhouse.jdbc.v2=true"), V2);
+        Assert.assertEquals(driver.isV2("jdbc:clickhouse://localhost:8123?clickhouse.jdbc.v2=false"), V1);
+
+    }
 }

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseDriverTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseDriverTest.java
@@ -31,6 +31,7 @@ public class ClickHouseDriverTest extends JdbcIntegrationTest {
     }
     @Test(groups = "integration")
     public void testV2Driver() {
+        System.setProperty("clickhouse.jdbc.v1","false");
         ClickHouseDriver driver = new ClickHouseDriver();
         Boolean V1 = false;
         Boolean V2 = true;
@@ -39,6 +40,6 @@ public class ClickHouseDriverTest extends JdbcIntegrationTest {
         Assert.assertEquals(driver.isV2("jdbc:clickhouse://localhost:8123?clickhouse.jdbc.v1=false"), V2);
         Assert.assertEquals(driver.isV2("jdbc:clickhouse://localhost:8123?clickhouse.jdbc.v2=true"), V2);
         Assert.assertEquals(driver.isV2("jdbc:clickhouse://localhost:8123?clickhouse.jdbc.v2=false"), V1);
-
+        System.setProperty("clickhouse.jdbc.v1","true");
     }
 }

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
@@ -66,10 +66,6 @@ import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
-    @BeforeClass
-    public void setUp() {
-        System.setProperty("clickhouse.jdbc.v1","true");
-    }
     @DataProvider(name = "columnsWithDefaultValue")
     private Object[][] getColumnsWithDefaultValue() {
         return new Object[][] {

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
@@ -60,11 +60,16 @@ import com.clickhouse.jdbc.internal.StreamBasedPreparedStatement;
 
 import org.testng.Assert;
 import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
+    @BeforeClass
+    public void setUp() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
     @DataProvider(name = "columnsWithDefaultValue")
     private Object[][] getColumnsWithDefaultValue() {
         return new Object[][] {

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
@@ -61,11 +61,16 @@ import com.clickhouse.jdbc.internal.StreamBasedPreparedStatement;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
 public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
+    @BeforeMethod(groups = "integration")
+    public void setV1() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
     @DataProvider(name = "columnsWithDefaultValue")
     private Object[][] getColumnsWithDefaultValue() {
         return new Object[][] {

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseResultSetTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseResultSetTest.java
@@ -34,10 +34,15 @@ import com.clickhouse.data.value.UnsignedInteger;
 
 import org.testng.Assert;
 import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class ClickHouseResultSetTest extends JdbcIntegrationTest {
+    @BeforeClass
+    public void setUp() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
     @DataProvider(name = "nullableTypes")
     private Object[][] getNullableTypes() {
         return new Object[][] {

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseResultSetTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseResultSetTest.java
@@ -35,10 +35,15 @@ import com.clickhouse.data.value.UnsignedInteger;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class ClickHouseResultSetTest extends JdbcIntegrationTest {
+    @BeforeMethod(groups = "integration")
+    public void setV1() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
     @DataProvider(name = "nullableTypes")
     private Object[][] getNullableTypes() {
         return new Object[][] {

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseResultSetTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseResultSetTest.java
@@ -39,10 +39,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class ClickHouseResultSetTest extends JdbcIntegrationTest {
-    @BeforeClass
-    public void setUp() {
-        System.setProperty("clickhouse.jdbc.v1","true");
-    }
     @DataProvider(name = "nullableTypes")
     private Object[][] getNullableTypes() {
         return new Object[][] {

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseStatementTest.java
@@ -60,11 +60,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class ClickHouseStatementTest extends JdbcIntegrationTest {
-    @BeforeClass
-    public void setUp() {
-        System.setProperty("clickhouse.jdbc.v1","true");
-    }
-
     @DataProvider(name = "timeZoneTestOptions")
     private Object[][] getTimeZoneTestOptions() {
         return new Object[][] {

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseStatementTest.java
@@ -17,6 +17,7 @@ import com.clickhouse.data.value.UnsignedShort;
 import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.testng.Assert;
 import org.testng.SkipException;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -59,6 +60,11 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class ClickHouseStatementTest extends JdbcIntegrationTest {
+    @BeforeClass
+    public void setUp() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
+
     @DataProvider(name = "timeZoneTestOptions")
     private Object[][] getTimeZoneTestOptions() {
         return new Object[][] {

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHouseStatementTest.java
@@ -18,6 +18,7 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -60,6 +61,10 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 public class ClickHouseStatementTest extends JdbcIntegrationTest {
+    @BeforeMethod(groups = "integration")
+    public void setV1() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
     @DataProvider(name = "timeZoneTestOptions")
     private Object[][] getTimeZoneTestOptions() {
         return new Object[][] {

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/CombinedResultSetTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/CombinedResultSetTest.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.List;
 
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -15,6 +16,11 @@ import com.clickhouse.client.ClickHouseSimpleResponse;
 import com.clickhouse.data.ClickHouseColumn;
 
 public class CombinedResultSetTest {
+    @BeforeClass
+    public void setUp() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
+
     @DataProvider(name = "multipleResultSetsProvider")
     private Object[][] getMultipleResultSets() {
         ClickHouseConfig config = new ClickHouseConfig();

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/CombinedResultSetTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/CombinedResultSetTest.java
@@ -16,11 +16,6 @@ import com.clickhouse.client.ClickHouseSimpleResponse;
 import com.clickhouse.data.ClickHouseColumn;
 
 public class CombinedResultSetTest {
-    @BeforeClass
-    public void setUp() {
-        System.setProperty("clickhouse.jdbc.v1","true");
-    }
-
     @DataProvider(name = "multipleResultSetsProvider")
     private Object[][] getMultipleResultSets() {
         ClickHouseConfig config = new ClickHouseConfig();

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/CombinedResultSetTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/CombinedResultSetTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -16,6 +17,10 @@ import com.clickhouse.client.ClickHouseSimpleResponse;
 import com.clickhouse.data.ClickHouseColumn;
 
 public class CombinedResultSetTest {
+    @BeforeMethod(groups = "integration")
+    public void setV1() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
     @DataProvider(name = "multipleResultSetsProvider")
     private Object[][] getMultipleResultSets() {
         ClickHouseConfig config = new ClickHouseConfig();

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/GenericJDBCTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/GenericJDBCTest.java
@@ -1,6 +1,7 @@
 package com.clickhouse.jdbc;
 
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.sql.*;
@@ -9,6 +10,11 @@ import java.util.Properties;
 import static org.testng.Assert.assertThrows;
 
 public class GenericJDBCTest extends JdbcIntegrationTest {
+    @BeforeClass
+    public void setUp() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
+
     public Connection getConnection(Properties properties) throws SQLException {
         if (properties == null) {
             properties = new Properties();

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/GenericJDBCTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/GenericJDBCTest.java
@@ -10,11 +10,6 @@ import java.util.Properties;
 import static org.testng.Assert.assertThrows;
 
 public class GenericJDBCTest extends JdbcIntegrationTest {
-    @BeforeClass
-    public void setUp() {
-        System.setProperty("clickhouse.jdbc.v1","true");
-    }
-
     public Connection getConnection(Properties properties) throws SQLException {
         if (properties == null) {
             properties = new Properties();

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/JdbcIssuesTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/JdbcIssuesTest.java
@@ -2,6 +2,7 @@ package com.clickhouse.jdbc;
 
 import org.testcontainers.shaded.org.apache.commons.lang3.StringUtils;
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import java.sql.Connection;
@@ -11,6 +12,11 @@ import java.sql.Statement;
 import java.util.Properties;
 
 public class JdbcIssuesTest extends JdbcIntegrationTest {
+    @BeforeClass
+    public void setUp() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
+
     @Test(groups = "integration")
     public void test01Decompress() throws SQLException {
         String TABLE_NAME = "decompress_issue_01";

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/JdbcIssuesTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/JdbcIssuesTest.java
@@ -12,11 +12,6 @@ import java.sql.Statement;
 import java.util.Properties;
 
 public class JdbcIssuesTest extends JdbcIntegrationTest {
-    @BeforeClass
-    public void setUp() {
-        System.setProperty("clickhouse.jdbc.v1","true");
-    }
-
     @Test(groups = "integration")
     public void test01Decompress() throws SQLException {
         String TABLE_NAME = "decompress_issue_01";

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/JdbcIssuesTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/JdbcIssuesTest.java
@@ -3,6 +3,7 @@ package com.clickhouse.jdbc;
 import org.testcontainers.shaded.org.apache.commons.lang3.StringUtils;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import java.sql.Connection;
@@ -12,6 +13,10 @@ import java.sql.Statement;
 import java.util.Properties;
 
 public class JdbcIssuesTest extends JdbcIntegrationTest {
+    @BeforeMethod(groups = "integration")
+    public void setV1() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
     @Test(groups = "integration")
     public void test01Decompress() throws SQLException {
         String TABLE_NAME = "decompress_issue_01";

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/JdbcParameterizedQueryTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/JdbcParameterizedQueryTest.java
@@ -6,10 +6,15 @@ import com.clickhouse.client.ClickHouseConfig;
 
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class JdbcParameterizedQueryTest {
     private final ClickHouseConfig config = new ClickHouseConfig();
+    @BeforeMethod(groups = "unit")
+    public void setV1() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
 
     @Test(groups = "unit")
     public void testParseBlankQueries() {

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/JdbcParameterizedQueryTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/JdbcParameterizedQueryTest.java
@@ -9,11 +9,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class JdbcParameterizedQueryTest {
-    @BeforeClass
-    public void setUp() {
-        System.setProperty("clickhouse.jdbc.v1","true");
-    }
-
     private final ClickHouseConfig config = new ClickHouseConfig();
 
     @Test(groups = "unit")

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/JdbcParameterizedQueryTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/JdbcParameterizedQueryTest.java
@@ -5,9 +5,15 @@ import java.util.Arrays;
 import com.clickhouse.client.ClickHouseConfig;
 
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class JdbcParameterizedQueryTest {
+    @BeforeClass
+    public void setUp() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
+
     private final ClickHouseConfig config = new ClickHouseConfig();
 
     @Test(groups = "unit")

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/JdbcParseHandlerTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/JdbcParseHandlerTest.java
@@ -9,9 +9,15 @@ import com.clickhouse.jdbc.parser.ClickHouseSqlStatement;
 import com.clickhouse.jdbc.parser.StatementType;
 
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class JdbcParseHandlerTest {
+    @BeforeClass
+    public void setUp() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
+
     @Test(groups = "unit")
     public void testInsertFromInFileStatement() {
         JdbcParseHandler handler = JdbcParseHandler.getInstance(false, false, true);

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/JdbcParseHandlerTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/JdbcParseHandlerTest.java
@@ -13,11 +13,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class JdbcParseHandlerTest {
-    @BeforeClass
-    public void setUp() {
-        System.setProperty("clickhouse.jdbc.v1","true");
-    }
-
     @Test(groups = "unit")
     public void testInsertFromInFileStatement() {
         JdbcParseHandler handler = JdbcParseHandler.getInstance(false, false, true);

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/JdbcParseHandlerTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/JdbcParseHandlerTest.java
@@ -10,9 +10,15 @@ import com.clickhouse.jdbc.parser.StatementType;
 
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 public class JdbcParseHandlerTest {
+    @BeforeMethod(groups = "unit")
+    public void setV1() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
+
     @Test(groups = "unit")
     public void testInsertFromInFileStatement() {
         JdbcParseHandler handler = JdbcParseHandler.getInstance(false, false, true);

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/internal/ClickHouseConnectionImplTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/internal/ClickHouseConnectionImplTest.java
@@ -11,9 +11,15 @@ import com.clickhouse.jdbc.JdbcIntegrationTest;
 import com.clickhouse.jdbc.parser.ClickHouseSqlStatement;
 
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class ClickHouseConnectionImplTest extends JdbcIntegrationTest {
+    @BeforeClass
+    public void setUp() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
+
     @Test(groups = "integration")
     public void testManualCommit() throws SQLException {
         if (isCloud()) return; //TODO: testManualCommit - Revisit, see: https://github.com/ClickHouse/clickhouse-java/issues/1747

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/internal/ClickHouseConnectionImplTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/internal/ClickHouseConnectionImplTest.java
@@ -15,11 +15,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class ClickHouseConnectionImplTest extends JdbcIntegrationTest {
-    @BeforeClass
-    public void setUp() {
-        System.setProperty("clickhouse.jdbc.v1","true");
-    }
-
     @Test(groups = "integration")
     public void testManualCommit() throws SQLException {
         if (isCloud()) return; //TODO: testManualCommit - Revisit, see: https://github.com/ClickHouse/clickhouse-java/issues/1747

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/internal/ClickHouseJdbcUrlParserTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/internal/ClickHouseJdbcUrlParserTest.java
@@ -13,10 +13,16 @@ import com.clickhouse.client.config.ClickHouseDefaults;
 import com.clickhouse.jdbc.internal.ClickHouseJdbcUrlParser.ConnectionInfo;
 
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class ClickHouseJdbcUrlParserTest {
+    @BeforeClass
+    public void setUp() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
+
     @Test(groups = "unit")
     public void testParseInvalidUri() {
         Assert.assertThrows(SQLException.class, () -> ClickHouseJdbcUrlParser.parse(null, null));

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/internal/ClickHouseJdbcUrlParserTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/internal/ClickHouseJdbcUrlParserTest.java
@@ -18,11 +18,6 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class ClickHouseJdbcUrlParserTest {
-    @BeforeClass
-    public void setUp() {
-        System.setProperty("clickhouse.jdbc.v1","true");
-    }
-
     @Test(groups = "unit")
     public void testParseInvalidUri() {
         Assert.assertThrows(SQLException.class, () -> ClickHouseJdbcUrlParser.parse(null, null));

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/internal/JdbcTransactionTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/internal/JdbcTransactionTest.java
@@ -9,11 +9,6 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class JdbcTransactionTest {
-    @BeforeClass
-    public void setUp() {
-        System.setProperty("clickhouse.jdbc.v1","true");
-    }
-
     @Test(groups = "unit")
     public void testQuery() {
         JdbcTransaction tx = new JdbcTransaction();

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/internal/JdbcTransactionTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/internal/JdbcTransactionTest.java
@@ -5,9 +5,15 @@ import java.util.Arrays;
 import java.util.Collections;
 
 import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 public class JdbcTransactionTest {
+    @BeforeClass
+    public void setUp() {
+        System.setProperty("clickhouse.jdbc.v1","true");
+    }
+
     @Test(groups = "unit")
     public void testQuery() {
         JdbcTransaction tx = new JdbcTransaction();


### PR DESCRIPTION
## Summary
Set JDBC v2 as default driver 

## Checklist
Delete items not relevant to your PR:
- [ ] Closes issue <!-- Link to an issue to close on merge. -->
- [X] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
