### PR TITLE
Implement BinaryStreamReader.EnumValue.toString()

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -728,6 +728,11 @@ public class BinaryStreamReader {
         public double doubleValue() {
             return value;
         }
+
+        @Override
+        public String toString() {
+            return name;
+        }
     }
 
     /**


### PR DESCRIPTION
## Summary

In a Spring Boot application using `org.springframework.jdbc.core.JdbcTemplate#queryForList(java.lang.String)`, doing a simple `SELECT * from table` from a table containing `Enum` columns returns the enum values as strings as interpreted by `Object.toString()`. These strings are not meaningful to the caller, since they are of the form `"com.clickhouse.client.api.data_formats.internal.BinaryStreamReader$EnumValue@7331ed36"`

`name` feels to me like the obvious choice to represent an enum value as string.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
