### PR TITLE
[client-v2] Fix support in ClickHouseBinaryFormatReader for SimpleAggregateValue

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
@@ -222,8 +222,11 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
 
         for (int i = 0; i < columns.length; i++) {
             ClickHouseColumn column = columns[i];
-
-            switch (column.getDataType()) {
+            ClickHouseDataType columnDataType = column.getDataType();
+            if (columnDataType.equals(ClickHouseDataType.SimpleAggregateFunction)){
+                columnDataType = column.getNestedColumns().get(0).getDataType();
+            }
+            switch (columnDataType) {
                 case Int8:
                 case Int16:
                 case UInt8:
@@ -378,7 +381,11 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
     public Instant getInstant(String colName) {
         int colIndex = schema.nameToIndex(colName);
         ClickHouseColumn column = schema.getColumns().get(colIndex);
-        switch (column.getDataType()) {
+        ClickHouseDataType columnDataType = column.getDataType();
+        if (columnDataType.equals(ClickHouseDataType.SimpleAggregateFunction)){
+            columnDataType = column.getNestedColumns().get(0).getDataType();
+        }
+        switch (columnDataType) {
             case Date:
             case Date32:
                 LocalDate data = readValue(colName);
@@ -402,7 +409,11 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
     public ZonedDateTime getZonedDateTime(String colName) {
         int colIndex = schema.nameToIndex(colName);
         ClickHouseColumn column = schema.getColumns().get(colIndex);
-        switch (column.getDataType()) {
+        ClickHouseDataType columnDataType = column.getDataType();
+        if (columnDataType.equals(ClickHouseDataType.SimpleAggregateFunction)){
+            columnDataType = column.getNestedColumns().get(0).getDataType();
+        }
+        switch (columnDataType) {
             case DateTime:
             case DateTime64:
             case Date:


### PR DESCRIPTION
## Summary
This is a response to #2127 which is complementary to #2022. I'm however concerned by my solution as it is, it may be contested or refused. The solution proposed here is by adding a specific check for each operation that gets the dataType to check if it's a simpleAggregateFunction, and if it's the case take the nested column datatype. Maybe a modification of the ClickhouseColumn implementation could be cleaner but its scope is above my understanding at this moment. 


Closes #2127 
## Checklist
- [x] Closes #2127 
- [x] Unit and integration tests covering the common scenarios were added