### PR TITLE
fixed getTableSchema by passing database to settings

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -1882,8 +1882,9 @@ public class Client implements AutoCloseable {
     private TableSchema getTableSchemaImpl(String describeQuery, String name, String originalQuery, String database) {
         int operationTimeout = getOperationTimeout();
 
-        try (QueryResponse response = operationTimeout == 0 ? query(describeQuery).get() :
-                query(describeQuery).get(getOperationTimeout(), TimeUnit.SECONDS)) {
+        QuerySettings settings = new QuerySettings().setDatabase(database);
+        try (QueryResponse response = operationTimeout == 0 ? query(describeQuery, settings).get() :
+                query(describeQuery, settings).get(getOperationTimeout(), TimeUnit.SECONDS)) {
             return TableSchemaParser.readTSKV(response.getInputStream(), name, originalQuery, database);
         } catch (TimeoutException e) {
             throw new ClientException("Operation has likely timed out after " + getOperationTimeout() + " seconds.", e);

--- a/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
@@ -105,8 +105,7 @@ public class InsertTests extends BaseIntegrationTest {
                 .useHttpCompression(useHttpCompression)
                 .setDefaultDatabase(ClickHouseServerForTest.getDatabase())
                 .serverSetting(ServerSettings.ASYNC_INSERT, "0")
-                .serverSetting(ServerSettings.WAIT_END_OF_QUERY, "1")
-                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "true").equals("true"));
+                .serverSetting(ServerSettings.WAIT_END_OF_QUERY, "1");
     }
 
     @AfterMethod(groups = { "integration" })
@@ -162,7 +161,7 @@ public class InsertTests extends BaseIntegrationTest {
         client.execute("DROP TABLE IF EXISTS " + tableName, commandSettings).get(EXECUTE_CMD_TIMEOUT, TimeUnit.SECONDS);
         client.execute(createSQL, commandSettings).get(EXECUTE_CMD_TIMEOUT, TimeUnit.SECONDS);
 
-        client.register(PojoWithJSON.class, client.getTableSchema(tableName, "default"));
+        client.register(PojoWithJSON.class, client.getTableSchema(tableName));
         PojoWithJSON pojo = new PojoWithJSON();
         pojo.setEventPayload(originalJsonStr);
         List<Object> data = Arrays.asList(pojo);
@@ -189,7 +188,7 @@ public class InsertTests extends BaseIntegrationTest {
 
         initTable(tableName, createSQL);
 
-        client.register(SamplePOJO.class, client.getTableSchema(tableName, "default"));
+        client.register(SamplePOJO.class, client.getTableSchema(tableName));
 
         System.out.println("Inserting POJO: " + pojo);
         try (InsertResponse response = client.insert(tableName, Collections.singletonList(pojo), settings).get(EXECUTE_CMD_TIMEOUT, TimeUnit.SECONDS)) {
@@ -231,7 +230,7 @@ public class InsertTests extends BaseIntegrationTest {
 
         initTable(tableName, createSQL);
 
-        client.register(SamplePOJO.class, client.getTableSchema(tableName, "default"));
+        client.register(SamplePOJO.class, client.getTableSchema(tableName));
 
         try (InsertResponse response = client.insert(tableName, Collections.singletonList(pojo), settings).get(30, TimeUnit.SECONDS)) {
             fail("Should have thrown an exception");

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -1883,7 +1883,7 @@ public class QueryTests extends BaseIntegrationTest {
             throw e;
         }
 
-        client.register(AggregateFuncDTO.class, client.getTableSchema(tableName, "default"));
+        client.register(AggregateFuncDTO.class, client.getTableSchema(tableName));
 
         try (InsertResponse response = client.insert(tableName, Collections.singletonList(pojo)).get(30, TimeUnit.SECONDS)) {
             Assert.assertEquals(response.getWrittenRows(), 1);


### PR DESCRIPTION
## Summary
Passes database in operation settings when doing describe request for a table in non-default DB. 

Closes https://github.com/ClickHouse/clickhouse-java/issues/2139
## Checklist
Delete items not relevant to your PR:
- [x] Closes #2139 
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
