### PR TITLE
Deprecating all classes/interfaces/etc from v1

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/AbstractClient.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/AbstractClient.java
@@ -23,6 +23,7 @@ import com.clickhouse.logging.LoggerFactory;
  * Base class for implementing a thread-safe ClickHouse client. It uses
  * {@link ReadWriteLock} to manage access to underlying connection.
  */
+@Deprecated
 public abstract class AbstractClient<T> implements ClickHouseClient {
     private static final Logger log = LoggerFactory.getLogger(AbstractClient.class);
 

--- a/clickhouse-client/src/main/java/com/clickhouse/client/AbstractSocketClient.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/AbstractSocketClient.java
@@ -33,6 +33,7 @@ import com.clickhouse.data.ClickHouseUtils;
 import com.clickhouse.logging.Logger;
 import com.clickhouse.logging.LoggerFactory;
 
+@Deprecated
 public class AbstractSocketClient implements AutoCloseable {
     static class SocketRequest {
         final ClickHouseConfig config;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseClient.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseClient.java
@@ -57,6 +57,7 @@ import com.clickhouse.logging.LoggerFactory;
  * artifact, so that {@code java.util.SerivceLoader} can discover the
  * implementation properly in runtime.
  */
+@Deprecated
 public interface ClickHouseClient extends AutoCloseable {
     Logger LOG = LoggerFactory.getLogger(ClickHouseClient.class);
 

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseClientBuilder.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseClientBuilder.java
@@ -28,6 +28,7 @@ import com.clickhouse.logging.LoggerFactory;
  * {@link ClickHouseClient#builder()} for instantiation, and avoid
  * multi-threading as it's NOT thread-safe.
  */
+@Deprecated
 public class ClickHouseClientBuilder {
     /**
      * Dummy client which is only used by {@link Agent}.

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseCluster.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseCluster.java
@@ -10,6 +10,7 @@ import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.data.ClickHouseChecker;
 import com.clickhouse.data.ClickHouseUtils;
 
+@Deprecated
 public class ClickHouseCluster extends ClickHouseNodes {
     private static final long serialVersionUID = 8684489015067906319L;
 

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseConfig.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseConfig.java
@@ -31,6 +31,7 @@ import com.clickhouse.data.ClickHouseVersion;
  * An immutable class holding client-specific options like
  * {@link ClickHouseCredentials} and {@link ClickHouseNodeSelector} etc.
  */
+@Deprecated
 public class ClickHouseConfig implements ClickHouseDataConfig {
     static final class ClientOptions {
         static final ClientOptions INSTANCE = new ClientOptions();

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseCredentials.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseCredentials.java
@@ -9,6 +9,7 @@ import com.clickhouse.data.ClickHouseChecker;
  * This encapsulates access token, certificate or user name password combination
  * for accessing ClickHouse.
  */
+@Deprecated
 public class ClickHouseCredentials implements Serializable {
     private static final long serialVersionUID = -8883041793709590486L;
 

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseDnsResolver.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseDnsResolver.java
@@ -13,6 +13,7 @@ import com.clickhouse.logging.LoggerFactory;
  * {@link com.clickhouse.client.config.ClickHouseDefaults#SRV_RESOLVE} is set to
  * {@code true}.
  */
+@Deprecated
 public class ClickHouseDnsResolver {
     private static final Logger log = LoggerFactory.getLogger(ClickHouseDnsResolver.class);
 

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseException.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseException.java
@@ -12,6 +12,7 @@ import java.util.regex.Pattern;
  * Exception thrown from ClickHouse server. See full list at
  * https://github.com/ClickHouse/ClickHouse/blob/master/src/Common/ErrorCodes.cpp.
  */
+@Deprecated
 public class ClickHouseException extends Exception {
     /**
      * Generated ID.

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseLoadBalancingPolicy.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseLoadBalancingPolicy.java
@@ -20,6 +20,7 @@ import com.clickhouse.data.ClickHouseUtils;
  * get node from a managed list; 2) managing node's status; and 3) optionally
  * schedule background tasks like node discovery and health check.
  */
+@Deprecated
 public abstract class ClickHouseLoadBalancingPolicy implements Serializable {
     static class DefaultPolicy extends ClickHouseLoadBalancingPolicy {
         @Override

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNode.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNode.java
@@ -45,6 +45,7 @@ import com.clickhouse.logging.LoggerFactory;
  * This class depicts a ClickHouse server, essentially a combination of host,
  * port and protocol, for client to connect.
  */
+@Deprecated
 public class ClickHouseNode implements Function<ClickHouseNodeSelector, ClickHouseNode>, Serializable {
     /**
      * Node status.

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodeManager.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodeManager.java
@@ -12,6 +12,7 @@ import com.clickhouse.client.ClickHouseNode.Status;
  * Node manager is responsible for managing list of nodes and their status. It
  * also runs scheduled tasks in background for node discovery and health check.
  */
+@Deprecated
 public interface ClickHouseNodeManager extends Function<ClickHouseNodeSelector, ClickHouseNode>, Serializable {
     /**
      * Gets a copy of nodes, which in most cases are in healthy status. However,

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodeSelector.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodeSelector.java
@@ -19,6 +19,7 @@ import com.clickhouse.logging.LoggerFactory;
  * {@link ClickHouseClient} according to preferred protocol(s); and 2) pick
  * suitable {@link ClickHouseNode} to connect to.
  */
+@Deprecated
 public class ClickHouseNodeSelector implements Serializable {
     private static final Logger log = LoggerFactory.getLogger(ClickHouseNodeSelector.class);
     private static final long serialVersionUID = 488571984297086418L;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodes.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseNodes.java
@@ -38,6 +38,7 @@ import com.clickhouse.logging.LoggerFactory;
  * {@link ClickHouseLoadBalancingPolicy} is used to pickup available node and
  * moving node between lists according to its status.
  */
+@Deprecated
 public class ClickHouseNodes implements ClickHouseNodeManager {
     private static final Logger log = LoggerFactory.getLogger(ClickHouseNodes.class);
     private static final long serialVersionUID = 4931904980127690349L;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseParameterizedQuery.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseParameterizedQuery.java
@@ -29,6 +29,7 @@ import com.clickhouse.data.ClickHouseValues;
  * name", we have two parameters: {@code no} and {@code name}. Moreover, type of
  * the last parameter is {@code String}.
  */
+@Deprecated
 public class ClickHouseParameterizedQuery implements Serializable {
     private static final long serialVersionUID = 8108887349618342152L;
 

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseProtocol.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseProtocol.java
@@ -7,6 +7,7 @@ import java.util.List;
 /**
  * This defines protocols can be used to connect to ClickHouse.
  */
+@Deprecated
 public enum ClickHouseProtocol {
     /**
      * Protocol detection is needed when establishing connection.

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseRequest.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseRequest.java
@@ -48,6 +48,7 @@ import com.clickhouse.data.ClickHouseWriter;
  * Request object holding references to {@link ClickHouseClient},
  * {@link ClickHouseNode}, format, sql, options and settings etc. for execution.
  */
+@Deprecated
 @SuppressWarnings("squid:S119")
 public class ClickHouseRequest<SelfT extends ClickHouseRequest<SelfT>> implements Serializable {
     private static final Set<String> SPECIAL_SETTINGS;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseRequestManager.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseRequestManager.java
@@ -11,6 +11,7 @@ import com.clickhouse.data.ClickHouseUtils;
  * instantiate customized request manager first, and then fall back to default
  * implementation if no luck.
  */
+@Deprecated
 public class ClickHouseRequestManager {
     /**
      * Inner class for static initialization.

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseResponse.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseResponse.java
@@ -36,6 +36,7 @@ import com.clickhouse.data.ClickHouseRecord;
  * prefer to handle stream instead of deserialized data</li>
  * </ul>
  */
+@Deprecated
 public interface ClickHouseResponse extends AutoCloseable, Serializable {
     /**
      * Empty response that can never be closed.

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseResponseSummary.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseResponseSummary.java
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.AtomicReference;
 /**
  * Summary of ClickHouse response.
  */
+@Deprecated
 public class ClickHouseResponseSummary implements Serializable {
     private static final long serialVersionUID = 6241261266635143197L;
 

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseSimpleResponse.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseSimpleResponse.java
@@ -17,6 +17,7 @@ import java.util.TimeZone;
 /**
  * A simple response built on top of two lists: columns and records.
  */
+@Deprecated
 public class ClickHouseSimpleResponse implements ClickHouseResponse {
     private static final long serialVersionUID = 6883452584393840649L;
 

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseSocketFactory.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseSocketFactory.java
@@ -6,6 +6,7 @@ import java.io.IOException;
  * Generic factory interface for creating sockets used by the TCP and Apache
  * Http clients.
  */
+@Deprecated
 public interface ClickHouseSocketFactory {
     /**
      * Creates a new instance of the provided configuration and class type.

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseSslContextProvider.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseSslContextProvider.java
@@ -14,6 +14,7 @@ import com.clickhouse.data.ClickHouseChecker;
  * This interface defines how to build SSL context based on given configuration
  * and target server.
  */
+@Deprecated
 public interface ClickHouseSslContextProvider {
     /**
      * Get non-null SSL context provider.

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseStreamResponse.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseStreamResponse.java
@@ -22,6 +22,7 @@ import com.clickhouse.logging.LoggerFactory;
 /**
  * A stream response from server.
  */
+@Deprecated
 public class ClickHouseStreamResponse implements ClickHouseResponse {
     private static final Logger log = LoggerFactory.getLogger(ClickHouseStreamResponse.class);
 

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseTransaction.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseTransaction.java
@@ -22,6 +22,7 @@ import com.clickhouse.logging.LoggerFactory;
  * also contains session ID and references to the connected server and client
  * for issuing queries.
  */
+@Deprecated
 public final class ClickHouseTransaction implements Serializable {
     /**
      * This class encapsulates transaction ID, which is defined as

--- a/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseTransactionException.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/ClickHouseTransactionException.java
@@ -1,5 +1,6 @@
 package com.clickhouse.client;
 
+@Deprecated
 public class ClickHouseTransactionException extends ClickHouseException {
     public static final int ERROR_INVALID_TRANSACTION = 649;
     public static final int ERROR_UNKNOWN_STATUS_OF_TRANSACTION = 659;

--- a/clickhouse-client/src/main/java/com/clickhouse/client/UnsupportedProtocolException.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/UnsupportedProtocolException.java
@@ -1,5 +1,6 @@
 package com.clickhouse.client;
 
+@Deprecated
 public class UnsupportedProtocolException extends IllegalStateException {
     private final ClickHouseProtocol protocol;
 

--- a/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseClientOption.java
@@ -17,6 +17,7 @@ import com.clickhouse.data.ClickHouseDataConfig;
 /**
  * Generic client options.
  */
+@Deprecated
 public enum ClickHouseClientOption implements ClickHouseOption {
     /**
      * Whether the client should run in async mode(e.g.

--- a/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseDefaultSslContextProvider.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseDefaultSslContextProvider.java
@@ -30,6 +30,7 @@ import com.clickhouse.client.ClickHouseConfig;
 import com.clickhouse.client.ClickHouseSslContextProvider;
 import com.clickhouse.data.ClickHouseUtils;
 
+@Deprecated
 public class ClickHouseDefaultSslContextProvider implements ClickHouseSslContextProvider {
     static final String PEM_HEADER_PREFIX = "---BEGIN ";
     static final String PEM_HEADER_SUFFIX = " PRIVATE KEY---";

--- a/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseDefaults.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseDefaults.java
@@ -17,6 +17,7 @@ import com.clickhouse.data.ClickHouseDataConfig;
  * {@code -Ddefault_async=false} on the Java command line, or setting
  * environment variable {@code DEFAULT_ASYNC=false}.
  */
+@Deprecated
 public enum ClickHouseDefaults implements ClickHouseOption {
     /**
      * Default execution mode.

--- a/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseHealthCheckMethod.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseHealthCheckMethod.java
@@ -1,5 +1,6 @@
 package com.clickhouse.client.config;
 
+@Deprecated
 public enum ClickHouseHealthCheckMethod {
     /**
      * Ping is the protocol-specific approach for health check, which in general is

--- a/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseProxyType.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseProxyType.java
@@ -3,6 +3,7 @@ package com.clickhouse.client.config;
 /**
  * Defines supported SSL mode.
  */
+@Deprecated
 public enum ClickHouseProxyType {
     IGNORE, DIRECT, HTTP, SOCKS;
 }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseSslMode.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseSslMode.java
@@ -3,6 +3,7 @@ package com.clickhouse.client.config;
 /**
  * Defines supported SSL mode.
  */
+@Deprecated
 public enum ClickHouseSslMode {
     NONE, STRICT
 }

--- a/clickhouse-client/src/main/java/com/clickhouse/client/naming/SrvResolver.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/naming/SrvResolver.java
@@ -13,6 +13,7 @@ import org.xbill.DNS.SRVRecord;
 import org.xbill.DNS.TextParseException;
 import org.xbill.DNS.Type;
 
+@Deprecated
 public class SrvResolver extends ClickHouseDnsResolver {
     private static final Logger log = LoggerFactory.getLogger(SrvResolver.class);
 

--- a/clickhouse-data/src/main/java/com/clickhouse/config/ClickHouseBufferingMode.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/config/ClickHouseBufferingMode.java
@@ -3,6 +3,7 @@ package com.clickhouse.config;
 /**
  * Supported buffering mode for dealing with request and response.
  */
+@Deprecated
 public enum ClickHouseBufferingMode {
     // TODO Adaptive / Dynamic
 

--- a/clickhouse-data/src/main/java/com/clickhouse/config/ClickHouseConfigChangeListener.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/config/ClickHouseConfigChangeListener.java
@@ -5,6 +5,7 @@ import java.io.Serializable;
 /**
  * Configuration change listener.
  */
+@Deprecated
 public interface ClickHouseConfigChangeListener<T> {
     /**
      * Triggered when {@link ClickHouseOption} was changed. Removing an option is

--- a/clickhouse-data/src/main/java/com/clickhouse/config/ClickHouseDefaultOption.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/config/ClickHouseDefaultOption.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 
 import com.clickhouse.data.ClickHouseChecker;
 
+@Deprecated
 public final class ClickHouseDefaultOption implements ClickHouseOption {
     private final String name;
     private final String key;

--- a/clickhouse-data/src/main/java/com/clickhouse/config/ClickHouseOption.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/config/ClickHouseOption.java
@@ -13,6 +13,7 @@ import java.util.TimeZone;
  * composed of key, default value(which implies type of the value) and
  * description.
  */
+@Deprecated
 public interface ClickHouseOption extends Serializable {
     /**
      * Converts given string to key value pairs.

--- a/clickhouse-data/src/main/java/com/clickhouse/config/ClickHouseRenameMethod.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/config/ClickHouseRenameMethod.java
@@ -5,6 +5,7 @@ import java.util.function.UnaryOperator;
 /**
  * Methods for renaming.
  */
+@Deprecated
 public enum ClickHouseRenameMethod {
     /**
      * No OP.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ByteUtils.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ByteUtils.java
@@ -2,6 +2,7 @@ package com.clickhouse.data;
 
 import java.nio.ByteOrder;
 
+@Deprecated
 public final class ByteUtils {
     public boolean equals(byte[] a, int aFromIndex, int aToIndex, byte[] b, int bFromIndex, int bToIndex) {
         int aLen = aToIndex - aFromIndex;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseAggregateFunction.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseAggregateFunction.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 
+@Deprecated
 public enum ClickHouseAggregateFunction {
     // select concat(f.name, '(', f.case_insensitive ? 'true' : 'false',
     // a.names != '' ? concat(',', replaceAll(replaceRegexpAll(a.names,

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseArraySequence.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseArraySequence.java
@@ -3,6 +3,7 @@ package com.clickhouse.data;
 /**
  * This interface represents a generic array value.
  */
+@Deprecated
 public interface ClickHouseArraySequence extends ClickHouseValue {
     /**
      * Allocates an array according to given length. Same as

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseByteBuffer.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseByteBuffer.java
@@ -18,6 +18,7 @@ import java.util.UUID;
  * array, and it uses {@link #position()} and {@link #length()} to define the
  * slice. You may think of it as a lite version of {@link java.nio.ByteBuffer}.
  */
+@Deprecated
 public final class ClickHouseByteBuffer implements Serializable {
     private static final long serialVersionUID = -8178041799873465082L;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseByteUtils.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseByteUtils.java
@@ -8,6 +8,7 @@ import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 
+@Deprecated
 public final class ClickHouseByteUtils {
     // partial class
     private static final ByteUtils BU = new ByteUtils(ByteOrder.LITTLE_ENDIAN);

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseCache.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseCache.java
@@ -8,6 +8,7 @@ import com.clickhouse.data.cache.JdkLruCache;
 /**
  * Wrapper interface depicts essential methods required by a client-side cache.
  */
+@Deprecated
 public interface ClickHouseCache<K, V> {
     /**
      * Default cache size.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseChecker.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseChecker.java
@@ -7,6 +7,8 @@ import java.util.Locale;
 /**
  * Utility class for validation.
  */
+
+@Deprecated
 public final class ClickHouseChecker {
     private static final String DEFAULT_NAME = "value";
     private static final String ERR_SHOULD_BETWEEN = "%s(%s) should be between %s and %s inclusive of both values";

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseCityHash.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseCityHash.java
@@ -42,6 +42,7 @@ package com.clickhouse.data;
  * NOTE: The code is modified to be compatible with CityHash128 used in
  * ClickHouse
  */
+@Deprecated
 public class ClickHouseCityHash {
 
     private static final long k0 = 0xc3a5c85c97cb3127L;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseColumn.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseColumn.java
@@ -55,6 +55,7 @@ import java.util.TimeZone;
 /**
  * This class represents a column defined in database.
  */
+@Deprecated
 public final class ClickHouseColumn implements Serializable {
     public static final String TYPE_NAME = "Column";
     public static final ClickHouseColumn[] EMPTY_ARRAY = new ClickHouseColumn[0];

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseCompression.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseCompression.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 /**
  * Supported compression algoritms.
  */
+@Deprecated
 public enum ClickHouseCompression {
     NONE("", "", ""),
     BROTLI("application/x-brotli", "br", "br"),

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseCompressionAlgorithm.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseCompressionAlgorithm.java
@@ -16,6 +16,7 @@ import com.clickhouse.data.compress.SnappySupport;
 import com.clickhouse.data.compress.XzSupport;
 import com.clickhouse.data.compress.ZstdSupport;
 
+@Deprecated
 public interface ClickHouseCompressionAlgorithm {
     static final String ERROR_FAILED_TO_WRAP_INPUT = "Failed to wrap input stream";
     static final String ERROR_FAILED_TO_WRAP_OUTPUT = "Failed to wrap output stream";

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataConfig.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataConfig.java
@@ -7,6 +7,7 @@ import java.io.Serializable;
 import java.math.RoundingMode;
 import java.util.TimeZone;
 
+@Deprecated
 public interface ClickHouseDataConfig extends Serializable {
     static class Wrapped implements ClickHouseDataConfig {
         private static final long serialVersionUID = -8358244156373920188L;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataProcessor.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataProcessor.java
@@ -22,6 +22,7 @@ import java.util.NoSuchElementException;
  * specific column or data type, data processor is a combination of both, and it
  * can handle more scenarios like separator between columns and rows.
  */
+@Deprecated
 public abstract class ClickHouseDataProcessor {
     protected static final class DefaultSerDe {
         public final ClickHouseColumn[] columns;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataStreamFactory.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataStreamFactory.java
@@ -24,6 +24,7 @@ import com.clickhouse.data.stream.NonBlockingPipedOutputStream;
 /**
  * Factory class for creating objects to handle data stream.
  */
+@Deprecated
 public class ClickHouseDataStreamFactory {
     protected static final class DefaultExecutors {
         protected static final ExecutorService executor;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataType.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataType.java
@@ -47,6 +47,7 @@ import com.clickhouse.data.value.UnsignedShort;
  * ClickHouse, but for the sake of this driver, we treat these data types as
  * modifiers for the underlying base data types.
  */
+@Deprecated
 @SuppressWarnings("squid:S115")
 public enum ClickHouseDataType {
     Bool(Boolean.class, false, false, true, 1, 1, 0, 0, 0, false,0x2D, "BOOLEAN"),

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataUpdater.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataUpdater.java
@@ -7,6 +7,7 @@ import java.io.IOException;
  * {@link ClickHouseInputStream#readCustom(ClickHouseDataUpdater)} and
  * {@link ClickHouseOutputStream#writeCustom(ClickHouseDataUpdater)}.
  */
+@Deprecated
 @FunctionalInterface
 public interface ClickHouseDataUpdater {
     /**

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDeferredValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDeferredValue.java
@@ -16,6 +16,7 @@ import java.util.function.Supplier;
  * {@link Supplier} or {@link Future} to retrieve value only when {@link #get()}
  * or {@link #getOptional()} was called.
  */
+@Deprecated
 public final class ClickHouseDeferredValue<T> implements Supplier<T> {
     /**
      * Wraps a future object.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDeserializer.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDeserializer.java
@@ -10,6 +10,7 @@ import com.clickhouse.data.value.ClickHouseEmptyValue;
 /**
  * Functional interface for deserialization.
  */
+@Deprecated
 @FunctionalInterface
 public interface ClickHouseDeserializer {
     static class CompositeDeserializer implements ClickHouseDeserializer {

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseEnum.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseEnum.java
@@ -5,6 +5,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
+@Deprecated
 public class ClickHouseEnum implements Serializable {
     private static final long serialVersionUID = -978231193821209918L;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseExternalTable.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseExternalTable.java
@@ -13,6 +13,7 @@ import java.util.List;
 /**
  * "Attached" temporary table.
  */
+@Deprecated
 public class ClickHouseExternalTable implements Serializable {
     public static class Builder {
         private String name;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseFile.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseFile.java
@@ -13,6 +13,7 @@ import java.nio.file.Path;
  * Wrapper of {@link java.io.File} with additional information like compression
  * and format.
  */
+@Deprecated
 public class ClickHouseFile extends ClickHousePassThruStream {
     private static final long serialVersionUID = -2641191818870839568L;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseFormat.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseFormat.java
@@ -6,6 +6,7 @@ import java.util.Locale;
  * All formats supported by ClickHouse. More information at:
  * https://clickhouse.com/docs/en/interfaces/formats/.
  */
+@Deprecated
 @SuppressWarnings("squid:S115")
 public enum ClickHouseFormat {
     // start with the most common ones

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseFreezableMap.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseFreezableMap.java
@@ -12,6 +12,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Freezable map. Once the map is freezed, all writes will be discarded without
  * any error.
  */
+@Deprecated
 public class ClickHouseFreezableMap<K, V> implements Map<K, V> {
     /**
      * Creates a freezable map with initial data and optional whitelisted keys.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseInputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseInputStream.java
@@ -42,6 +42,7 @@ import com.clickhouse.data.stream.WrappedInputStream;
  * creation as well as closing the stream when it reaches end of stream. This
  * class is also responsible for creating various input stream as needed.
  */
+@Deprecated
 public abstract class ClickHouseInputStream extends InputStream implements Iterable<ClickHouseByteBuffer> {
     protected static final String ERROR_INCOMPLETE_READ = "Reached end of input stream after reading %d of %d bytes";
     protected static final String ERROR_NULL_BYTES = "Non-null byte array is required";

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseOutputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseOutputStream.java
@@ -14,6 +14,7 @@ import com.clickhouse.data.stream.WrappedOutputStream;
  * Extended output stream for write optimization. It also acts as a factory
  * class providing static methods for creating output stream as needed.
  */
+@Deprecated
 public abstract class ClickHouseOutputStream extends OutputStream {
     protected static final String ERROR_NULL_BYTES = "Non-null byte array is required";
     protected static final String ERROR_REUSE_BUFFER = "Please pass a different byte array instead of the same internal buffer for reading";

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHousePassThruStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHousePassThruStream.java
@@ -8,6 +8,7 @@ import java.io.Serializable;
  * This class encapsulates custom input and output stream to ensure no
  * compression/decompression will be applied during execution.
  */
+@Deprecated
 public class ClickHousePassThruStream implements Serializable {
     private static final long serialVersionUID = -879012829388929569L;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHousePipedOutputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHousePipedOutputStream.java
@@ -11,6 +11,7 @@ import java.util.concurrent.TimeoutException;
 /**
  * SPSC(Single-producer single-consumer) channel for streaming.
  */
+@Deprecated
 public abstract class ClickHousePipedOutputStream extends ClickHouseOutputStream {
     /**
      * Handles async write result.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseRecord.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseRecord.java
@@ -9,6 +9,7 @@ import java.util.NoSuchElementException;
  * sometimes it could a (nested) column, a (semi-)structured object, or even the
  * whole data set.
  */
+@Deprecated
 public interface ClickHouseRecord extends Iterable<ClickHouseValue>, Serializable {
     /**
      * Empty record.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseRecordMapper.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseRecordMapper.java
@@ -10,6 +10,7 @@ import com.clickhouse.data.mapper.RecordMapperFactory;
  * Functional interface for mapping {@link ClickHouseRecord} to customized
  * object.
  */
+@Deprecated
 @FunctionalInterface
 public interface ClickHouseRecordMapper {
     /**

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseRecordTransformer.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseRecordTransformer.java
@@ -1,6 +1,7 @@
 package com.clickhouse.data;
 
 @FunctionalInterface
+@Deprecated
 public interface ClickHouseRecordTransformer {
     /**
      * Updates values in the given record.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseSerializer.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseSerializer.java
@@ -8,6 +8,7 @@ import java.util.List;
 /**
  * Functional interface for serializtion.
  */
+@Deprecated
 @FunctionalInterface
 public interface ClickHouseSerializer {
     static class CompositeSerializer implements ClickHouseSerializer {

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseSimpleRecord.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseSimpleRecord.java
@@ -9,6 +9,7 @@ import java.util.Map;
  * Default implementation of {@link com.clickhouse.data.ClickHouseRecord},
  * which is simply a combination of list of columns and array of values.
  */
+@Deprecated
 public class ClickHouseSimpleRecord implements ClickHouseRecord {
     public static final ClickHouseSimpleRecord EMPTY = new ClickHouseSimpleRecord(Collections.emptyList(),
             new ClickHouseValue[0]);

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseStreamConfig.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseStreamConfig.java
@@ -1,5 +1,6 @@
 package com.clickhouse.data;
 
+@Deprecated
 public interface ClickHouseStreamConfig {
 
 }

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseThreadFactory.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseThreadFactory.java
@@ -7,6 +7,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import com.clickhouse.logging.Logger;
 import com.clickhouse.logging.LoggerFactory;
 
+@Deprecated
 public class ClickHouseThreadFactory implements ThreadFactory {
     private static final Logger log = LoggerFactory.getLogger(ClickHouseThreadFactory.class);
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseUtils.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseUtils.java
@@ -51,6 +51,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 import java.util.function.UnaryOperator;
 
+@Deprecated
 public final class ClickHouseUtils {
     private static final boolean IS_UNIX;
     private static final boolean IS_WINDOWS;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseValue.java
@@ -37,6 +37,7 @@ import java.util.UUID;
  * convenient methods for type conversion(e.g. use {@link #asDateTime()} to
  * convert an integer to {@link java.time.LocalDateTime}).
  */
+@Deprecated
 public interface ClickHouseValue extends Serializable {
     /**
      * Create a customized exception for unsupported type conversion.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseValues.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseValues.java
@@ -36,6 +36,7 @@ import com.clickhouse.data.value.ClickHouseIpv6Value;
 /**
  * Help class for dealing with values.
  */
+@Deprecated
 public final class ClickHouseValues {
     public static final BigInteger BIGINT_HL_BOUNDARY = BigInteger.ONE.shiftLeft(64); // 2^64
     public static final BigInteger BIGINT_SL_BOUNDARY = BigInteger.valueOf(Long.MAX_VALUE);

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseVersion.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseVersion.java
@@ -11,6 +11,7 @@ import java.util.regex.Pattern;
  * and suffix like '-[testing|stable|lts]' will be ignored in parsing and
  * comparison.
  */
+@Deprecated
 public final class ClickHouseVersion implements Comparable<ClickHouseVersion>, Serializable {
     private static final long serialVersionUID = 6721014333437055314L;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseWriter.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseWriter.java
@@ -2,6 +2,7 @@ package com.clickhouse.data;
 
 import java.io.IOException;
 
+@Deprecated
 @FunctionalInterface
 public interface ClickHouseWriter {
     static final String TYPE_NAME = "Writer";

--- a/clickhouse-data/src/main/java/com/clickhouse/data/DelegatedInputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/DelegatedInputStream.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Iterator;
 
+@Deprecated
 final class DelegatedInputStream extends ClickHouseInputStream {
     private final ClickHouseInputStream input;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/UnloadableClassLoader.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/UnloadableClassLoader.java
@@ -10,6 +10,7 @@ import java.util.WeakHashMap;
  * class content(byte[]). The class will be only unloaded once there's no place
  * referring to the class name and GC is triggered.
  */
+@Deprecated
 public final class UnloadableClassLoader extends ClassLoader {
     public static final boolean HAS_ASM;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/cache/CaffeineCache.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/cache/CaffeineCache.java
@@ -12,6 +12,7 @@ import com.github.benmanes.caffeine.cache.Caffeine;
  * Cache based on Caffeine implementation. Please be aware that it's not really
  * a LRU cache.
  */
+@Deprecated
 public class CaffeineCache<K, V> implements ClickHouseCache<K, V> {
     private final Cache<K, V> cache;
     private final Function<K, V> loadFunc;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/cache/JdkLruCache.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/cache/JdkLruCache.java
@@ -12,6 +12,7 @@ import com.clickhouse.data.ClickHouseCache;
  * A simple thread-safe LRU cache based on LinkedHashMap. It's not as effient as
  * the one in Caffeine/Guava, but it requires no extra dependency.
  */
+@Deprecated
 public class JdkLruCache<K, V> implements ClickHouseCache<K, V> {
     static class LruCacheMap<K, V> extends LinkedHashMap<K, V> {
         private final int capacity;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/compress/BrotliSupport.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/compress/BrotliSupport.java
@@ -12,6 +12,7 @@ import com.clickhouse.data.ClickHousePassThruStream;
 import com.clickhouse.data.stream.WrappedInputStream;
 import com.clickhouse.data.stream.WrappedOutputStream;
 
+@Deprecated
 public final class BrotliSupport {
     public static class DefaultImpl implements ClickHouseCompressionAlgorithm {
         @Override

--- a/clickhouse-data/src/main/java/com/clickhouse/data/compress/Bz2Support.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/compress/Bz2Support.java
@@ -12,6 +12,7 @@ import com.clickhouse.data.ClickHousePassThruStream;
 import com.clickhouse.data.stream.WrappedInputStream;
 import com.clickhouse.data.stream.WrappedOutputStream;
 
+@Deprecated
 public final class Bz2Support {
     public static class DefaultImpl implements ClickHouseCompressionAlgorithm {
         protected int normalize(int level) {

--- a/clickhouse-data/src/main/java/com/clickhouse/data/compress/DeflateSupport.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/compress/DeflateSupport.java
@@ -15,6 +15,7 @@ import com.clickhouse.data.ClickHousePassThruStream;
 import com.clickhouse.data.stream.WrappedInputStream;
 import com.clickhouse.data.stream.WrappedOutputStream;
 
+@Deprecated
 public final class DeflateSupport {
     public static class DefaultImpl implements ClickHouseCompressionAlgorithm {
         @Override

--- a/clickhouse-data/src/main/java/com/clickhouse/data/compress/GzipSupport.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/compress/GzipSupport.java
@@ -15,6 +15,7 @@ import com.clickhouse.data.ClickHousePassThruStream;
 import com.clickhouse.data.stream.WrappedInputStream;
 import com.clickhouse.data.stream.WrappedOutputStream;
 
+@Deprecated
 public final class GzipSupport {
     public static class DefaultImpl implements ClickHouseCompressionAlgorithm {
         @Override

--- a/clickhouse-data/src/main/java/com/clickhouse/data/compress/Lz4Support.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/compress/Lz4Support.java
@@ -12,6 +12,7 @@ import com.clickhouse.data.ClickHousePassThruStream;
 import com.clickhouse.data.stream.Lz4InputStream;
 import com.clickhouse.data.stream.Lz4OutputStream;
 
+@Deprecated
 public final class Lz4Support {
     public static class DefaultImpl implements ClickHouseCompressionAlgorithm {
         protected int normalize(int level) {

--- a/clickhouse-data/src/main/java/com/clickhouse/data/compress/NoneSupport.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/compress/NoneSupport.java
@@ -14,6 +14,7 @@ import com.clickhouse.data.stream.EmptyOutputStream;
 import com.clickhouse.data.stream.WrappedInputStream;
 import com.clickhouse.data.stream.WrappedOutputStream;
 
+@Deprecated
 public final class NoneSupport {
     public static class DefaultImpl implements ClickHouseCompressionAlgorithm {
         @Override

--- a/clickhouse-data/src/main/java/com/clickhouse/data/compress/SnappySupport.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/compress/SnappySupport.java
@@ -12,6 +12,7 @@ import com.clickhouse.data.ClickHousePassThruStream;
 import com.clickhouse.data.stream.WrappedInputStream;
 import com.clickhouse.data.stream.WrappedOutputStream;
 
+@Deprecated
 public final class SnappySupport {
     public static class DefaultImpl implements ClickHouseCompressionAlgorithm {
         @Override

--- a/clickhouse-data/src/main/java/com/clickhouse/data/compress/XzSupport.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/compress/XzSupport.java
@@ -12,6 +12,7 @@ import com.clickhouse.data.ClickHousePassThruStream;
 import com.clickhouse.data.stream.WrappedInputStream;
 import com.clickhouse.data.stream.WrappedOutputStream;
 
+@Deprecated
 public final class XzSupport {
     public static class DefaultImpl implements ClickHouseCompressionAlgorithm {
         protected int normalize(int level) {

--- a/clickhouse-data/src/main/java/com/clickhouse/data/compress/ZstdSupport.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/compress/ZstdSupport.java
@@ -12,6 +12,7 @@ import com.clickhouse.data.ClickHousePassThruStream;
 import com.clickhouse.data.stream.WrappedInputStream;
 import com.clickhouse.data.stream.WrappedOutputStream;
 
+@Deprecated
 public final class ZstdSupport {
     static class DefaultImpl implements ClickHouseCompressionAlgorithm {
         protected int normalize(int level) {

--- a/clickhouse-data/src/main/java/com/clickhouse/data/format/BinaryDataProcessor.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/format/BinaryDataProcessor.java
@@ -26,6 +26,7 @@ import com.clickhouse.data.value.ClickHouseIntegerValue;
 import com.clickhouse.data.value.ClickHouseLongValue;
 import com.clickhouse.data.value.ClickHouseShortValue;
 
+@Deprecated
 public interface BinaryDataProcessor {
     static class ArrayDeserializer extends ClickHouseDeserializer.CompositeDeserializer {
         private final long length;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/format/BinaryStreamUtils.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/format/BinaryStreamUtils.java
@@ -35,6 +35,8 @@ import com.clickhouse.data.value.ClickHouseBitmap;
 /**
  * Utility class for dealing with binary stream and data.
  */
+
+@Deprecated
 public final class BinaryStreamUtils {
     public static final int U_INT8_MAX = (1 << 8) - 1;
     public static final int U_INT16_MAX = (1 << 16) - 1;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/format/ClickHouseBinaryFormatProcessor.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/format/ClickHouseBinaryFormatProcessor.java
@@ -13,6 +13,7 @@ import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 
+@Deprecated
 public class ClickHouseBinaryFormatProcessor extends ClickHouseDataProcessor {
 
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/format/ClickHouseRowBinaryProcessor.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/format/ClickHouseRowBinaryProcessor.java
@@ -31,6 +31,7 @@ import com.clickhouse.data.value.ClickHouseBitmapValue;
  * Data processor for handling {@link ClickHouseFormat#RowBinary} and
  * {@link ClickHouseFormat#RowBinaryWithNamesAndTypes} two formats.
  */
+@Deprecated
 public class ClickHouseRowBinaryProcessor extends ClickHouseDataProcessor {
     public static class BitmapSerDe implements ClickHouseDeserializer, ClickHouseSerializer {
         private final ClickHouseDataType innerType;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/format/ClickHouseTabSeparatedProcessor.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/format/ClickHouseTabSeparatedProcessor.java
@@ -24,6 +24,7 @@ import com.clickhouse.data.ClickHouseUtils;
 import com.clickhouse.data.ClickHouseValue;
 import com.clickhouse.data.format.tsv.ByteFragment;
 
+@Deprecated
 public class ClickHouseTabSeparatedProcessor extends ClickHouseDataProcessor {
     private static String[] toStringArray(ByteFragment headerFragment, byte delimitter) {
         if (delimitter == (byte) 0) {

--- a/clickhouse-data/src/main/java/com/clickhouse/data/format/JsonStreamUtils.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/format/JsonStreamUtils.java
@@ -16,6 +16,7 @@ import java.io.OutputStreamWriter;
 /**
  * Utility class for reading and writing objects in JSON format.
  */
+@Deprecated
 public final class JsonStreamUtils {
     private static final Gson gson = new Gson();
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/format/TextDataProcessor.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/format/TextDataProcessor.java
@@ -15,6 +15,7 @@ import com.clickhouse.data.ClickHouseOutputStream;
 import com.clickhouse.data.ClickHouseSerializer;
 import com.clickhouse.data.ClickHouseValue;
 
+@Deprecated
 public interface TextDataProcessor {
     static class TextSerDe implements ClickHouseDeserializer, ClickHouseSerializer {
         private static final Map<String, TextSerDe> cache = new ConcurrentHashMap<>();

--- a/clickhouse-data/src/main/java/com/clickhouse/data/format/tsv/ArrayByteFragment.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/format/tsv/ArrayByteFragment.java
@@ -1,5 +1,6 @@
 package com.clickhouse.data.format.tsv;
 
+@Deprecated
 public final class ArrayByteFragment extends ByteFragment {
 
     private ArrayByteFragment(byte[] buf, int start, int len) {

--- a/clickhouse-data/src/main/java/com/clickhouse/data/format/tsv/ByteFragment.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/format/tsv/ByteFragment.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 
+@Deprecated
 public class ByteFragment {
 
     protected final byte[] buf;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/format/tsv/FastByteArrayInputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/format/tsv/FastByteArrayInputStream.java
@@ -6,6 +6,7 @@ import java.io.InputStream;
 /**
  * Not synchronized quick version of {@link java.io.ByteArrayInputStream}
  */
+@Deprecated
 public final class FastByteArrayInputStream extends InputStream {
     private final byte[] buf;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/format/tsv/FastByteArrayOutputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/format/tsv/FastByteArrayOutputStream.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 /**
  * Not synchronized quick version of {@link java.io.ByteArrayOutputStream}
  */
-
+@Deprecated
 public final class FastByteArrayOutputStream extends OutputStream {
 
     /**

--- a/clickhouse-data/src/main/java/com/clickhouse/data/format/tsv/StreamSplitter.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/format/tsv/StreamSplitter.java
@@ -8,6 +8,7 @@ import java.nio.charset.StandardCharsets;
  * We have a stream of bytes and a separator as an input. We split the stream by
  * the separator and pass the byte arrays to output.
  */
+@Deprecated
 public class StreamSplitter {
     private static final int MAX_ARRAY_LENGTH = Integer.MAX_VALUE - 8;
     private static final int buflen = 65536;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/mapper/AbstractRecordMapper.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/mapper/AbstractRecordMapper.java
@@ -15,6 +15,7 @@ import com.clickhouse.data.ClickHouseRecord;
 import com.clickhouse.data.ClickHouseRecordMapper;
 import com.clickhouse.data.ClickHouseUtils;
 
+@Deprecated
 public abstract class AbstractRecordMapper implements ClickHouseRecordMapper, WrappedMapper {
 
     static final class PropertyInfo {

--- a/clickhouse-data/src/main/java/com/clickhouse/data/mapper/CompiledRecordMapper.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/mapper/CompiledRecordMapper.java
@@ -10,6 +10,7 @@ import com.clickhouse.data.ClickHouseRecord;
 import com.clickhouse.data.ClickHouseRecordMapper;
 import com.clickhouse.data.ClickHouseValue;
 
+@Deprecated
 public class CompiledRecordMapper extends AbstractRecordMapper {
     private final Constructor<?> constructor;
     private final PropertyInfo[] properties;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/mapper/CustomRecordMappers.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/mapper/CustomRecordMappers.java
@@ -7,6 +7,7 @@ import java.lang.reflect.Method;
 import com.clickhouse.data.ClickHouseRecord;
 import com.clickhouse.data.ClickHouseUtils;
 
+@Deprecated
 final class CustomRecordMappers {
     static final class RecordConstructor extends AbstractRecordMapper {
         private final Constructor<?> constructor;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/mapper/DynamicRecordMapper.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/mapper/DynamicRecordMapper.java
@@ -18,6 +18,7 @@ import com.clickhouse.data.ClickHouseRecordMapper;
 import com.clickhouse.data.ClickHouseUtils;
 import com.clickhouse.data.ClickHouseValue;
 
+@Deprecated
 final class DynamicRecordMapper extends AbstractRecordMapper {
     static class PropertySetter implements BiConsumer<Object, ClickHouseValue> {
         private static final Map<String, Method> typedValues;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/mapper/IterableRecordWrapper.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/mapper/IterableRecordWrapper.java
@@ -8,6 +8,7 @@ import com.clickhouse.data.ClickHouseDataConfig;
 import com.clickhouse.data.ClickHouseRecord;
 import com.clickhouse.data.ClickHouseRecordMapper;
 
+@Deprecated
 public final class IterableRecordWrapper<T> implements Iterator<T> {
     private final ClickHouseDataConfig config;
     private final List<ClickHouseColumn> columns;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/mapper/RecordMapperFactory.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/mapper/RecordMapperFactory.java
@@ -13,6 +13,7 @@ import com.clickhouse.data.ClickHouseRecord;
 import com.clickhouse.data.ClickHouseRecordMapper;
 import com.clickhouse.data.UnloadableClassLoader;
 
+@Deprecated
 public final class RecordMapperFactory {
     private static final AtomicReference<ClickHouseCache<Class<?>, WrappedMapper>> CACHED_MAPPERS = new AtomicReference<>();
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/mapper/WrappedMapper.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/mapper/WrappedMapper.java
@@ -6,6 +6,7 @@ import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseDataConfig;
 import com.clickhouse.data.ClickHouseRecordMapper;
 
+@Deprecated
 public interface WrappedMapper {
     ClickHouseRecordMapper get(ClickHouseDataConfig config, List<ClickHouseColumn> columns);
 }

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/AbstractByteArrayInputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/AbstractByteArrayInputStream.java
@@ -17,6 +17,7 @@ import com.clickhouse.data.ClickHouseUtils;
 /**
  * Byte-array backed input stream.
  */
+@Deprecated
 public abstract class AbstractByteArrayInputStream extends ClickHouseInputStream {
     protected byte[] buffer;
     protected int position;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/AbstractByteArrayOutputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/AbstractByteArrayOutputStream.java
@@ -9,6 +9,7 @@ import com.clickhouse.data.ClickHouseOutputStream;
 import com.clickhouse.logging.Logger;
 import com.clickhouse.logging.LoggerFactory;
 
+@Deprecated
 public abstract class AbstractByteArrayOutputStream extends ClickHouseOutputStream {
     private static final Logger log = LoggerFactory.getLogger(AbstractByteArrayOutputStream.class);
     protected final byte[] buffer;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/AbstractByteBufferInputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/AbstractByteBufferInputStream.java
@@ -19,6 +19,7 @@ import com.clickhouse.data.ClickHouseUtils;
 /**
  * {@link java.nio.ByteBuffer} backed input stream.
  */
+@Deprecated
 public abstract class AbstractByteBufferInputStream extends ClickHouseInputStream {
     protected ByteBuffer buffer;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/AdaptiveQueue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/AdaptiveQueue.java
@@ -5,6 +5,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
 
+@Deprecated
 public interface AdaptiveQueue<E> {
     // too slow
     static final class JctoolsSpscQueue<E> implements AdaptiveQueue<E> {

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/BlockingInputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/BlockingInputStream.java
@@ -13,6 +13,7 @@ import com.clickhouse.data.ClickHouseUtils;
  * {@link java.nio.ByteBuffer} backed input stream with
  * {@link java.util.concurrent.BlockingQueue}.
  */
+@Deprecated
 public class BlockingInputStream extends AbstractByteBufferInputStream {
     private final BlockingQueue<ByteBuffer> queue;
     private final long timeout;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/BlockingPipedOutputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/BlockingPipedOutputStream.java
@@ -26,6 +26,7 @@ import com.clickhouse.data.ClickHouseWriter;
  * client. To avoid dead lock and high memory usage, please make sure writer and
  * reader are on two separate threads.
  */
+@Deprecated
 public class BlockingPipedOutputStream extends ClickHousePipedOutputStream {
     protected final BlockingQueue<ByteBuffer> queue;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/ByteArrayQueueInputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/ByteArrayQueueInputStream.java
@@ -6,6 +6,7 @@ import com.clickhouse.data.ClickHouseChecker;
 import java.io.IOException;
 import java.util.Queue;
 
+@Deprecated
 public class ByteArrayQueueInputStream extends AbstractByteArrayInputStream {
 
     private final Queue<byte[]> queue;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/CapacityPolicy.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/CapacityPolicy.java
@@ -1,5 +1,6 @@
 package com.clickhouse.data.stream;
 
+@Deprecated
 @FunctionalInterface
 public interface CapacityPolicy {
     static class FixedCapacity implements CapacityPolicy {

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/DeferredInputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/DeferredInputStream.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 
 import com.clickhouse.data.ClickHouseDeferredValue;
 
+@Deprecated
 public final class DeferredInputStream extends InputStream {
     private final ClickHouseDeferredValue<InputStream> ref;
     private InputStream in;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/DeferredOutputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/DeferredOutputStream.java
@@ -5,6 +5,7 @@ import java.io.OutputStream;
 
 import com.clickhouse.data.ClickHouseDeferredValue;
 
+@Deprecated
 public final class DeferredOutputStream extends OutputStream {
     private final ClickHouseDeferredValue<OutputStream> ref;
     private OutputStream out;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/EmptyInputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/EmptyInputStream.java
@@ -11,6 +11,7 @@ import com.clickhouse.data.ClickHouseOutputStream;
 /**
  * Empty input stream produces nothing and it can never be closed.
  */
+@Deprecated
 public final class EmptyInputStream extends ClickHouseInputStream {
     public static final EmptyInputStream INSTANCE = new EmptyInputStream();
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/EmptyOutputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/EmptyOutputStream.java
@@ -8,6 +8,7 @@ import com.clickhouse.data.ClickHouseOutputStream;
 /**
  * Empty output stream consumes nothing and it can never be closed.
  */
+@Deprecated
 public final class EmptyOutputStream extends ClickHouseOutputStream {
     public static final EmptyOutputStream INSTANCE = new EmptyOutputStream();
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/IterableByteArrayInputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/IterableByteArrayInputStream.java
@@ -6,6 +6,7 @@ import java.util.Iterator;
 import com.clickhouse.data.ClickHouseByteBuffer;
 import com.clickhouse.data.ClickHouseChecker;
 
+@Deprecated
 public class IterableByteArrayInputStream extends AbstractByteArrayInputStream {
     private final Iterator<byte[]> it;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/IterableByteBufferInputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/IterableByteBufferInputStream.java
@@ -8,6 +8,7 @@ import java.util.Iterator;
 import com.clickhouse.data.ClickHouseByteBuffer;
 import com.clickhouse.data.ClickHouseChecker;
 
+@Deprecated
 public class IterableByteBufferInputStream extends AbstractByteBufferInputStream {
     private final Iterator<ByteBuffer> it;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/IterableMultipleInputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/IterableMultipleInputStream.java
@@ -12,6 +12,7 @@ import com.clickhouse.data.ClickHouseDataUpdater;
 import com.clickhouse.data.ClickHouseInputStream;
 import com.clickhouse.data.ClickHouseOutputStream;
 
+@Deprecated
 public final class IterableMultipleInputStream<T> extends AbstractByteArrayInputStream {
     private final Function<T, InputStream> func;
     private final Iterator<T> it;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/IterableObjectInputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/IterableObjectInputStream.java
@@ -7,6 +7,7 @@ import java.util.function.Function;
 import com.clickhouse.data.ClickHouseByteBuffer;
 import com.clickhouse.data.ClickHouseChecker;
 
+@Deprecated
 public class IterableObjectInputStream<T> extends AbstractByteArrayInputStream {
     private final Function<T, byte[]> func;
     private final Iterator<T> it;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/Lz4InputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/Lz4InputStream.java
@@ -19,6 +19,7 @@ import net.jpountz.lz4.LZ4FastDecompressor;
 /**
  * Reader from clickhouse in lz4.
  */
+@Deprecated
 public class Lz4InputStream extends AbstractByteArrayInputStream {
     private static final LZ4Factory factory = LZ4Factory.fastestInstance();
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/Lz4OutputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/Lz4OutputStream.java
@@ -14,6 +14,7 @@ import com.clickhouse.logging.LoggerFactory;
 import net.jpountz.lz4.LZ4Compressor;
 import net.jpountz.lz4.LZ4Factory;
 
+@Deprecated
 public class Lz4OutputStream extends AbstractByteArrayOutputStream {
     private static final LZ4Factory factory = LZ4Factory.fastestInstance();
     private static final Logger log = LoggerFactory.getLogger(Lz4OutputStream.class);

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/NonBlockingInputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/NonBlockingInputStream.java
@@ -7,6 +7,7 @@ import java.nio.ByteBuffer;
 import com.clickhouse.data.ClickHouseChecker;
 import com.clickhouse.data.ClickHouseUtils;
 
+@Deprecated
 public class NonBlockingInputStream extends AbstractByteBufferInputStream {
     private final AdaptiveQueue<ByteBuffer> queue;
     private final long timeout;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/NonBlockingPipedOutputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/NonBlockingPipedOutputStream.java
@@ -24,6 +24,7 @@ import com.clickhouse.logging.LoggerFactory;
  * client. To avoid dead lock and high memory usage, please make sure writer and
  * reader are on two separate threads.
  */
+@Deprecated
 public class NonBlockingPipedOutputStream extends ClickHousePipedOutputStream {
 
     private static final Logger log = LoggerFactory.getLogger(NonBlockingPipedOutputStream.class);

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/RestrictedInputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/RestrictedInputStream.java
@@ -16,6 +16,7 @@ import com.clickhouse.data.ClickHouseOutputStream;
  * {@link WrappedInputStream}, the inner input stream remains open after calling
  * close().
  */
+@Deprecated
 public class RestrictedInputStream extends AbstractByteArrayInputStream {
     private final InputStream in;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/WrappedInputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/WrappedInputStream.java
@@ -13,6 +13,7 @@ import com.clickhouse.data.ClickHousePassThruStream;
 /**
  * Wrapper of {@link java.io.InputStream} with buffer.
  */
+@Deprecated
 public class WrappedInputStream extends AbstractByteArrayInputStream {
     private final InputStream in;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/WrappedOutputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/WrappedOutputStream.java
@@ -10,6 +10,7 @@ import com.clickhouse.data.ClickHousePassThruStream;
 /**
  * Wrapper of {@link java.io.OutputStream}.
  */
+@Deprecated
 public class WrappedOutputStream extends AbstractByteArrayOutputStream {
     private final OutputStream output;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseArrayValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseArrayValue.java
@@ -18,6 +18,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of Array.
  */
+@Deprecated
 public class ClickHouseArrayValue<T> extends ClickHouseObjectValue<T[]> implements ClickHouseArraySequence {
     /**
      * Creates an empty array.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseBigDecimalValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseBigDecimalValue.java
@@ -17,6 +17,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@link BigDecimal}.
  */
+@Deprecated
 public class ClickHouseBigDecimalValue extends ClickHouseObjectValue<BigDecimal> {
     /**
      * Create a new instance representing null value.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseBigIntegerValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseBigIntegerValue.java
@@ -15,6 +15,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@link BigInteger}.
  */
+@Deprecated
 public class ClickHouseBigIntegerValue extends ClickHouseObjectValue<BigInteger> {
     /**
      * Create a new instance representing null value.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseBitmap.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseBitmap.java
@@ -20,6 +20,7 @@ import org.roaringbitmap.longlong.Roaring64NavigableMap;
 import com.clickhouse.data.ClickHouseByteUtils;
 import com.clickhouse.data.ClickHouseDataType;
 
+@Deprecated
 public abstract class ClickHouseBitmap {
     private static final int[] EMPTY_INT_ARRAY = new int[0];
     private static final long[] EMPTY_LONG_ARRAY = new long[0];

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseBitmapValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseBitmapValue.java
@@ -18,6 +18,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@code Bitmap}.
  */
+@Deprecated
 public class ClickHouseBitmapValue extends ClickHouseObjectValue<ClickHouseBitmap> {
     /**
      * Create a new instance representing empty value.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseBoolValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseBoolValue.java
@@ -8,6 +8,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@code bool}.
  */
+@Deprecated
 public class ClickHouseBoolValue implements ClickHouseValue {
     private static final String ERROR_INVALID_NUMBER = "Boolean value can be only 1(true) or 0(false).";
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseByteValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseByteValue.java
@@ -9,6 +9,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@code byte}.
  */
+@Deprecated
 public class ClickHouseByteValue implements ClickHouseValue {
     /**
      * Unsigned version of {@code ClickHouseByteValue}.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseDateTimeValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseDateTimeValue.java
@@ -19,6 +19,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@link LocalDateTime}.
  */
+@Deprecated
 public class ClickHouseDateTimeValue extends ClickHouseObjectValue<LocalDateTime> {
     /**
      * Default value.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseDateValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseDateValue.java
@@ -12,6 +12,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@link LocalDate}.
  */
+@Deprecated
 public class ClickHouseDateValue extends ClickHouseObjectValue<LocalDate> {
     /**
      * Default date.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseDoubleValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseDoubleValue.java
@@ -10,6 +10,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@code double}.
  */
+@Deprecated
 public class ClickHouseDoubleValue implements ClickHouseValue {
     /**
      * Create a new instance representing null value.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseEmptyValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseEmptyValue.java
@@ -9,6 +9,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of Nothing.
  */
+@Deprecated
 public final class ClickHouseEmptyValue implements ClickHouseValue {
     /**
      * Singleton.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseEnumValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseEnumValue.java
@@ -9,6 +9,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@code enum}.
  */
+@Deprecated
 public class ClickHouseEnumValue implements ClickHouseValue {
     /**
      * Create a new instance representing null value.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseFloatValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseFloatValue.java
@@ -10,6 +10,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@code float}.
  */
+@Deprecated
 public class ClickHouseFloatValue implements ClickHouseValue {
     /**
      * Create a new instance representing null value.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseGeoMultiPolygonValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseGeoMultiPolygonValue.java
@@ -22,6 +22,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@code MultiPolygon}.
  */
+@Deprecated
 public class ClickHouseGeoMultiPolygonValue extends ClickHouseObjectValue<double[][][][]> {
     static final double[][][][] EMPTY_VALUE = new double[0][][][];
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseGeoPointValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseGeoPointValue.java
@@ -19,6 +19,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@code Point}.
  */
+@Deprecated
 public class ClickHouseGeoPointValue extends ClickHouseObjectValue<double[]> {
     /**
      * Creats a point of origin.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseGeoPolygonValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseGeoPolygonValue.java
@@ -22,6 +22,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@code Polygon}.
  */
+@Deprecated
 public class ClickHouseGeoPolygonValue extends ClickHouseObjectValue<double[][][]> {
     static final double[][][] EMPTY_VALUE = new double[0][][];
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseGeoRingValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseGeoRingValue.java
@@ -22,6 +22,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@code Ring}.
  */
+@Deprecated
 public class ClickHouseGeoRingValue extends ClickHouseObjectValue<double[][]> {
     static final double[][] EMPTY_VALUE = new double[0][];
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseInstantValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseInstantValue.java
@@ -17,6 +17,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@link Instant}.
  */
+@Deprecated
 public class ClickHouseInstantValue extends ClickHouseObjectValue<Instant> {
     /**
      * Default instant.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseIntegerValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseIntegerValue.java
@@ -8,6 +8,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@code int}.
  */
+@Deprecated
 public class ClickHouseIntegerValue implements ClickHouseValue {
     /**
      * Unsigned version of {@code ClickHouseIntegerValue}.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseIpv4Value.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseIpv4Value.java
@@ -17,6 +17,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@link Inet4Address}.
  */
+@Deprecated
 public class ClickHouseIpv4Value extends ClickHouseObjectValue<Inet4Address> {
     public static final Inet4Address DEFAULT;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseIpv6Value.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseIpv6Value.java
@@ -17,6 +17,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@link Inet6Address}.
  */
+@Deprecated
 public class ClickHouseIpv6Value extends ClickHouseObjectValue<Inet6Address> {
     public static final Inet6Address DEFAULT;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseLongValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseLongValue.java
@@ -8,6 +8,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@code long}.
  */
+@Deprecated
 public class ClickHouseLongValue implements ClickHouseValue {
     /**
      * Unsigned version of {@code ClickHouseLongValue}.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseMapValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseMapValue.java
@@ -18,6 +18,7 @@ import com.clickhouse.data.ClickHouseChecker;
 import com.clickhouse.data.ClickHouseValue;
 import com.clickhouse.data.ClickHouseValues;
 
+@Deprecated
 public class ClickHouseMapValue extends ClickHouseObjectValue<Map<?, ?>> {
     private static final String DEFAULT_STRING_KEY = "1";
     private static final String DEFAULT_UUID_KEY = "00000000-0000-0000-0000-000000000000";

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseNestedValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseNestedValue.java
@@ -25,6 +25,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of Nested.
  */
+@Deprecated
 public class ClickHouseNestedValue extends ClickHouseObjectValue<Object[][]> {
     /**
      * Creates an empty nested value.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseObjectValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseObjectValue.java
@@ -6,6 +6,7 @@ import java.util.Objects;
 import com.clickhouse.data.ClickHouseValue;
 import com.clickhouse.data.ClickHouseValues;
 
+@Deprecated
 public abstract class ClickHouseObjectValue<T> implements ClickHouseValue {
     // a nested structure like Map might not be always serializable
     @SuppressWarnings("squid:S1948")

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseOffsetDateTimeValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseOffsetDateTimeValue.java
@@ -18,6 +18,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@link OffsetDateTime}.
  */
+@Deprecated
 public class ClickHouseOffsetDateTimeValue extends ClickHouseObjectValue<OffsetDateTime> {
     /**
      * Default value.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseShortValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseShortValue.java
@@ -9,6 +9,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@code short}.
  */
+@Deprecated
 public class ClickHouseShortValue implements ClickHouseValue {
     /**
      * Unsigned version of {@code ClickHouseShortValue}.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseStringValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseStringValue.java
@@ -20,6 +20,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@link String}.
  */
+@Deprecated
 public class ClickHouseStringValue implements ClickHouseValue {
     /**
      * Create a new instance representing null value.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseTupleValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseTupleValue.java
@@ -26,6 +26,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of Tuple.
  */
+@Deprecated
 public class ClickHouseTupleValue extends ClickHouseObjectValue<List<Object>> {
     /**
      * Wrap the given value.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseUuidValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/ClickHouseUuidValue.java
@@ -15,6 +15,7 @@ import com.clickhouse.data.ClickHouseValues;
 /**
  * Wrapper class of {@link UUID}.
  */
+@Deprecated
 public class ClickHouseUuidValue extends ClickHouseObjectValue<UUID> {
     /**
      * Default value.

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/UnsignedByte.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/UnsignedByte.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 /**
  * A wrapper class for unsigned {@code byte}.
  */
+@Deprecated
 public final class UnsignedByte extends Number implements Comparable<UnsignedByte> {
     public static final int BYTES = Byte.BYTES;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/UnsignedInteger.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/UnsignedInteger.java
@@ -3,6 +3,7 @@ package com.clickhouse.data.value;
 /**
  * A wrapper class for unsigned {@code int}.
  */
+@Deprecated
 public final class UnsignedInteger extends Number implements Comparable<UnsignedInteger> {
     public static final int BYTES = Integer.BYTES;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/UnsignedLong.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/UnsignedLong.java
@@ -5,6 +5,7 @@ import java.math.BigInteger;
 /**
  * A wrapper class for unsigned {@code long}.
  */
+@Deprecated
 public final class UnsignedLong extends Number implements Comparable<UnsignedLong> {
     public static final BigInteger MASK = BigInteger.ONE.shiftLeft(Long.SIZE).subtract(BigInteger.ONE);
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/UnsignedShort.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/UnsignedShort.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 /**
  * A wrapper class for unsigned {@code short}.
  */
+@Deprecated
 public final class UnsignedShort extends Number implements Comparable<UnsignedShort> {
     public static final int BYTES = Short.BYTES;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/array/ClickHouseBoolArrayValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/array/ClickHouseBoolArrayValue.java
@@ -27,6 +27,7 @@ import com.clickhouse.data.value.ClickHouseObjectValue;
 /**
  * Wrapper of {@code boolean[]}.
  */
+@Deprecated
 public class ClickHouseBoolArrayValue extends ClickHouseObjectValue<boolean[]> implements ClickHouseArraySequence {
     private static final String TYPE_NAME = "boolean[]";
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/array/ClickHouseByteArrayValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/array/ClickHouseByteArrayValue.java
@@ -28,6 +28,7 @@ import com.clickhouse.data.value.UnsignedByte;
 /**
  * Wrapper of {@code byte[]}.
  */
+@Deprecated
 public class ClickHouseByteArrayValue extends ClickHouseObjectValue<byte[]> implements ClickHouseArraySequence {
     static final class UnsignedByteArrayValue extends ClickHouseByteArrayValue {
         @Override

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/array/ClickHouseDoubleArrayValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/array/ClickHouseDoubleArrayValue.java
@@ -27,6 +27,7 @@ import com.clickhouse.data.value.ClickHouseObjectValue;
 /**
  * Wrapper of {@code double[]}.
  */
+@Deprecated
 public class ClickHouseDoubleArrayValue extends ClickHouseObjectValue<double[]> implements ClickHouseArraySequence {
     private static final String TYPE_NAME = "double[]";
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/array/ClickHouseFloatArrayValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/array/ClickHouseFloatArrayValue.java
@@ -27,6 +27,7 @@ import com.clickhouse.data.value.ClickHouseObjectValue;
 /**
  * Wrapper of {@code float[]}.
  */
+@Deprecated
 public class ClickHouseFloatArrayValue extends ClickHouseObjectValue<float[]> implements ClickHouseArraySequence {
     private static final String TYPE_NAME = "float[]";
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/array/ClickHouseIntArrayValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/array/ClickHouseIntArrayValue.java
@@ -28,6 +28,7 @@ import com.clickhouse.data.value.UnsignedInteger;
 /**
  * Wrapper of {@code int[]}.
  */
+@Deprecated
 public class ClickHouseIntArrayValue extends ClickHouseObjectValue<int[]> implements ClickHouseArraySequence {
     static final class UnsignedIntArrayValue extends ClickHouseIntArrayValue {
         @Override

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/array/ClickHouseLongArrayValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/array/ClickHouseLongArrayValue.java
@@ -28,6 +28,7 @@ import com.clickhouse.data.value.UnsignedLong;
 /**
  * Wrapper of {@code long[]}.
  */
+@Deprecated
 public class ClickHouseLongArrayValue extends ClickHouseObjectValue<long[]> implements ClickHouseArraySequence {
     static final class UnsignedLongArrayValue extends ClickHouseLongArrayValue {
         @Override

--- a/clickhouse-data/src/main/java/com/clickhouse/data/value/array/ClickHouseShortArrayValue.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/value/array/ClickHouseShortArrayValue.java
@@ -28,6 +28,7 @@ import com.clickhouse.data.value.UnsignedShort;
 /**
  * Wrapper of {@code short[]}.
  */
+@Deprecated
 public class ClickHouseShortArrayValue extends ClickHouseObjectValue<short[]> implements ClickHouseArraySequence {
     static final class UnsignedShortArrayValue extends ClickHouseShortArrayValue {
         @Override

--- a/clickhouse-data/src/main/java/com/clickhouse/logging/JdkLogger.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/logging/JdkLogger.java
@@ -7,6 +7,7 @@ import java.util.logging.Level;
 /**
  * Adaptor for JDK logger.
  */
+@Deprecated
 public class JdkLogger implements Logger {
     private final java.util.logging.Logger logger;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/logging/JdkLoggerFactory.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/logging/JdkLoggerFactory.java
@@ -3,6 +3,7 @@ package com.clickhouse.logging;
 /**
  * Adaptor of JDK logger factory.
  */
+@Deprecated
 public class JdkLoggerFactory extends LoggerFactory {
     @Override
     public Logger get(String name) {

--- a/clickhouse-data/src/main/java/com/clickhouse/logging/LogMessage.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/logging/LogMessage.java
@@ -5,6 +5,7 @@ import java.util.Locale;
 /**
  * Log message with arguments and/or error.
  */
+@Deprecated
 public final class LogMessage {
     /**
      * Creates a log message with arguments. The latest argument could be a

--- a/clickhouse-data/src/main/java/com/clickhouse/logging/Logger.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/logging/Logger.java
@@ -6,6 +6,7 @@ import java.util.function.Supplier;
  * Unified logger. Pay attention that the {@code format} follows standard
  * {@link java.util.Formatter}.
  */
+@Deprecated
 public interface Logger {
     /**
      * Error message for providing null logger.

--- a/clickhouse-data/src/main/java/com/clickhouse/logging/LoggerFactory.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/logging/LoggerFactory.java
@@ -5,6 +5,7 @@ import java.util.ServiceLoader;
 /**
  * Unified factory class to get logger.
  */
+@Deprecated
 public abstract class LoggerFactory {
     private static final LoggerFactory instance;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/logging/Slf4jLogger.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/logging/Slf4jLogger.java
@@ -5,6 +5,7 @@ import java.util.function.Supplier;
 /**
  * Adaptor for slf4j logger.
  */
+@Deprecated
 public class Slf4jLogger implements Logger {
     private final org.slf4j.Logger logger;
 

--- a/clickhouse-data/src/main/java/com/clickhouse/logging/Slf4jLoggerFactory.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/logging/Slf4jLoggerFactory.java
@@ -3,6 +3,7 @@ package com.clickhouse.logging;
 /**
  * Adaptor of slf4j logger factory.
  */
+@Deprecated
 public class Slf4jLoggerFactory extends LoggerFactory {
     @Override
     public Logger get(Class<?> clazz) {

--- a/clickhouse-data/src/main/java/com/clickhouse/logging/package-info.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/logging/package-info.java
@@ -1,4 +1,5 @@
 /**
  * Provides logging classes.
  */
+@Deprecated
 package com.clickhouse.logging;

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ApacheHttpConnectionImpl.java
@@ -75,6 +75,7 @@ import java.util.concurrent.TimeUnit;
 /**
  * Created by wujianchao on 2022/12/1.
  */
+@Deprecated
 public class ApacheHttpConnectionImpl extends ClickHouseHttpConnection {
     private static final Logger log = LoggerFactory.getLogger(ApacheHttpConnectionImpl.class);
 

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpClient.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpClient.java
@@ -32,6 +32,7 @@ import java.util.concurrent.CompletionException;
 import java.util.concurrent.ConcurrentSkipListSet;
 import java.util.stream.Collectors;
 
+@Deprecated
 public class ClickHouseHttpClient extends AbstractClient<ClickHouseHttpConnection> {
     private static final Logger log = LoggerFactory.getLogger(ClickHouseHttpClient.class);
 

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnection.java
@@ -34,6 +34,7 @@ import com.clickhouse.logging.Logger;
 import com.clickhouse.logging.LoggerFactory;
 import org.apache.hc.core5.http.HttpHeaders;
 
+@Deprecated
 public abstract class ClickHouseHttpConnection implements AutoCloseable {
     private static final Logger log = LoggerFactory.getLogger(ClickHouseHttpConnection.class);
 

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnectionFactory.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpConnectionFactory.java
@@ -13,6 +13,7 @@ import com.clickhouse.client.http.config.HttpConnectionProvider;
 import com.clickhouse.logging.Logger;
 import com.clickhouse.logging.LoggerFactory;
 
+@Deprecated
 public final class ClickHouseHttpConnectionFactory {
     private static final Logger log = LoggerFactory.getLogger(ClickHouseHttpConnectionFactory.class);
 

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpEntity.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpEntity.java
@@ -14,6 +14,7 @@ import java.util.List;
 /**
  * Used to encapsulate post request.
  */
+@Deprecated
 public class ClickHouseHttpEntity extends AbstractHttpEntity {
     private final ClickHouseConfig config;
     private final byte[] boundary;

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpProto.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpProto.java
@@ -1,5 +1,6 @@
 package com.clickhouse.client.http;
 
+@Deprecated
 public class ClickHouseHttpProto {
 
 

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpResponse.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/ClickHouseHttpResponse.java
@@ -16,6 +16,7 @@ import com.clickhouse.data.ClickHouseInputStream;
 import com.clickhouse.data.ClickHouseUtils;
 import com.clickhouse.logging.Logger;
 
+@Deprecated
 public class ClickHouseHttpResponse {
     private static long getLongValue(Map<String, String> map, String key) {
         String value = map.get(key);

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/HttpUrlConnectionImpl.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/HttpUrlConnectionImpl.java
@@ -43,6 +43,7 @@ import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.ExecutorService;
 
+@Deprecated
 public class HttpUrlConnectionImpl extends ClickHouseHttpConnection {
     private static final Logger log = LoggerFactory.getLogger(HttpUrlConnectionImpl.class);
 

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/ClickHouseHttpOption.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/ClickHouseHttpOption.java
@@ -9,6 +9,7 @@ import java.net.UnknownHostException;
 /**
  * Http client options.
  */
+@Deprecated
 public enum ClickHouseHttpOption implements ClickHouseOption {
     /**
      * HTTP connection provider.

--- a/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/HttpConnectionProvider.java
+++ b/clickhouse-http-client/src/main/java/com/clickhouse/client/http/config/HttpConnectionProvider.java
@@ -1,5 +1,6 @@
 package com.clickhouse.client.http.config;
 
+@Deprecated
 public enum HttpConnectionProvider {
     HTTP_CLIENT,
     HTTP_URL_CONNECTION,

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/AbstractResultSet.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/AbstractResultSet.java
@@ -18,6 +18,7 @@ import java.sql.SQLXML;
 import java.sql.Time;
 import java.sql.Timestamp;
 
+@Deprecated
 public abstract class AbstractResultSet extends JdbcWrapper implements ResultSet {
     protected void ensureOpen() throws SQLException {
         if (isClosed()) {

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseArray.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseArray.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import com.clickhouse.data.ClickHouseChecker;
 import com.clickhouse.data.ClickHouseColumn;
 
+@Deprecated
 public class ClickHouseArray implements Array {
     private final int columnIndex;
     private ClickHouseResultSet resultSet;

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseBlob.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseBlob.java
@@ -5,6 +5,7 @@ import java.io.OutputStream;
 import java.sql.Blob;
 import java.sql.SQLException;
 
+@Deprecated
 public class ClickHouseBlob implements Blob {
 
     @Override

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseClob.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseClob.java
@@ -8,6 +8,7 @@ import java.sql.Clob;
 import java.sql.NClob;
 import java.sql.SQLException;
 
+@Deprecated
 public class ClickHouseClob implements NClob {
 
     @Override

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseConnection.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseConnection.java
@@ -24,6 +24,7 @@ import com.clickhouse.data.ClickHouseValue;
 import com.clickhouse.data.ClickHouseVersion;
 import com.clickhouse.jdbc.parser.ClickHouseSqlStatement;
 
+@Deprecated
 public interface ClickHouseConnection extends Connection {
     static final String COLUMN_ELEMENT = "element";
     static final String COLUMN_ARRAY = "array";

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDataSource.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDataSource.java
@@ -7,6 +7,7 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
 
+@Deprecated
 public class ClickHouseDataSource implements javax.sql.DataSource, com.clickhouse.jdbc.JdbcV2Wrapper {
     private final DataSource dataSource;
     private final ClickHouseDriver driver;

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDatabaseMetaData.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDatabaseMetaData.java
@@ -30,6 +30,7 @@ import com.clickhouse.client.ClickHouseSimpleResponse;
 import com.clickhouse.logging.Logger;
 import com.clickhouse.logging.LoggerFactory;
 
+@Deprecated
 public class ClickHouseDatabaseMetaData extends JdbcWrapper implements DatabaseMetaData {
     private static final Logger log = LoggerFactory.getLogger(ClickHouseDatabaseMetaData.class);
 

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDriver.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDriver.java
@@ -9,6 +9,7 @@ import java.sql.SQLException;
 import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
 
+@Deprecated
 public class ClickHouseDriver implements java.sql.Driver {
     private static final Logger log = LoggerFactory.getLogger(ClickHouseDriver.class);
     private java.sql.Driver driver;

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHousePreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHousePreparedStatement.java
@@ -23,6 +23,7 @@ import java.sql.Types;
 import com.clickhouse.data.ClickHouseInputStream;
 import com.clickhouse.data.format.BinaryStreamUtils;
 
+@Deprecated
 public interface ClickHousePreparedStatement extends PreparedStatement {
     @Override
     default void setNull(int parameterIndex, int sqlType) throws SQLException {

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseResultSet.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseResultSet.java
@@ -43,6 +43,7 @@ import com.clickhouse.data.ClickHouseRecord;
 import com.clickhouse.data.ClickHouseUtils;
 import com.clickhouse.data.ClickHouseValue;
 
+@Deprecated
 public class ClickHouseResultSet extends AbstractResultSet {
     private ClickHouseRecord currentRow;
     private Iterator<ClickHouseRecord> rowCursor;

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseResultSetMetaData.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseResultSetMetaData.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseUtils;
 
+@Deprecated
 public class ClickHouseResultSetMetaData extends JdbcWrapper implements ResultSetMetaData {
     public static ResultSetMetaData of(JdbcConfig config, String database, String table, List<ClickHouseColumn> columns,
             JdbcTypeMapping mapper, Map<String, Class<?>> typeMap) throws SQLException {

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseScrollableResultSet.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseScrollableResultSet.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import com.clickhouse.client.ClickHouseResponse;
 
+@Deprecated
 public class ClickHouseScrollableResultSet extends ClickHouseResultSet {
 
 	private final List<byte[]> records;

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseStatement.java
@@ -8,6 +8,7 @@ import com.clickhouse.client.ClickHouseConfig;
 import com.clickhouse.client.ClickHouseRequest;
 import com.clickhouse.client.ClickHouseRequest.Mutation;
 
+@Deprecated
 public interface ClickHouseStatement extends Statement {
     @Override
     ClickHouseConnection getConnection() throws SQLException;

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseStruct.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseStruct.java
@@ -6,6 +6,7 @@ import java.util.Map;
 
 import com.clickhouse.data.ClickHouseChecker;
 
+@Deprecated
 public class ClickHouseStruct implements Struct {
     private final String typeName;
     private final Object[] values;

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseXml.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseXml.java
@@ -10,6 +10,7 @@ import java.sql.SQLXML;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
 
+@Deprecated
 public class ClickHouseXml implements SQLXML {
 
     @Override

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/CombinedResultSet.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/CombinedResultSet.java
@@ -25,6 +25,7 @@ import java.util.Map;
 /**
  * Wrapper of multiple ResultSets.
  */
+@Deprecated
 public class CombinedResultSet extends AbstractResultSet {
     private final ResultSet[] results;
 

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/DataSourceV1.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/DataSourceV1.java
@@ -13,6 +13,7 @@ import java.sql.SQLFeatureNotSupportedException;
 import java.util.Properties;
 import java.util.logging.Logger;
 
+@Deprecated
 public class DataSourceV1 extends JdbcWrapper implements DataSource {
     private final String url;
     private final Properties props;

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/DriverV1.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/DriverV1.java
@@ -32,6 +32,7 @@ import com.clickhouse.jdbc.internal.ClickHouseJdbcUrlParser;
  * <li>{@code jdbc:clickhouse://localhost/system?protocol=grpc}</li>
  * </ul>
  */
+@Deprecated
 public class DriverV1 implements Driver {
     private static final Logger log = LoggerFactory.getLogger(DriverV1.class);
 

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/JdbcConfig.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/JdbcConfig.java
@@ -18,6 +18,7 @@ import com.clickhouse.logging.LoggerFactory;
 /**
  * JDBC-specific configuration.
  */
+@Deprecated
 public class JdbcConfig {
     private static final Logger log = LoggerFactory.getLogger(JdbcConfig.class);
 

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/JdbcParameterizedQuery.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/JdbcParameterizedQuery.java
@@ -13,6 +13,7 @@ import com.clickhouse.data.ClickHouseValues;
  * A parameterized query is a parsed query with parameters being extracted for
  * substitution.
  */
+@Deprecated
 public final class JdbcParameterizedQuery extends ClickHouseParameterizedQuery {
     /**
      * Creates an instance by parsing the given query.

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/JdbcParseHandler.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/JdbcParseHandler.java
@@ -12,6 +12,7 @@ import com.clickhouse.jdbc.parser.ClickHouseSqlStatement;
 import com.clickhouse.jdbc.parser.ParseHandler;
 import com.clickhouse.jdbc.parser.StatementType;
 
+@Deprecated
 public class JdbcParseHandler extends ParseHandler {
     private static final String SETTING_MUTATIONS_SYNC = "mutations_sync";
 

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/JdbcTypeMapping.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/JdbcTypeMapping.java
@@ -26,6 +26,7 @@ import com.clickhouse.data.ClickHouseUtils;
  * does not impact serialization and deserialization, which is handled
  * separately by {@link com.clickhouse.data.ClickHouseDataProcessor}.
  */
+@Deprecated
 public class JdbcTypeMapping {
     static final class AnsiTypeMapping extends JdbcTypeMapping {
         static String toAnsiSqlType(ClickHouseDataType dataType, int precision, int scale, TimeZone tz) {

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/JdbcWrapper.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/JdbcWrapper.java
@@ -2,6 +2,7 @@ package com.clickhouse.jdbc;
 
 import java.sql.SQLException;
 
+@Deprecated
 public abstract class JdbcWrapper {
     public <T> T unwrap(Class<T> iface) throws SQLException {
         if (iface.isAssignableFrom(getClass())) {

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/Main.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/Main.java
@@ -44,6 +44,7 @@ import com.clickhouse.data.value.ClickHouseLongValue;
 import com.clickhouse.data.value.ClickHouseStringValue;
 import com.clickhouse.jdbc.internal.ClickHouseConnectionImpl;
 
+@Deprecated
 public final class Main {
     public static class Pojo {
         private byte b;

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/SqlExceptionUtils.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/SqlExceptionUtils.java
@@ -10,6 +10,7 @@ import com.clickhouse.client.ClickHouseException;
 /**
  * Helper class for building {@link SQLException}.
  */
+@Deprecated
 public final class SqlExceptionUtils {
     public static final String SQL_STATE_CLIENT_ERROR = "HY000";
     public static final String SQL_STATE_OPERATION_CANCELLED = "HY008";

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/AbstractPreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/AbstractPreparedStatement.java
@@ -8,6 +8,7 @@ import com.clickhouse.client.ClickHouseRequest;
 import com.clickhouse.data.ClickHouseUtils;
 import com.clickhouse.jdbc.SqlExceptionUtils;
 
+@Deprecated
 public abstract class AbstractPreparedStatement extends ClickHouseStatementImpl implements PreparedStatement {
     protected AbstractPreparedStatement(ClickHouseConnectionImpl connection, ClickHouseRequest<?> request,
             int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseConnectionImpl.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseConnectionImpl.java
@@ -60,6 +60,7 @@ import com.clickhouse.jdbc.parser.ClickHouseSqlStatement;
 import com.clickhouse.jdbc.parser.ParseHandler;
 import com.clickhouse.jdbc.parser.StatementType;
 
+@Deprecated
 public class ClickHouseConnectionImpl extends JdbcWrapper implements ClickHouseConnection {
     private static final Logger log = LoggerFactory.getLogger(ClickHouseConnectionImpl.class);
 

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseJdbcUrlParser.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseJdbcUrlParser.java
@@ -15,6 +15,7 @@ import com.clickhouse.data.ClickHouseUtils;
 import com.clickhouse.jdbc.JdbcConfig;
 import com.clickhouse.jdbc.SqlExceptionUtils;
 
+@Deprecated
 public class ClickHouseJdbcUrlParser {
     public static class ConnectionInfo {
         private final String cacheKey;

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseParameterMetaData.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseParameterMetaData.java
@@ -13,6 +13,7 @@ import com.clickhouse.jdbc.JdbcTypeMapping;
 import com.clickhouse.jdbc.SqlExceptionUtils;
 import com.clickhouse.jdbc.JdbcWrapper;
 
+@Deprecated
 public class ClickHouseParameterMetaData extends JdbcWrapper implements ParameterMetaData {
     protected final List<ClickHouseColumn> params;
     protected final JdbcTypeMapping mapper;

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseStatementImpl.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/ClickHouseStatementImpl.java
@@ -60,6 +60,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.function.Function;
 
+@Deprecated
 public class ClickHouseStatementImpl extends JdbcWrapper
         implements ClickHouseConfigChangeListener<ClickHouseRequest<?>>, ClickHouseStatement {
     private static final Logger log = LoggerFactory.getLogger(ClickHouseStatementImpl.class);

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/InputBasedPreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/InputBasedPreparedStatement.java
@@ -33,6 +33,7 @@ import com.clickhouse.logging.LoggerFactory;
 import com.clickhouse.jdbc.ClickHousePreparedStatement;
 import com.clickhouse.jdbc.SqlExceptionUtils;
 
+@Deprecated
 public class InputBasedPreparedStatement extends AbstractPreparedStatement implements ClickHousePreparedStatement {
     private static final Logger log = LoggerFactory.getLogger(InputBasedPreparedStatement.class);
 

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/JdbcSavepoint.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/JdbcSavepoint.java
@@ -5,6 +5,7 @@ import java.sql.Savepoint;
 
 import com.clickhouse.jdbc.SqlExceptionUtils;
 
+@Deprecated
 public class JdbcSavepoint implements Savepoint {
     final int id;
     final String name;

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/JdbcTransaction.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/JdbcTransaction.java
@@ -14,6 +14,7 @@ import com.clickhouse.data.ClickHouseUtils;
 import com.clickhouse.logging.Logger;
 import com.clickhouse.jdbc.SqlExceptionUtils;
 
+@Deprecated
 public class JdbcTransaction {
     static final String ACTION_COMMITTED = "committed";
     static final String ACTION_ROLLBACK = "rolled back";

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/SqlBasedPreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/SqlBasedPreparedStatement.java
@@ -44,6 +44,7 @@ import com.clickhouse.jdbc.JdbcParameterizedQuery;
 import com.clickhouse.jdbc.SqlExceptionUtils;
 import com.clickhouse.jdbc.parser.ClickHouseSqlStatement;
 
+@Deprecated
 public class SqlBasedPreparedStatement extends AbstractPreparedStatement implements ClickHousePreparedStatement {
     private static final Logger log = LoggerFactory.getLogger(SqlBasedPreparedStatement.class);
 

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/StreamBasedPreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/StreamBasedPreparedStatement.java
@@ -34,6 +34,7 @@ import com.clickhouse.jdbc.ClickHousePreparedStatement;
 import com.clickhouse.jdbc.SqlExceptionUtils;
 import com.clickhouse.jdbc.parser.ClickHouseSqlStatement;
 
+@Deprecated
 public class StreamBasedPreparedStatement extends AbstractPreparedStatement implements ClickHousePreparedStatement {
     private static final Logger log = LoggerFactory.getLogger(StreamBasedPreparedStatement.class);
 

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/TableBasedPreparedStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/internal/TableBasedPreparedStatement.java
@@ -29,6 +29,7 @@ import com.clickhouse.jdbc.ClickHousePreparedStatement;
 import com.clickhouse.jdbc.SqlExceptionUtils;
 import com.clickhouse.jdbc.parser.ClickHouseSqlStatement;
 
+@Deprecated
 public class TableBasedPreparedStatement extends AbstractPreparedStatement implements ClickHousePreparedStatement {
     private static final Logger log = LoggerFactory.getLogger(TableBasedPreparedStatement.class);
 

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/parser/ClickHouseSqlStatement.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/parser/ClickHouseSqlStatement.java
@@ -11,6 +11,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.Map.Entry;
 
+@Deprecated
 public class ClickHouseSqlStatement {
     public static final String DEFAULT_DATABASE = "system";
     public static final String DEFAULT_TABLE = "unknown";

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/parser/ClickHouseSqlUtils.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/parser/ClickHouseSqlUtils.java
@@ -1,5 +1,6 @@
 package com.clickhouse.jdbc.parser;
 
+@Deprecated
 public final class ClickHouseSqlUtils {
     public static boolean isQuote(char ch) {
         return ch == '"' || ch == '\'' || ch == '`';

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/parser/LanguageType.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/parser/LanguageType.java
@@ -1,5 +1,6 @@
 package com.clickhouse.jdbc.parser;
 
+@Deprecated
 public enum LanguageType {
     UNKNOWN, // unknown language
     DCL, // data control language

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/parser/OperationType.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/parser/OperationType.java
@@ -1,5 +1,6 @@
 package com.clickhouse.jdbc.parser;
 
+@Deprecated
 public enum OperationType {
     UNKNOWN, READ, WRITE
 }

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/parser/ParseHandler.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/parser/ParseHandler.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+@Deprecated
 public abstract class ParseHandler {
     /**
      * Handle macro like "#include('/tmp/template.sql')".

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/parser/StatementType.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/parser/StatementType.java
@@ -1,5 +1,6 @@
 package com.clickhouse.jdbc.parser;
 
+@Deprecated
 public enum StatementType {
     UNKNOWN(LanguageType.UNKNOWN, OperationType.UNKNOWN, false), // unknown statement
     ALTER(LanguageType.DDL, OperationType.UNKNOWN, false), // alter statement


### PR DESCRIPTION
## Summary
* Deprecated all classes in the V1 packages (including the ones we reference in V2) - if we still need something, we should move it into V2 somewhere rather than have it dangling in these other modules.

Closes https://github.com/ClickHouse/clickhouse-java/issues/2157
## Checklist
Delete items not relevant to your PR:
- [x] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
