### PR TITLE
feat(ClientV2): Add execute(String, Map<String,Object>)

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -1939,6 +1939,26 @@ public class Client implements AutoCloseable {
      * <p>Executes a SQL command and doesn't care response. Useful for DDL statements, like `CREATE`, `DROP`, `ALTER`.
      * Method however returns execution errors from a server or summary in case of successful execution. </p>
      *
+     * @param sql      - SQL command
+     * @param params   - query parameters
+     * @param settings  - execution settings
+     * @return {@code CompletableFuture<CommandResponse>} - a promise to command response
+     */
+    public CompletableFuture<CommandResponse> execute(String sql, Map<String, Object> params, CommandSettings settings){
+        return query(sql, params, settings)
+                .thenApplyAsync(response -> {
+                    try {
+                        return new CommandResponse(response);
+                    } catch (Exception e) {
+                        throw new ClientException("Failed to get command response", e);
+                    }
+                });
+    }
+
+    /**
+     * <p>Executes a SQL command and doesn't care response. Useful for DDL statements, like `CREATE`, `DROP`, `ALTER`.
+     * Method however returns execution errors from a server or summary in case of successful execution. </p>
+     *
      * @param sql - SQL command
      * @return {@code CompletableFuture<CommandResponse>} - a promise to command response
      */

--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -1920,6 +1920,25 @@ public class Client implements AutoCloseable {
      * <p>Executes a SQL command and doesn't care response. Useful for DDL statements, like `CREATE`, `DROP`, `ALTER`.
      * Method however returns execution errors from a server or summary in case of successful execution. </p>
      *
+     * @param sql      - SQL command
+     * @param params   - query parameters
+     * @return {@code CompletableFuture<CommandResponse>} - a promise to command response
+     */
+    public CompletableFuture<CommandResponse> execute(String sql, Map<String, Object> params){
+        return query(sql, params)
+                .thenApplyAsync(response -> {
+                    try {
+                        return new CommandResponse(response);
+                    } catch (Exception e) {
+                        throw new ClientException("Failed to get command response", e);
+                    }
+                });
+    }
+
+    /**
+     * <p>Executes a SQL command and doesn't care response. Useful for DDL statements, like `CREATE`, `DROP`, `ALTER`.
+     * Method however returns execution errors from a server or summary in case of successful execution. </p>
+     *
      * @param sql - SQL command
      * @return {@code CompletableFuture<CommandResponse>} - a promise to command response
      */

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -74,12 +74,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -1560,6 +1555,34 @@ public class QueryTests extends BaseIntegrationTest {
             Assert.assertTrue((Integer) record.getInteger("col1") >= 2);
         }
         Assert.assertEquals(allRecords.size(), 2);
+    }
+
+    @Test(groups = {"integration"})
+    public void testExecuteQueryParam() throws ExecutionException, InterruptedException, TimeoutException {
+
+        final String table = "execute_query_test";
+        Map<String, Object> query_param = Map.of("table_name",table, "engine","MergeTree");
+        client.execute("DROP TABLE IF EXISTS " + table).get(10, TimeUnit.SECONDS);
+        client.execute("CREATE TABLE {table_name:Identifier} ( id UInt32, name String, created_at DateTime) ENGINE = MergeTree ORDER BY tuple()", query_param)
+                .get(10, TimeUnit.SECONDS);
+
+        TableSchema schema = client.getTableSchema(table);
+        Assert.assertNotNull(schema);
+    }
+
+    @Test(groups = {"integration"})
+    public void testExecuteQueryParamCommandSettings() throws ExecutionException, InterruptedException, TimeoutException {
+
+        final String table = "execute_query_test";
+        String q1Id = UUID.randomUUID().toString();
+        Map<String, Object> query_param = Map.of("table_name",table, "engine","MergeTree");
+        client.execute("DROP TABLE IF EXISTS " + table).get(10, TimeUnit.SECONDS);
+        client.execute("CREATE TABLE {table_name:Identifier} ( id UInt32, name String, created_at DateTime) ENGINE = MergeTree ORDER BY tuple()",
+                        query_param, (CommandSettings) new CommandSettings().setQueryId(q1Id))
+                .get(10, TimeUnit.SECONDS);
+
+        TableSchema schema = client.getTableSchema(table);
+        Assert.assertNotNull(schema);
     }
 
     @Test(groups = {"integration"})

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -1561,7 +1561,9 @@ public class QueryTests extends BaseIntegrationTest {
     public void testExecuteQueryParam() throws ExecutionException, InterruptedException, TimeoutException {
 
         final String table = "execute_query_test";
-        Map<String, Object> query_param = Map.of("table_name",table, "engine","MergeTree");
+        Map<String, Object> query_param = new HashMap<>();
+        query_param.put("table_name",table);
+        query_param.put("engine","MergeTree");
         client.execute("DROP TABLE IF EXISTS " + table).get(10, TimeUnit.SECONDS);
         client.execute("CREATE TABLE {table_name:Identifier} ( id UInt32, name String, created_at DateTime) ENGINE = MergeTree ORDER BY tuple()", query_param)
                 .get(10, TimeUnit.SECONDS);
@@ -1575,7 +1577,9 @@ public class QueryTests extends BaseIntegrationTest {
 
         final String table = "execute_query_test";
         String q1Id = UUID.randomUUID().toString();
-        Map<String, Object> query_param = Map.of("table_name",table, "engine","MergeTree");
+        Map<String, Object> query_param = new HashMap<>();
+        query_param.put("table_name",table);
+        query_param.put("engine","MergeTree");
         client.execute("DROP TABLE IF EXISTS " + table).get(10, TimeUnit.SECONDS);
         client.execute("CREATE TABLE {table_name:Identifier} ( id UInt32, name String, created_at DateTime) ENGINE = MergeTree ORDER BY tuple()",
                         query_param, (CommandSettings) new CommandSettings().setQueryId(q1Id))


### PR DESCRIPTION
## Summary
An an overload of the execute method, to be used like the queryAll with the sql statement and the query params in a Map<String, Object>. 

I didn't add tests for this method as relaying on the query method only. 

Closes #2152 
## Checklist
Delete items not relevant to your PR:
- [X] Closes #2152
- [X] A human-readable description of the changes was provided to include in CHANGELOG
