### PR TITLE
Added some null pointer checks for edge cases

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
@@ -99,6 +99,10 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
      * @throws IOException
      */
     public boolean readToPOJO(Map<String, POJOSetter> deserializers, Object obj ) throws IOException {
+        if (columns == null || columns.length == 0) {
+            return false;
+        }
+
         boolean firstColumn = true;
 
         for (ClickHouseColumn column : columns) {
@@ -135,6 +139,10 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
      * @throws IOException
      */
     public boolean readRecord(Map<String, Object> record) throws IOException {
+        if (columns == null || columns.length == 0) {
+            return false;
+        }
+
         boolean firstColumn = true;
         for (ClickHouseColumn column : columns) {
             try {
@@ -157,6 +165,10 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
     }
 
     protected boolean readRecord(Object[] record) throws IOException {
+        if (columns == null || columns.length == 0) {
+            return false;
+        }
+
         boolean firstColumn = true;
         for (int i = 0; i < columns.length; i++) {
             try {

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -345,6 +345,14 @@ public class QueryTests extends BaseIntegrationTest {
     }
 
     @Test(groups = {"integration"})
+    public void testQueryAllInsertSelect() {
+        client.queryAll("CREATE TABLE IF NOT EXISTS nums (number Int16) ENGINE = MergeTree() ORDER BY number;");
+        String sql = "INSERT INTO nums SELECT * FROM system.numbers LIMIT 100";
+        List<GenericRecord> records = client.queryAll(sql);
+        Assert.assertTrue(records.isEmpty());
+    }
+
+    @Test(groups = {"integration"})
     public void testQueryJSONEachRow() throws ExecutionException, InterruptedException {
         Map<String, Object> datasetRecord = prepareSimpleDataSet();
         QuerySettings settings = new QuerySettings().setFormat(ClickHouseFormat.JSONEachRow);


### PR DESCRIPTION
## Summary
Added null checks to prevent NPE when using queryAll with INSERT INTO SELECT statements

Closes https://github.com/ClickHouse/clickhouse-java/issues/2150
## Checklist
Delete items not relevant to your PR:
- [x] Closes #<issue ref>
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
