### PR TITLE
fix: fix creation of Inet6Address.

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -182,7 +182,7 @@ public class BinaryStreamReader {
                     return (T) Inet4Address.getByAddress(readNBytesLE(input, 4));
                 case IPv6:
                     // https://clickhouse.com/docs/en/sql-reference/data-types/ipv6
-                    return (T) Inet6Address.getByAddress(readNBytes(input, 16));
+                    return (T) Inet6Address.getByAddress(null, readNBytes(input, 16), null);
                 case UUID:
                     return (T) new UUID(readLongLE(), readLongLE());
                 case Point:

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/DataTypeTests.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/DataTypeTests.java
@@ -926,4 +926,16 @@ public class DataTypeTests extends JdbcIntegrationTest {
             }
         }
     }
+
+    @Test(groups = "integration")
+    void testIPv6MappedToIPv4() throws Exception {
+        try (Connection conn = getJdbcConnection()) {
+            try (Statement stmt = conn.createStatement()) {
+                ResultSet rs = stmt.executeQuery("select toIPv6('::ffff:1.1.1.1')");
+                assertTrue(rs.next());
+                assertEquals(rs.getString(1), "/0:0:0:0:0:ffff:101:101");
+                assertFalse(rs.next());
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
The problem is that when using the InetAddress.getByAddress method, it returns an Inet4Address object if the provided address can be mapped to an IPv4 address. I used another overloaded method that always returns an Inet6Address, and I also created a test scenario for this case.

Closes #2140
## Checklist
Delete items not relevant to your PR:
- [x] Closes #2140 
- [x] Unit and integration tests covering the common scenarios were added