### PR TITLE
Support getting table schema from a query with params

### DIFF
--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -1638,8 +1638,10 @@ public class QueryTests extends BaseIntegrationTest {
 
     @Test(groups = {"integration"})
     public void testGetTableSchemaFromQueryWithParams() {
+        Map<String, Object> queryParams = new HashMap<>();
+        queryParams.put("param1", 2);
         TableSchema schema = client.getTableSchemaFromQuery("SELECT toUInt32(1) as col1, {param1:String} as col2",
-                Map.of("param1", "value"));
+                queryParams);
         Assert.assertNotNull(schema);
         Assert.assertEquals(schema.getColumns().size(), 2);
         Assert.assertEquals(schema.getColumns().get(0).getColumnName(), "col1");

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -1626,8 +1626,20 @@ public class QueryTests extends BaseIntegrationTest {
     }
 
     @Test(groups = {"integration"})
-    public void testGetTableSchemaFromQuery() throws Exception {
+    public void testGetTableSchemaFromQuery() {
         TableSchema schema = client.getTableSchemaFromQuery("SELECT toUInt32(1) as col1, 'value' as col2");
+        Assert.assertNotNull(schema);
+        Assert.assertEquals(schema.getColumns().size(), 2);
+        Assert.assertEquals(schema.getColumns().get(0).getColumnName(), "col1");
+        Assert.assertEquals(schema.getColumns().get(0).getDataType(), ClickHouseDataType.UInt32);
+        Assert.assertEquals(schema.getColumns().get(1).getColumnName(), "col2");
+        Assert.assertEquals(schema.getColumns().get(1).getDataType(), ClickHouseDataType.String);
+    }
+
+    @Test(groups = {"integration"})
+    public void testGetTableSchemaFromQueryWithParams() {
+        TableSchema schema = client.getTableSchemaFromQuery("SELECT toUInt32(1) as col1, {param1:String} as col2",
+                Map.of("param1", "value"));
         Assert.assertNotNull(schema);
         Assert.assertEquals(schema.getColumns().size(), 2);
         Assert.assertEquals(schema.getColumns().get(0).getColumnName(), "col1");


### PR DESCRIPTION
## Summary
Adds support for getting the table schema for a query with params.

Before this PR, there's no good way to get the table schema for a query that has params. The method `getTableSchemaFromQuery(String sql)` takes a SQL query but no params. This PR simply adds a new method to the client: `getTableSchemaFromQuery(String sql, Map<String, Object> params)`


## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
