### PR TITLE
PR Fixes failing Test in Windows when attempting to locate files with reserved characters in the file path

### DIFF
--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseUtils.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseUtils.java
@@ -357,6 +357,17 @@ public final class ClickHouseUtils {
         }
 
         if (!pattern.startsWith("glob:") && !pattern.startsWith("regex:")) {
+            if (IS_WINDOWS) {
+                final String reservedCharsWindows = "<>:\"|?*";
+                pattern.chars().anyMatch(
+                        value -> {
+                            if (value < ' ' || reservedCharsWindows.indexOf(value) != -1) {
+                                throw new IllegalArgumentException("File path contains reserved character <%s>".formatted((char) value));
+                            }
+                            return false;
+                        }
+                );
+            }
             Path path = Paths.get(pattern);
             if (path.isAbsolute()) {
                 return Collections.singletonList(path);

--- a/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseUtilsTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseUtilsTest.java
@@ -7,6 +7,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Locale;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
@@ -96,8 +97,20 @@ public class ClickHouseUtilsTest {
         Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseUtils.findFiles(null));
         Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseUtils.findFiles(""));
 
+        if (System.getProperty("os.name").toLowerCase(Locale.ROOT).contains("windows")) {
+            Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseUtils.findFiles("READM?.md"));
+            Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseUtils.findFiles("READM<?.md"));
+            Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseUtils.findFiles("READM>.md"));
+            Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseUtils.findFiles("READM|.md"));
+            Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseUtils.findFiles("READM*.md"));
+            Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseUtils.findFiles("READM<>:\\\"|?*.md"));
+            Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseUtils.findFiles(" "));
+        }
+        else {
+            Assert.assertEquals(ClickHouseUtils.findFiles("READM?.md").size(), 1);
+        }
+
         Assert.assertEquals(ClickHouseUtils.findFiles("README.md").size(), 1);
-        Assert.assertEquals(ClickHouseUtils.findFiles("READM?.md").size(), 1);
         Assert.assertEquals(ClickHouseUtils.findFiles("glob:*.md").size(), 1);
         Assert.assertTrue(ClickHouseUtils.findFiles("glob:**.java", "src", "..").size() >= 1);
         Assert.assertTrue(ClickHouseUtils.findFiles("glob:**.java", "src/test").size() >= 1);


### PR DESCRIPTION
## Summary
Throws an exception when try to find a file with reserved character in the file path on Windows OS
[Test failure in Windows when attempting to locate files with reserved characters in the file path.](https://github.com/ClickHouse/clickhouse-java/issues/2114)
![{C3380B60-8E88-4027-8F1E-E1B745387316}](https://github.com/user-attachments/assets/7651cb30-ac04-47ed-91cc-55c0efa746c5)


Closes [Test failure in Windows when attempting to locate files with reserved characters in the file path.](https://github.com/ClickHouse/clickhouse-java/issues/2114)
## Checklist
Delete items not relevant to your PR:
- [x] Closes [Test failure in Windows when attempting to locate files with reserved characters in the file path.](https://github.com/ClickHouse/clickhouse-java/issues/2114)
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
