### PR TITLE
fix: #2132 fix executing queries with 'WITH' clause in jdbc v2

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/StatementImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/StatementImpl.java
@@ -84,6 +84,7 @@ public class StatementImpl implements Statement, JdbcV2Wrapper {
 
                 switch (tokens[0].toUpperCase()) {
                     case "SELECT": return StatementType.SELECT;
+                    case "WITH": return StatementType.SELECT;
                     case "INSERT": return StatementType.INSERT;
                     case "DELETE": return StatementType.DELETE;
                     case "UPDATE": return StatementType.UPDATE;

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/PreparedStatementTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/PreparedStatementTest.java
@@ -260,4 +260,20 @@ public class PreparedStatementTest extends JdbcIntegrationTest {
             }
         }
     }
+
+
+    @Test(groups = "integration")
+    void testWithClause() throws Exception {
+        int count = 0;
+        try (Connection conn = getJdbcConnection()) {
+            try (PreparedStatement stmt = conn.prepareStatement("with data as (SELECT number FROM numbers(100)) select * from data ")) {
+                stmt.execute();
+                ResultSet rs = stmt.getResultSet();
+                while (rs.next()) {
+                    count++;
+                }
+            }
+        }
+        assertEquals(count, 100);
+    }
 }

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/StatementTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/StatementTest.java
@@ -464,6 +464,11 @@ public class StatementTest extends JdbcIntegrationTest {
         assertEquals(StatementImpl.parseStatementType("      "), StatementImpl.StatementType.OTHER);
     }
 
+    @Test(groups = { "integration" })
+    public void testParseStatementWithClause() throws Exception {
+        assertEquals(StatementImpl.parseStatementType("with data as (SELECT number FROM numbers(100)) select * from data"), StatementImpl.StatementType.SELECT);
+    }
+
 
     @Test(groups = { "integration" })
     public void testWithIPs() throws Exception {
@@ -538,5 +543,20 @@ public class StatementTest extends JdbcIntegrationTest {
              Statement stmt = conn.createStatement()) {
             Assert.expectThrows(SQLException.class, () ->stmt.executeQuery("SELECT 1 FORMAT JSON"));
         }
+    }
+
+    @Test(groups = "integration")
+    void testWithClause() throws Exception {
+        int count = 0;
+        try (Connection conn = getJdbcConnection()) {
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("with data as (SELECT number FROM numbers(100)) select * from data");
+                ResultSet rs = stmt.getResultSet();
+                while (rs.next()) {
+                    count++;
+                }
+            }
+        }
+        assertEquals(count, 100);
     }
 }


### PR DESCRIPTION
## Summary

The issue seemed to be in the `parseStatementType` function. I have also added several tests related to this scenario.
Closes #2132 

## Checklist
- [x] Closes #2132
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG

I'm not sure what to do regarding the changelog. If there's any action required, please guide me. Thank you for your help!