### PR TITLE
change connection schema after USE is executed

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/StatementImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/StatementImpl.java
@@ -366,6 +366,13 @@ public class StatementImpl implements Statement, JdbcV2Wrapper {
                 }
             }
             return false;
+        } else if (type == StatementType.USE) {
+            executeUpdate(sql, settings);
+            //USE Database
+            List<String> tokens = JdbcUtils.tokenizeSQL(sql);
+            this.schema = tokens.get(1).replace("\"", "");;
+            LOG.info("Changed statement schema " + schema);
+            return false;
         } else {
             executeUpdate(sql, settings);
             return false;

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/StatementTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/StatementTest.java
@@ -539,4 +539,17 @@ public class StatementTest extends JdbcIntegrationTest {
             Assert.expectThrows(SQLException.class, () ->stmt.executeQuery("SELECT 1 FORMAT JSON"));
         }
     }
+
+    @Test(groups = { "integration" })
+    public void testSwitchDatabase() throws Exception {
+        String createSql = "CREATE TABLE strings (id UInt8, words String) ENGINE = MergeTree ORDER BY ()";
+        try (Connection conn = getJdbcConnection()) {
+            try (Statement stmt = conn.createStatement()) {
+                assertEquals(stmt.executeUpdate(createSql), 0);
+                assertEquals(stmt.executeUpdate("CREATE DATABASE \"test\" ENGINE=Atomic"), 0);
+                assertFalse(stmt.execute("USE \"test\""));
+                assertEquals(stmt.executeUpdate(createSql), 0);
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->
enable `USE database;` statement for JDBC V2
Closes [#2137](https://github.com/ClickHouse/clickhouse-java/issues/2137)
## Checklist
Delete items not relevant to your PR:
- [x] Closes [#2137](https://github.com/ClickHouse/clickhouse-java/issues/2137)
- [x] Unit and integration tests covering the common scenarios were added

