### PR TITLE
[jdbc-v2] fixed switching db test

### DIFF
--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
@@ -2511,7 +2511,7 @@ public abstract class ClientIntegrationTest extends BaseIntegrationTest {
 
             tx.begin();
             try {
-                Thread.sleep(3000L);
+                Thread.sleep(4000L);
             } catch (InterruptedException ex) {
                 Assert.fail("Sleep was interrupted", ex);
             }

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/StatementTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/StatementTest.java
@@ -562,12 +562,13 @@ public class StatementTest extends JdbcIntegrationTest {
 
     @Test(groups = { "integration" })
     public void testSwitchDatabase() throws Exception {
+        String databaseName = getDatabase() + "_test_switch";
         String createSql = "CREATE TABLE switchDatabaseWithUse (id UInt8, words String) ENGINE = MergeTree ORDER BY ()";
         try (Connection conn = getJdbcConnection()) {
             try (Statement stmt = conn.createStatement()) {
                 assertEquals(stmt.executeUpdate(createSql), 0);
-                assertEquals(stmt.executeUpdate("CREATE DATABASE \"newDatabase\" ENGINE=Atomic"), 0);
-                assertFalse(stmt.execute("USE \"newDatabase\""));
+                assertEquals(stmt.executeUpdate("CREATE DATABASE \"" + databaseName + "\""), 0);
+                assertFalse(stmt.execute("USE \"" + databaseName + "\""));
                 assertEquals(stmt.executeUpdate(createSql), 0);
             }
         }


### PR DESCRIPTION
## Summary
Test creates db with engine `Atomic`. It is not necessary and disabled on cloud instances. 

## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
