### PR TITLE
fix null SSLSocket (#2206)

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/JdbcConfiguration.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/JdbcConfiguration.java
@@ -57,11 +57,7 @@ public class JdbcConfiguration {
         initProperties(urlProperties, info);
 
         // after initializing all properties - set final connection URL
-        boolean useSSL = Boolean.parseBoolean(info.getProperty(DriverProperties.SECURE_CONNECTION.getKey(), "false"));
-        String bearerToken = info.getProperty(ClientConfigProperties.BEARERTOKEN_AUTH.getKey(), null);
-        if (bearerToken != null) {
-            clientProperties.put(ClientConfigProperties.BEARERTOKEN_AUTH.getKey(), bearerToken);
-        }
+        boolean useSSL = Boolean.parseBoolean(clientProperties.getOrDefault(DriverProperties.SECURE_CONNECTION.getKey(), "false"));
         this.connectionUrl = createConnectionURL(tmpConnectionUrl, useSSL);
         this.isIgnoreUnsupportedRequests= Boolean.parseBoolean(getDriverProperty(DriverProperties.IGNORE_UNSUPPORTED_VALUES.getKey(), "false"));
     }


### PR DESCRIPTION
## Summary
- read ssl property from clientProperties that have already been initialized
- The clientProperties already contain bearerToken

Closes [#2206 ](https://github.com/ClickHouse/clickhouse-java/issues/2206)
## Checklist
Delete items not relevant to your PR:
- [ ] Closes [#2206 ](https://github.com/ClickHouse/clickhouse-java/issues/2206)
