### PR TITLE
Fix links to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Nightly Builds: https://s01.oss.sonatype.org/content/repositories/snapshots/com/
 
 | Component                 | Maven Central Link | Javadoc Link | Documentation Link | 
 |---------------------------|--------------------|--------------|---------------------|
-| ClickHouse Java Client V2 | [![Maven Central](https://img.shields.io/maven-central/v/com.clickhouse/client-v2)](https://mvnrepository.com/artifact/com.clickhouse/client-v2) | [![javadoc](https://javadoc.io/badge2/com.clickhouse/client-v2/javadoc.svg)](https://javadoc.io/doc/com.clickhouse/client-v2) | [docs](https://clickhouse.com/docs/integrations/java/client-v2) | 
+| ClickHouse Java Client V2 | [![Maven Central](https://img.shields.io/maven-central/v/com.clickhouse/client-v2)](https://mvnrepository.com/artifact/com.clickhouse/client-v2) | [![javadoc](https://javadoc.io/badge2/com.clickhouse/client-v2/javadoc.svg)](https://javadoc.io/doc/com.clickhouse/client-v2) | [docs](https://clickhouse.com/docs/integrations/java) | 
 
 ### Examples
 
@@ -85,7 +85,7 @@ Nightly Builds: https://s01.oss.sonatype.org/content/repositories/snapshots/com/
 
 | Component | Maven Central Link | Javadoc Link | Documentation Link |
 |-----------|--------------------|--------------|--------------------|
-| ClickHouse JDBC Driver | [![Maven Central](https://img.shields.io/maven-central/v/com.clickhouse/clickhouse-jdbc)](https://mvnrepository.com/artifact/com.clickhouse/clickhouse-jdbc) |[![javadoc](https://javadoc.io/badge2/com.clickhouse/clickhouse-jdbc/javadoc.svg)](https://javadoc.io/doc/com.clickhouse/clickhouse-jdbc)|[docs](https://clickhouse.com/docs/integrations/java/jdbc-v2)|
+| ClickHouse JDBC Driver | [![Maven Central](https://img.shields.io/maven-central/v/com.clickhouse/clickhouse-jdbc)](https://mvnrepository.com/artifact/com.clickhouse/clickhouse-jdbc) |[![javadoc](https://javadoc.io/badge2/com.clickhouse/clickhouse-jdbc/javadoc.svg)](https://javadoc.io/doc/com.clickhouse/clickhouse-jdbc)|[docs](https://clickhouse.com/docs/integrations/language-clients/java/jdbc)|
 
 ### Examples
 


### PR DESCRIPTION
## Summary


Currently these 404

Closes <!-- Link to an issue to close on merge. -->
## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
