### PR TITLE
[jdbc] Fix missing dependency in shaded package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - [jdbc-v2] Fixed SQL parser failure to parse SQL statement with comments (https://github.com/ClickHouse/clickhouse-java/issues/2217)
 - [client-v2] Fixed issue with excessive logging (https://github.com/ClickHouse/clickhouse-java/issues/2201)
 - [jdbc-v2] Fixed handling IP addresses (https://github.com/ClickHouse/clickhouse-java/issues/2140)
+- [jdbc] - Fixed missing LZ4 dependency in shaded package (https://github.com/ClickHouse/clickhouse-java/issues/2275)
 
 ## 0.8.2
 

--- a/clickhouse-jdbc/pom.xml
+++ b/clickhouse-jdbc/pom.xml
@@ -420,6 +420,7 @@
                                     <include>org.apache.httpcomponents.core5:httpcore5</include>
                                     <include>org.apache.httpcomponents.core5:httpcore5-h2</include>
                                     <include>com.clickhouse:jdbc-v2</include>
+                                    <include>org.apache.commons:commons-compress</include>
                                     <include>org.lz4:lz4-java</include>
                                 </includes>
                             </artifactSet>


### PR DESCRIPTION
## Summary
Fixes missing LZ4 dependency in shaded because related package was not included in the list 

Closes https://github.com/ClickHouse/clickhouse-java/issues/2275
## Checklist
Delete items not relevant to your PR:
- [ ] Closes #2275 
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
