### PR TITLE
SerializerUtils support OffsetDateTime and Instant

### DIFF
--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseUtils.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseUtils.java
@@ -362,7 +362,7 @@ public final class ClickHouseUtils {
                 pattern.chars().anyMatch(
                         value -> {
                             if (value < ' ' || reservedCharsWindows.indexOf(value) != -1) {
-                                throw new IllegalArgumentException("File path contains reserved character <%s>".formatted((char) value));
+                                throw new IllegalArgumentException(String.format("File path contains reserved character <%s>", value));
                             }
                             return false;
                         }

--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -2000,6 +2000,7 @@ public class Client implements AutoCloseable {
         return isAsync ? CompletableFuture.supplyAsync(resultSupplier, sharedOperationExecutor) : CompletableFuture.completedFuture(resultSupplier.get());
     }
 
+    @Override
     public String toString() {
         return "Client{" +
                 "endpoints=" + endpoints +

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/ClickHouseBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/ClickHouseBinaryFormatReader.java
@@ -11,11 +11,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
-import java.time.Duration;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -534,6 +530,10 @@ public interface ClickHouseBinaryFormatReader extends AutoCloseable {
     LocalDateTime getLocalDateTime(String colName);
 
     LocalDateTime getLocalDateTime(int index);
+
+    OffsetDateTime getOffsetDateTime(String colName);
+
+    OffsetDateTime getOffsetDateTime(int index);
 
     TableSchema getSchema();
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryFormatSerializer.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryFormatSerializer.java
@@ -12,6 +12,8 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
+import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
@@ -143,6 +145,22 @@ public class RowBinaryFormatSerializer {
 
     public void writeDateTime64(ZonedDateTime value, int scale, ZoneId targetTz) throws IOException {
         SerializerUtils.writeDateTime64(out, value, scale, targetTz);
+    }
+
+    public void writeDateTime32(OffsetDateTime value) throws IOException {
+        SerializerUtils.writeDateTime32(out, value, null);
+    }
+
+    public void writeDateTime64(OffsetDateTime value, int scale) throws IOException {
+        SerializerUtils.writeDateTime64(out, value, scale, null);
+    }
+
+    public void writeDateTime32(Instant value) throws IOException {
+        SerializerUtils.writeDateTime32(out, value, null);
+    }
+
+    public void writeDateTime64(Instant value, int scale) throws IOException {
+        SerializerUtils.writeDateTime64(out, value, scale, null);
     }
 
     public void writeEnum8(byte value) throws IOException {

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
@@ -27,12 +27,7 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
-import java.time.Duration;
-import java.time.Instant;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
 import java.util.*;
@@ -221,7 +216,7 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
 
     protected void setSchema(TableSchema schema) {
         this.schema = schema;
-        this.columns = schema.getColumns().toArray(new ClickHouseColumn[0]);
+        this.columns = schema.getColumns().toArray(ClickHouseColumn.EMPTY_ARRAY);
         this.convertions = new Map[columns.length];
 
         for (int i = 0; i < columns.length; i++) {
@@ -279,7 +274,7 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
             ClickHouseDataType dataType = schema.getColumnByName(colName).getDataType();
             ZonedDateTime zdt = (ZonedDateTime) value;
             if (dataType == ClickHouseDataType.Date) {
-                return zdt.format(com.clickhouse.client.api.DataTypeUtils.DATE_FORMATTER).toString();
+                return zdt.format(com.clickhouse.client.api.DataTypeUtils.DATE_FORMATTER);
             }
             return value.toString();
         } else {
@@ -369,11 +364,17 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
                 return data.atStartOfDay().toInstant(ZoneOffset.UTC);
             case DateTime:
             case DateTime64:
-                LocalDateTime dateTime = readValue(colName);
-                return dateTime.toInstant(column.getTimeZone().toZoneId().getRules().getOffset(dateTime));
-
+                Object colValue = readValue(colName);
+                if (colValue instanceof LocalDateTime) {
+                    LocalDateTime dateTime = (LocalDateTime) colValue;
+                    return dateTime.toInstant(column.getTimeZone().toZoneId().getRules().getOffset(dateTime));
+                } else {
+                    ZonedDateTime dateTime = (ZonedDateTime) colValue;
+                    return dateTime.toInstant();
+                }
+            default:
+                throw new ClientException("Column of type " + column.getDataType() + " cannot be converted to Instant");
         }
-        throw new ClientException("Column of type " + column.getDataType() + " cannot be converted to Instant");
     }
 
     @Override
@@ -386,9 +387,9 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
             case Date:
             case Date32:
                 return readValue(colName);
+            default:
+                throw new ClientException("Column of type " + column.getDataType() + " cannot be converted to Instant");
         }
-
-        throw new ClientException("Column of type " + column.getDataType() + " cannot be converted to Instant");
     }
 
     @Override
@@ -723,6 +724,24 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
             return ((ZonedDateTime) value).toLocalDateTime();
         }
         return (LocalDateTime) value;
+    }
+
+    @Override
+    public OffsetDateTime getOffsetDateTime(String colName) {
+        Object value = readValue(colName);
+        if (value instanceof ZonedDateTime) {
+            return ((ZonedDateTime) value).toOffsetDateTime();
+        }
+        return (OffsetDateTime) value;
+    }
+
+    @Override
+    public OffsetDateTime getOffsetDateTime(int index) {
+        Object value = readValue(index);
+        if (value instanceof ZonedDateTime) {
+            return ((ZonedDateTime) value).toOffsetDateTime();
+        }
+        return (OffsetDateTime) value;
     }
 
     @Override

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryReaderBackedRecord.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryReaderBackedRecord.java
@@ -355,6 +355,16 @@ public class BinaryReaderBackedRecord implements GenericRecord {
     }
 
     @Override
+    public OffsetDateTime getOffsetDateTime(String colName) {
+        return reader.getOffsetDateTime(colName);
+    }
+
+    @Override
+    public OffsetDateTime getOffsetDateTime(int index) {
+        return reader.getOffsetDateTime(index);
+    }
+
+    @Override
     public Object getObject(String colName) {
         return reader.readValue(colName);
     }

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/MapBackedRecord.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/MapBackedRecord.java
@@ -490,6 +490,24 @@ public class MapBackedRecord implements GenericRecord {
     }
 
     @Override
+    public OffsetDateTime getOffsetDateTime(String colName) {
+        Object value = readValue(colName);
+        if (value instanceof ZonedDateTime) {
+            return ((ZonedDateTime) value).toOffsetDateTime();
+        }
+        return (OffsetDateTime) value;
+    }
+
+    @Override
+    public OffsetDateTime getOffsetDateTime(int index) {
+        Object value = readValue(index);
+        if (value instanceof ZonedDateTime) {
+            return ((ZonedDateTime) value).toOffsetDateTime();
+        }
+        return (OffsetDateTime) value;
+    }
+
+    @Override
     public ClickHouseBitmap getClickHouseBitmap(String colName) {
         return readValue(colName);
     }

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/SerializerUtils.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/SerializerUtils.java
@@ -23,10 +23,7 @@ import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.sql.Timestamp;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
-import java.time.ZonedDateTime;
+import java.time.*;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -639,16 +636,22 @@ public class SerializerUtils {
     }
 
     public static void writeDateTime(OutputStream output, Object value, ZoneId targetTz) throws IOException {
-        long ts = 0;
+        long ts;
         if (value instanceof LocalDateTime) {
             LocalDateTime dt = (LocalDateTime) value;
             ts = dt.atZone(targetTz).toEpochSecond();
         } else if (value instanceof ZonedDateTime) {
             ZonedDateTime dt = (ZonedDateTime) value;
-            ts = dt.withZoneSameInstant(targetTz).toEpochSecond();
+            ts = dt.toEpochSecond();
         } else if (value instanceof Timestamp) {
             Timestamp t = (Timestamp) value;
             ts = t.toLocalDateTime().atZone(targetTz).toEpochSecond();
+        } else if(value instanceof OffsetDateTime) {
+            OffsetDateTime dt = (OffsetDateTime) value;
+            ts = dt.toEpochSecond();
+        } else if (value instanceof Instant) {
+            Instant dt = (Instant) value;
+            ts = dt.getEpochSecond();
         } else {
             throw new IllegalArgumentException("Cannot convert " + value + " to DataTime");
         }
@@ -661,19 +664,29 @@ public class SerializerUtils {
             throw new IllegalArgumentException("Invalid scale value '" + scale + "'");
         }
 
-        long ts = 0;
-        long nano = 0;
+        long ts;
+        long nano;
         if (value instanceof LocalDateTime) {
-            ZonedDateTime dt = ((LocalDateTime) value).atZone(targetTz);
-            ts = dt.toEpochSecond();
-            nano = dt.getNano();
+            LocalDateTime dt = (LocalDateTime) value;
+            ZonedDateTime zdt = dt.atZone(targetTz);
+            ts = zdt.toEpochSecond();
+            nano = zdt.getNano();
         } else if (value instanceof ZonedDateTime) {
-            ZonedDateTime dt = ((ZonedDateTime) value).withZoneSameInstant(targetTz);
+            ZonedDateTime dt = (ZonedDateTime) value;
             ts = dt.toEpochSecond();
             nano = dt.getNano();
         } else if (value instanceof Timestamp) {
-            ZonedDateTime dt = ((Timestamp) value).toLocalDateTime().atZone(targetTz);
+            Timestamp dt = (Timestamp) value;
+            ZonedDateTime zdt = dt.toLocalDateTime().atZone(targetTz);
+            ts = zdt.toEpochSecond();
+            nano = zdt.getNano();
+        } else if (value instanceof OffsetDateTime) {
+            OffsetDateTime dt = (OffsetDateTime) value;
             ts = dt.toEpochSecond();
+            nano = dt.getNano();
+        } else if (value instanceof Instant) {
+            Instant dt = (Instant) value;
+            ts = dt.getEpochSecond();
             nano = dt.getNano();
         } else {
             throw new IllegalArgumentException("Cannot convert " + value + " to DataTime");

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/GenericRecord.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/GenericRecord.java
@@ -487,6 +487,10 @@ public interface GenericRecord {
 
     LocalDateTime getLocalDateTime(int index);
 
+    OffsetDateTime getOffsetDateTime(String colName);
+
+    OffsetDateTime getOffsetDateTime(int index);
+
     Object getObject(String colName);
 
     Object getObject(int index);

--- a/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
@@ -135,7 +135,6 @@ public class InsertTests extends BaseIntegrationTest {
         assertEquals(response.getQueryId(), uuid);
     }
 
-
     @Test(groups = { "integration" }, enabled = true)
     public void insertPOJOWithJSON() throws Exception {
         if (isCloud()) {
@@ -458,12 +457,12 @@ public class InsertTests extends BaseIntegrationTest {
                 if (row[4] == null) {
                     formatWriter.writeDefault();
                 } else {
-                    formatWriter.writeString((String) row[4]);
+                    formatWriter.writeDateTime((ZonedDateTime) row[4], null);
                 }
                 if (row[5] == null) {
                     formatWriter.writeDefault();
                 } else {
-                    formatWriter.writeInt8((byte) row[5]);
+                    formatWriter.writeInt8(((Integer) row[5]).byteValue());
                 }
             }
         }, ClickHouseFormat.RowBinaryWithDefaults, new InsertSettings()).get()) {

--- a/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
@@ -43,6 +43,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.time.temporal.ChronoField;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -207,6 +208,12 @@ public class InsertTests extends BaseIntegrationTest {
             Assert.assertEquals(reader.getDouble("float64"), pojo.getFloat64());
             Assert.assertEquals(reader.getString("string"), pojo.getString());
             Assert.assertEquals(reader.getString("fixedString"), pojo.getFixedString());
+            Assert.assertTrue(reader.getZonedDateTime("zonedDateTime").isEqual(pojo.getZonedDateTime().withNano(0)));
+            Assert.assertTrue(reader.getZonedDateTime("zonedDateTime64").isEqual(pojo.getZonedDateTime64()));
+            Assert.assertTrue(reader.getOffsetDateTime("offsetDateTime").isEqual(pojo.getOffsetDateTime().withNano(0)));
+            Assert.assertTrue(reader.getOffsetDateTime("offsetDateTime64").isEqual(pojo.getOffsetDateTime64()));
+            Assert.assertEquals(reader.getInstant("instant"), pojo.getInstant().with(ChronoField.MICRO_OF_SECOND, 0));
+            Assert.assertEquals(reader.getInstant("instant64"), pojo.getInstant64());
         }
     }
 

--- a/client-v2/src/test/java/com/clickhouse/client/insert/SamplePOJO.java
+++ b/client-v2/src/test/java/com/clickhouse/client/insert/SamplePOJO.java
@@ -8,8 +8,7 @@ import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.net.UnknownHostException;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
+import java.time.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -66,6 +65,15 @@ public class SamplePOJO {
 
     private LocalDateTime dateTime;
     private LocalDateTime dateTime64;
+
+    private ZonedDateTime zonedDateTime;
+    private ZonedDateTime zonedDateTime64;
+
+    private OffsetDateTime offsetDateTime;
+    private OffsetDateTime offsetDateTime64;
+
+    private Instant instant;
+    private Instant instant64;
 
     private UUID uuid;
 
@@ -139,6 +147,15 @@ public class SamplePOJO {
 
         dateTime = LocalDateTime.now();
         dateTime64 = LocalDateTime.now();
+
+        zonedDateTime = ZonedDateTime.now();
+        zonedDateTime64 = ZonedDateTime.now();
+
+        offsetDateTime = OffsetDateTime.now();
+        offsetDateTime64 = OffsetDateTime.now();
+
+        instant = Instant.now();
+        instant64 = Instant.now();
 
         uuid = UUID.randomUUID();
 
@@ -474,6 +491,54 @@ public class SamplePOJO {
         this.dateTime64 = dateTime64;
     }
 
+    public ZonedDateTime getZonedDateTime() {
+        return zonedDateTime;
+    }
+
+    public void setZonedDateTime(ZonedDateTime zonedDateTime) {
+        this.zonedDateTime = zonedDateTime;
+    }
+
+    public ZonedDateTime getZonedDateTime64() {
+        return zonedDateTime64;
+    }
+
+    public void setZonedDateTime64(ZonedDateTime zonedDateTime64) {
+        this.zonedDateTime64 = zonedDateTime64;
+    }
+
+    public OffsetDateTime getOffsetDateTime() {
+        return offsetDateTime;
+    }
+
+    public void setOffsetDateTime(OffsetDateTime offsetDateTime) {
+        this.offsetDateTime = offsetDateTime;
+    }
+
+    public OffsetDateTime getOffsetDateTime64() {
+        return offsetDateTime64;
+    }
+
+    public void setOffsetDateTime64(OffsetDateTime offsetDateTime64) {
+        this.offsetDateTime64 = offsetDateTime64;
+    }
+
+    public Instant getInstant() {
+        return instant;
+    }
+
+    public void setInstant(Instant instant) {
+        this.instant = instant;
+    }
+
+    public Instant getInstant64() {
+        return instant64;
+    }
+
+    public void setInstant64(Instant instant64) {
+        this.instant64 = instant64;
+    }
+
     public UUID getUuid() {
         return uuid;
     }
@@ -628,6 +693,12 @@ public class SamplePOJO {
                 ", date32=" + date32 +
                 ", dateTime=" + dateTime +
                 ", dateTime64=" + dateTime64 +
+                ", zonedDateTime=" + zonedDateTime +
+                ", zonedDateTime64=" + zonedDateTime64 +
+                ", offsetDateTime=" + offsetDateTime +
+                ", offsetDateTime64=" + offsetDateTime64 +
+                ", instant=" + instant +
+                ", instant64=" + instant64 +
                 ", uuid=" + uuid +
                 ", enum8=" + enum8 +
                 ", enum16=" + enum16 +
@@ -684,6 +755,12 @@ public class SamplePOJO {
                 "date32 Date, " +
                 "dateTime DateTime, " +
                 "dateTime64 DateTime64(3), " +
+                "zonedDateTime DateTime, " +
+                "zonedDateTime64 DateTime64(9), " +
+                "offsetDateTime DateTime, " +
+                "offsetDateTime64 DateTime64(9), " +
+                "instant DateTime, " +
+                "instant64 DateTime64(9), " +
                 "uuid UUID, " +
                 "enum8 Enum8('a' = 1, 'b' = 2, 'c' = 3, 'd' = 4, 'e' = 5, 'f' = 6, 'g' = 7, 'h' = 8, 'i' = 9, 'j' = 10, 'k' = 11, 'l' = 12, 'm' = 13, 'n' = 14, 'o' = 15, 'p' = 16, 'q' = 17, 'r' = 18, 's' = 19, 't' = 20, 'u' = 21, 'v' = 22, 'w' = 23, 'x' = 24, 'y' = 25, 'z' = 26), " +
                 "enum16 Enum16('a' = 1, 'b' = 2, 'c' = 3, 'd' = 4, 'e' = 5, 'f' = 6, 'g' = 7, 'h' = 8, 'i' = 9, 'j' = 10, 'k' = 11, 'l' = 12, 'm' = 13, 'n' = 14, 'o' = 15, 'p' = 16, 'q' = 17, 'r' = 18, 's' = 19, 't' = 20, 'u' = 21, 'v' = 22, 'w' = 23, 'x' = 24, 'y' = 25, 'z' = 26), " +

--- a/client-v2/src/test/java/com/clickhouse/client/insert/SamplePOJO.java
+++ b/client-v2/src/test/java/com/clickhouse/client/insert/SamplePOJO.java
@@ -123,7 +123,6 @@ public class SamplePOJO {
         uint32 = (long) (random.nextDouble() * 4294967295L);
         uint64 = (long) (random.nextDouble() * 18446744073709615L);
 
-
         uint128 = upper.or(lower).abs();
         uint256 = upper1.or(upper2).or(lower1).or(lower2).abs();
 


### PR DESCRIPTION
## Summary

Use cases:

```java
public record MyData (OffsetDateTime ts1, Instant ts2) {
}

client.insert(List.of(new MyData(OffsetDateTime.now(), Instant.now())));
```

## Checklist
Delete items not relevant to your PR:
- [x] Closes #2117
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
