### PR TITLE
added manifest properties. fixed getting http client version

### DIFF
--- a/client-v2/pom.xml
+++ b/client-v2/pom.xml
@@ -13,8 +13,8 @@
     <packaging>jar</packaging>
 
     <name>ClickHouse Client API</name>
-    <description>New client api for ClickHouse</description>
-    <url>https://github.com/ClickHouse/clickhouse-java/tree/main/clickhouse-client-api</url>
+    <description>ClickHouse Client Library</description>
+    <url>https://github.com/ClickHouse/clickhouse-java/tree/main/client-v2</url>
 
     <properties>
         <apache.httpclient.version>5.3.1</apache.httpclient.version>
@@ -157,6 +157,22 @@
                         </path>
                     </annotationProcessorPaths>
                     <release>8</release>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptorRefs>
+                        <descriptorRef>jar-with-dependencies</descriptorRef>
+                    </descriptorRefs>
+                    <archive>
+                        <addMavenDescriptor>false</addMavenDescriptor>
+                        <manifest>
+                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                            <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                        </manifest>
+                    </archive>
                 </configuration>
             </plugin>
             <plugin>

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
@@ -72,6 +72,8 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -702,11 +704,30 @@ public class HttpAPIClientHelper {
         userAgent.setLength(userAgent.length() - 2);
         userAgent.append(')');
 
-        userAgent.append(" ")
-                .append(this.httpClient.getClass().getPackage().getImplementationTitle().replaceAll(" ", "-"))
-                .append('/')
-                .append(this.httpClient.getClass().getPackage().getImplementationVersion());
+        try {
+            String httpClientVersion = this.httpClient.getClass().getPackage().getImplementationVersion();
+            if (Objects.equals(this.httpClient.getClass().getPackage().getImplementationTitle(), this.getClass().getPackage().getImplementationTitle())) {
+                // shaded jar - all packages have same implementation title
+                httpClientVersion = "unknown";
+                try (InputStream in = Thread.currentThread().getContextClassLoader().getResourceAsStream("client-v2-version.properties")) {
+                    Properties p = new Properties();
+                    p.load(in);
 
+                    String tmp = p.getProperty("apache.http.client.version");
+                    if (tmp != null && !tmp.isEmpty() && !tmp.equals("${apache.httpclient.version}")) {
+                        httpClientVersion = tmp;
+                    }
+                } catch (Exception e) {
+                    // ignore
+                }
+            }
+            userAgent.append(" ")
+                    .append("Apache-HttpClient")
+                    .append('/')
+                    .append(httpClientVersion);
+        } catch (Exception e) {
+            LOG.info("failed to construct http client version string");
+        }
         return userAgent.toString();
     }
 

--- a/client-v2/src/main/resources/client-v2-version.properties
+++ b/client-v2/src/main/resources/client-v2-version.properties
@@ -1,2 +1,3 @@
 version=${revision}
 build.date=${build_timestamp}
+apache.http.client.version=${apache.httpclient.version}

--- a/examples/client-v2/pom.xml
+++ b/examples/client-v2/pom.xml
@@ -59,6 +59,7 @@
         <compiler-plugin.version>3.8.1</compiler-plugin.version>
 
         <minJdk>1.8</minJdk>
+        <clickhouse-packages.classifier>all</clickhouse-packages.classifier>
     </properties>
 
     <dependencies>
@@ -66,7 +67,7 @@
             <groupId>com.clickhouse</groupId>
             <artifactId>client-v2</artifactId>
             <version>${clickhouse-java.version}</version>
-            <classifier>all</classifier>
+            <classifier>${clickhouse-packages.classifier}</classifier>
         </dependency>
 
         <!-- Recommended for JSON parsing -->

--- a/pom.xml
+++ b/pom.xml
@@ -1049,6 +1049,33 @@
                             <argLine>${failsafeArgLine}</argLine>
                         </configuration>
                     </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-jar-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>default-jar</id>
+                                <configuration>
+                                    <archive>
+                                        <addMavenDescriptor>false</addMavenDescriptor>
+                                        <manifest>
+                                            <addDefaultEntries>true</addDefaultEntries>
+                                            <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                            <addBuildEnvironmentEntries>true</addBuildEnvironmentEntries>
+                                        </manifest>
+                                        <manifestEntries>
+                                            <Multi-Release>true</Multi-Release>
+                                            <Implementation-URL>${project.url}</Implementation-URL>
+                                            <Implementation-Vendor>ClickHouse, Inc.</Implementation-Vendor>
+                                            <Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>
+                                            <Implementation-Version><![CDATA[${project.artifactId} ${project.version} (revision: ${git.commit.id.abbrev})]]></Implementation-Version>
+                                            <SCM-Revision>${git.commit.id.full}</SCM-Revision>
+                                        </manifestEntries>
+                                    </archive>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
                 </plugins>
             </build>
         </profile>


### PR DESCRIPTION
## Summary
Version of the package can be hardcoded in a resource file or java one and version can be get from MANIFEST.MF. 
The last one is not required and may miss some records. Implementations relying on `getClass().getPackage().getImplementationVersion()` is unstable and in most cases it may return null or malformed information.
This PR make this approach only for dynamic version detection of 3rd-party libraries. Otherwise versions are read from resource file that is filed on building stage and guarantee to be present. 

## Checklist
Delete items not relevant to your PR:
- [x] Closes https://github.com/ClickHouse/clickhouse-java/issues/2061
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
