### PR TITLE
[client-v2] Fixed cleaning expired connections from the pool

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
@@ -49,6 +49,7 @@ import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.io.CloseMode;
 import org.apache.hc.core5.io.IOCallback;
 import org.apache.hc.core5.net.URIBuilder;
+import org.apache.hc.core5.pool.ConnPoolControl;
 import org.apache.hc.core5.pool.PoolConcurrencyPolicy;
 import org.apache.hc.core5.pool.PoolReusePolicy;
 import org.apache.hc.core5.util.TimeValue;
@@ -100,6 +101,9 @@ public class HttpAPIClientHelper {
 
     private String defaultUserAgent;
     private Object metricsRegistry;
+
+    ConnPoolControl<?> poolControl;
+
     public HttpAPIClientHelper(Map<String, String> configuration, Object metricsRegistry, boolean initSslContext) {
         this.chConfiguration = configuration;
         this.metricsRegistry = metricsRegistry;
@@ -226,6 +230,7 @@ public class HttpAPIClientHelper {
         connMgrBuilder.setSSLSocketFactory(sslConnectionSocketFactory);
         connMgrBuilder.setDefaultSocketConfig(socketConfig);
         PoolingHttpClientConnectionManager phccm = connMgrBuilder.build();
+        poolControl = phccm;
         if (metricsRegistry != null ) {
             try {
                 String mGroupName = chConfiguration.getOrDefault(ClientConfigProperties.METRICS_GROUP_NAME.getKey(),
@@ -365,6 +370,8 @@ public class HttpAPIClientHelper {
 
     public ClassicHttpResponse executeRequest(ClickHouseNode server, Map<String, Object> requestConfig,
                                              IOCallback<OutputStream> writeCallback) throws IOException {
+        poolControl.closeExpired();
+
         if (requestConfig == null) {
             requestConfig = Collections.emptyMap();
         }


### PR DESCRIPTION
## Summary
Expired connections are not removed from the pool. It causes two problem with metrics: they do not reflect actual state. 
This PR calls `poolControl.closeExpired()` before each request. It should not create a problem with pool. 


Closes https://github.com/ClickHouse/clickhouse-java/issues/2123
## Checklist
Delete items not relevant to your PR:
- [x] Closes #2123 
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
