### PR TITLE
[jdbc-v2] Base implementation of RowBinaryFormatWriter support in JDBC

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/ClickHouseBinaryFormatWriter.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/ClickHouseBinaryFormatWriter.java
@@ -1,0 +1,94 @@
+package com.clickhouse.client.api.data_formats;
+
+import com.clickhouse.data.ClickHouseFormat;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.List;
+
+/**
+ * Experimental API
+ */
+public interface ClickHouseBinaryFormatWriter {
+
+    /**
+     * Returns an output stream to which this writer is serializing values.
+     * Caution: this method is not intended for application usage.
+     * @return Output stream of the writer
+     */
+    OutputStream getOutputStream();
+
+    int getRowCount();
+
+    ClickHouseFormat getFormat();
+
+    void clearRow();
+
+    void setValue(String column, Object value);
+
+    void setValue(int colIndex, Object value);
+
+    void commitRow() throws IOException;
+
+    void setByte(String column, byte value);
+
+    void setByte(int colIndex, byte value);
+
+    void setShort(String column, short value);
+
+    void setShort(int colIndex, short value);
+
+    void setInteger(String column, int value);
+
+    void setInteger(int colIndex, int value);
+
+    void setLong(String column, long value);
+
+    void setLong(int colIndex, long value);
+
+    void setBigInteger(int colIndex, BigInteger value);
+
+    void setBigInteger(String column, BigInteger value);
+
+    void setFloat(int colIndex, float value);
+
+    void setFloat(String column, float value);
+
+    void setDouble(int colIndex, double value);
+
+    void setDouble(String column, double value);
+
+    void setBigDecimal(int colIndex, BigDecimal value);
+
+    void setBigDecimal(String column, BigDecimal value);
+
+    void setBoolean(int colIndex, boolean value);
+
+    void setBoolean(String column, boolean value);
+
+    void setString(String column, String value);
+
+    void setString(int colIndex, String value);
+
+    void setDate(String column, LocalDate value);
+
+    void setDate(int colIndex, LocalDate value);
+
+    void setDateTime(String column, LocalDateTime value);
+
+    void setDateTime(int colIndex, LocalDateTime value);
+
+    void setDateTime(String column, ZonedDateTime value);
+
+    void setDateTime(int colIndex, ZonedDateTime value);
+
+    void setList(String column, List<?> value);
+
+    void setList(int colIndex, List<?> value);
+
+}

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryFormatWriter.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryFormatWriter.java
@@ -7,9 +7,12 @@ import com.clickhouse.data.ClickHouseFormat;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
+import java.util.Arrays;
 import java.util.List;
 
 
@@ -21,7 +24,7 @@ import java.util.List;
  * <p>
  * Experimental API
  */
-public class RowBinaryFormatWriter {
+public class RowBinaryFormatWriter implements ClickHouseBinaryFormatWriter {
 
     private final OutputStream out;
 
@@ -30,6 +33,8 @@ public class RowBinaryFormatWriter {
     private final Object[] row;
 
     private final boolean defaultSupport;
+
+    private int rowCount = 0;
 
     public RowBinaryFormatWriter(OutputStream out, TableSchema tableSchema, ClickHouseFormat format) {
         if (format != ClickHouseFormat.RowBinary && format != ClickHouseFormat.RowBinaryWithDefaults) {
@@ -42,14 +47,37 @@ public class RowBinaryFormatWriter {
         this.defaultSupport = format == ClickHouseFormat.RowBinaryWithDefaults;
     }
 
+    @Override
+    public OutputStream getOutputStream() {
+        return out;
+    }
+
+    @Override
+    public int getRowCount() {
+        return rowCount;
+    }
+
+    @Override
+    public ClickHouseFormat getFormat() {
+        return defaultSupport ? ClickHouseFormat.RowBinaryWithDefaults : ClickHouseFormat.RowBinary;
+    }
+
+    @Override
+    public void clearRow() {
+        Arrays.fill(row, null);
+    }
+
+    @Override
     public void setValue(String column, Object value) {
         setValue(tableSchema.nameToColumnIndex(column), value);
     }
 
+    @Override
     public void setValue(int colIndex, Object value) {
         row[colIndex - 1] = value;
     }
 
+    @Override
     public void commitRow() throws IOException {
         List<ClickHouseColumn> columnList = tableSchema.getColumns();
         for (int i = 0; i < row.length; i++) {
@@ -59,76 +87,145 @@ public class RowBinaryFormatWriter {
                 SerializerUtils.serializeData(out, row[i], column);
             }
         }
+        rowCount++;
     }
 
+    @Override
     public void setByte(String column, byte value) {
         setValue(column, value);
     }
 
+    @Override
     public void setByte(int colIndex, byte value) {
         setValue(colIndex, value);
     }
 
+    @Override
     public void setShort(String column, short value) {
         setValue(column, value);
     }
 
+    @Override
     public void setShort(int colIndex, short value) {
         setValue(colIndex, value);
     }
 
+    @Override
     public void setInteger(String column, int value) {
         setValue(column, value);
     }
 
+    @Override
     public void setInteger(int colIndex, int value) {
         setValue(colIndex, value);
     }
 
+    @Override
     public void setLong(String column, long value) {
         setValue(column, value);
     }
 
+    @Override
     public void setLong(int colIndex, long value) {
         setValue(colIndex, value);
     }
 
+    @Override
+    public void setBigInteger(int colIndex, BigInteger value) {
+        setValue(colIndex, value);
+    }
+
+    @Override
+    public void setBigInteger(String column, BigInteger value) {
+        setValue(column, value);
+    }
+
+    @Override
+    public void setFloat(int colIndex, float value) {
+        setValue(colIndex, value);
+    }
+
+    @Override
+    public void setFloat(String column, float value) {
+        setValue(column, value);
+    }
+
+    @Override
+    public void setDouble(int colIndex, double value) {
+        setValue(colIndex, value);
+    }
+
+    @Override
+    public void setDouble(String column, double value) {
+        setValue(column, value);
+    }
+
+    @Override
+    public void setBigDecimal(int colIndex, BigDecimal value) {
+        setValue(colIndex, value);
+    }
+
+    @Override
+    public void setBigDecimal(String column, BigDecimal value) {
+        setValue(column, value);
+    }
+
+    @Override
+    public void setBoolean(int colIndex, boolean value) {
+        setValue(colIndex, value);
+    }
+
+    @Override
+    public void setBoolean(String column, boolean value) {
+        setValue(column, value);
+    }
+
+    @Override
     public void setString(String column, String value) {
         setValue(column, value);
     }
 
+    @Override
     public void setString(int colIndex, String value) {
         setValue(colIndex, value);
     }
 
+    @Override
     public void setDate(String column, LocalDate value) {
         setValue(column, value);
     }
 
+    @Override
     public void setDate(int colIndex, LocalDate value) {
         setValue(colIndex, value);
     }
 
+    @Override
     public void setDateTime(String column, LocalDateTime value) {
         setValue(column, value);
     }
 
+    @Override
     public void setDateTime(int colIndex, LocalDateTime value) {
         setValue(colIndex, value);
     }
 
+    @Override
     public void setDateTime(String column, ZonedDateTime value) {
         setValue(column, value);
     }
 
+    @Override
     public void setDateTime(int colIndex, ZonedDateTime value) {
         setValue(colIndex, value);
     }
 
+    @Override
     public void setList(String column, List<?> value) {
         setValue(column, value);
     }
 
+    @Override
     public void setList(int colIndex, List<?> value) {
         setValue(colIndex, value);
     }

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/ConnectionImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/ConnectionImpl.java
@@ -359,7 +359,14 @@ public class ConnectionImpl implements Connection, JdbcV2Wrapper {
     @Override
     public PreparedStatement prepareStatement(String sql, int resultSetType, int resultSetConcurrency, int resultSetHoldability) throws SQLException {
         checkOpen();
-        return new PreparedStatementImpl(this, sql);
+
+        StatementImpl.StatementType statementType = StatementImpl.parseStatementType(sql);
+        if (statementType == StatementImpl.StatementType.INSERT) {
+            if (!PreparedStatementImpl.FUNC_DETECT_REGEXP.matcher(sql).find()) {
+                return new WriterStatementImpl(this, sql, statementType);
+            }
+        }
+        return new PreparedStatementImpl(this, sql, statementType);
     }
 
     @Override

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/WriterStatementImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/WriterStatementImpl.java
@@ -1,0 +1,457 @@
+package com.clickhouse.jdbc;
+
+import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatWriter;
+import com.clickhouse.client.api.data_formats.RowBinaryFormatWriter;
+import com.clickhouse.client.api.insert.InsertResponse;
+import com.clickhouse.client.api.insert.InsertSettings;
+import com.clickhouse.client.api.metadata.TableSchema;
+import com.clickhouse.data.ClickHouseFormat;
+import com.clickhouse.jdbc.internal.ExceptionUtils;
+import com.clickhouse.jdbc.internal.JdbcUtils;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.Reader;
+import java.math.BigDecimal;
+import java.net.URL;
+import java.sql.Array;
+import java.sql.Blob;
+import java.sql.Clob;
+import java.sql.Date;
+import java.sql.NClob;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.RowId;
+import java.sql.SQLException;
+import java.sql.SQLType;
+import java.sql.SQLXML;
+import java.sql.Time;
+import java.sql.Timestamp;
+import java.util.Arrays;
+import java.util.Calendar;
+import java.util.concurrent.TimeUnit;
+
+public class WriterStatementImpl extends PreparedStatementImpl implements PreparedStatement {
+
+
+    private ByteArrayOutputStream out;
+    private ClickHouseBinaryFormatWriter writer;
+    private final TableSchema tableSchema;
+
+    public WriterStatementImpl(ConnectionImpl connection, String originalSql, StatementType statementType)
+            throws SQLException {
+        super(connection, originalSql, statementType);
+
+        String[] firstThreeTokens = originalSql.split("\\s+", 4);
+        if (firstThreeTokens.length != 4) {
+            throw new SQLException("Invalid or unsupported INSERT statement: " + originalSql);
+        }
+
+        String tableName = JdbcUtils.unQuoteTableName(firstThreeTokens[2]);
+        this.tableSchema = connection.getClient().getTableSchema(tableName, connection.getSchema());
+        try {
+            resetWriter();
+        } catch (IOException e) {
+            throw new SQLException(e);
+        }
+    }
+
+    private void resetWriter() throws IOException {
+        if (out != null) {
+            out.close();
+        }
+
+        out = new ByteArrayOutputStream();
+        writer = new RowBinaryFormatWriter(out, tableSchema, tableSchema.hasDefaults() ?
+                ClickHouseFormat.RowBinaryWithDefaults : ClickHouseFormat.RowBinary);
+    }
+
+    @Override
+    public ResultSet executeQuery() throws SQLException {
+        checkClosed();
+        throw new UnsupportedOperationException("bug. This PreparedStatement implementation should not be used with queries");
+    }
+
+    @Override
+    public int executeUpdate() throws SQLException {
+        return (int) this.executeLargeUpdate();
+    }
+
+    @Override
+    public long executeLargeUpdate() throws SQLException {
+        checkClosed();
+        int updateCount = 0;
+        InputStream in = new ByteArrayInputStream(out.toByteArray());
+        InsertSettings settings = new InsertSettings();
+        try (InsertResponse response = queryTimeout == 0 ?
+                connection.client.insert(tableSchema.getTableName(),in, writer.getFormat(), settings).get()
+                : connection.client.insert(tableSchema.getTableName(),in, writer.getFormat(), settings).get(queryTimeout, TimeUnit.SECONDS)) {
+            currentResultSet = null;
+            updateCount = Math.max(0, (int) response.getWrittenRows()); // when statement alters schema no result rows returned.
+            metrics = response.getMetrics();
+            lastQueryId = response.getQueryId();
+        } catch (Exception e) {
+            throw ExceptionUtils.toSqlState(e);
+        } finally {
+            try {
+                resetWriter();
+            } catch (Exception e) {
+                // ignore
+            }
+        }
+        return updateCount;
+    }
+
+    @Override
+    public void setNull(int parameterIndex, int sqlType) throws SQLException {
+        checkClosed();
+        writer.setValue(parameterIndex, null);
+    }
+
+    @Override
+    public void setBoolean(int parameterIndex, boolean x) throws SQLException {
+        checkClosed();
+        writer.setValue(parameterIndex, x);
+    }
+
+    @Override
+    public void setByte(int parameterIndex, byte x) throws SQLException {
+        checkClosed();
+        writer.setByte(parameterIndex, x);
+    }
+
+    @Override
+    public void setShort(int parameterIndex, short x) throws SQLException {
+        checkClosed();
+        writer.setShort(parameterIndex, x);
+    }
+
+    @Override
+    public void setInt(int parameterIndex, int x) throws SQLException {
+        checkClosed();
+        writer.setInteger(parameterIndex, x);
+    }
+
+    @Override
+    public void setLong(int parameterIndex, long x) throws SQLException {
+        checkClosed();
+        writer.setLong(parameterIndex, x);
+    }
+
+    @Override
+    public void setFloat(int parameterIndex, float x) throws SQLException {
+        checkClosed();
+        writer.setFloat(parameterIndex, x);
+    }
+
+    @Override
+    public void setDouble(int parameterIndex, double x) throws SQLException {
+        checkClosed();
+        writer.setDouble(parameterIndex, x);
+    }
+
+    @Override
+    public void setBigDecimal(int parameterIndex, BigDecimal x) throws SQLException {
+        checkClosed();
+        writer.setBigDecimal(parameterIndex, x);
+    }
+
+    @Override
+    public void setString(int parameterIndex, String x) throws SQLException {
+        checkClosed();
+        writer.setString(parameterIndex, x);
+    }
+
+    @Override
+    public void setBytes(int parameterIndex, byte[] x) throws SQLException {
+        checkClosed();
+
+    }
+
+    @Override
+    public void setDate(int parameterIndex, Date x) throws SQLException {
+        setDate(parameterIndex, x, null);
+    }
+
+    @Override
+    public void setTime(int parameterIndex, Time x) throws SQLException {
+        setTime(parameterIndex, x, null);
+    }
+
+    @Override
+    public void setTimestamp(int parameterIndex, Timestamp x) throws SQLException {
+        setTimestamp(parameterIndex, x, null);
+    }
+
+    @Override
+    public void setAsciiStream(int parameterIndex, InputStream x, int length) throws SQLException {
+        checkClosed();
+    }
+
+    @Override
+    public void setAsciiStream(int parameterIndex, InputStream x) throws SQLException {
+        checkClosed();
+
+    }
+
+    @Override
+    public void setAsciiStream(int parameterIndex, InputStream x, long length) throws SQLException {
+        checkClosed();
+
+    }
+
+    @Override
+    public void setUnicodeStream(int parameterIndex, InputStream x, int length) throws SQLException {
+        checkClosed();
+    }
+
+    @Override
+    public void setBinaryStream(int parameterIndex, InputStream x, int length) throws SQLException {
+        checkClosed();
+    }
+
+
+    @Override
+    public void setBinaryStream(int parameterIndex, InputStream x) throws SQLException {
+        checkClosed();
+
+    }
+
+    @Override
+    public void setBinaryStream(int parameterIndex, InputStream x, long length) throws SQLException {
+        checkClosed();
+
+    }
+
+    @Override
+    public void setCharacterStream(int parameterIndex, Reader x, int length) throws SQLException {
+        checkClosed();
+    }
+
+    @Override
+    public void setCharacterStream(int parameterIndex, Reader x, long length) throws SQLException {
+        checkClosed();
+    }
+
+    @Override
+    public void setCharacterStream(int parameterIndex, Reader x) throws SQLException {
+        checkClosed();
+    }
+
+    @Override
+    public void setNCharacterStream(int parameterIndex, Reader x) throws SQLException {
+        checkClosed();
+
+    }
+
+    @Override
+    public void setNCharacterStream(int parameterIndex, Reader x, long length) throws SQLException {
+        checkClosed();
+
+    }
+
+    @Override
+    public void clearParameters() throws SQLException {
+        checkClosed();
+        writer.clearRow();
+    }
+
+    @Override
+    public boolean execute() throws SQLException {
+        executeLargeUpdate();
+        return true;
+    }
+
+    @Override
+    public void addBatch() throws SQLException {
+        checkClosed();
+        try {
+            writer.commitRow();
+        } catch (Exception e) {
+            throw new SQLException(e);
+        }
+    }
+
+    @Override
+    public void setClob(int parameterIndex, Clob x) throws SQLException {
+        checkClosed();
+
+    }
+
+    @Override
+    public void setClob(int parameterIndex, Reader x, long length) throws SQLException {
+        checkClosed();
+
+    }
+
+    @Override
+    public void setBlob(int parameterIndex, Blob x) throws SQLException {
+        checkClosed();
+
+    }
+
+    @Override
+    public void setBlob(int parameterIndex, InputStream x, long length) throws SQLException {
+        checkClosed();
+
+    }
+
+    @Override
+    public void setBlob(int parameterIndex, InputStream inputStream) throws SQLException {
+        checkClosed();
+
+    }
+
+    @Override
+    public void setNClob(int parameterIndex, Reader x, long length) throws SQLException {
+        checkClosed();
+
+    }
+
+    @Override
+    public void setNClob(int parameterIndex, NClob x) throws SQLException {
+        checkClosed();
+
+    }
+
+    @Override
+    public void setClob(int parameterIndex, Reader x) throws SQLException {
+        checkClosed();
+
+    }
+
+    @Override
+    public void setNClob(int parameterIndex, Reader x) throws SQLException {
+        checkClosed();
+
+    }
+
+    @Override
+    public void setSQLXML(int parameterIndex, SQLXML x) throws SQLException {
+        checkClosed();
+
+    }
+
+    @Override
+    public void setArray(int parameterIndex, Array x) throws SQLException {
+        checkClosed();
+        writer.setValue(parameterIndex, x.getArray());
+    }
+
+    @Override
+    public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
+        checkClosed();
+        writer.setValue(parameterIndex, sqlDateToInstant(x, cal));
+    }
+
+    @Override
+    public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
+        checkClosed();
+        writer.setValue(parameterIndex, sqlTimeToInstant(x, cal));
+    }
+
+    @Override
+    public void setTimestamp(int parameterIndex, Timestamp x, Calendar cal) throws SQLException {
+        checkClosed();
+        writer.setDateTime(parameterIndex, sqlTimestampToZDT(x, cal));
+    }
+
+    @Override
+    public void setNull(int parameterIndex, int sqlType, String typeName) throws SQLException {
+        checkClosed();
+        writer.setValue(parameterIndex, null);
+    }
+
+    @Override
+    public void setURL(int parameterIndex, URL x) throws SQLException {
+        checkClosed();
+
+    }
+
+    @Override
+    public void setRowId(int parameterIndex, RowId x) throws SQLException {
+        checkClosed();
+
+    }
+
+    @Override
+    public void setNString(int parameterIndex, String value) throws SQLException {
+        checkClosed();
+
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x, int targetSqlType, int scaleOrLength) throws SQLException {
+        checkClosed();
+        // TODO: make proper data conversion in setObject methods
+        writer.setValue(parameterIndex, x);
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x, int targetSqlType) throws SQLException {
+        checkClosed();
+        writer.setValue(parameterIndex, x);
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x) throws SQLException {
+        checkClosed();
+        writer.setValue(parameterIndex, x);
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x, SQLType targetSqlType) throws SQLException {
+        setObject(parameterIndex, x, targetSqlType, 0);
+    }
+
+    @Override
+    public void setObject(int parameterIndex, Object x, SQLType targetSqlType, int scaleOrLength) throws SQLException {
+        checkClosed();
+        writer.setValue(parameterIndex, x);
+    }
+
+    @Override
+    public void close() throws SQLException {
+        super.close();
+        try {
+            if (out != null) {
+                out.close();
+                out = null;
+            }
+            writer = null;
+        } catch (Exception e) {
+            // ignore
+        }
+    }
+
+    @Override
+    public void cancel() throws SQLException {
+        try {
+            resetWriter();
+        } catch (Exception e ) {
+            throw new SQLException(e);
+        }
+    }
+
+    @Override
+    public int[] executeBatch() throws SQLException {
+        checkClosed();
+        int batchSize = writer.getRowCount();
+        long rowsInserted = executeLargeUpdate();
+        int[] results = new int[batchSize];
+        Arrays.fill(results, batchSize == rowsInserted? 1 : PreparedStatement.SUCCESS_NO_INFO);
+        return results;
+    }
+
+    @Override
+    public long[] executeLargeBatch() throws SQLException {
+        checkClosed();
+        int batchSize = writer.getRowCount();
+        long rowsInserted = executeLargeUpdate();
+        long[] results = new long[batchSize];
+        Arrays.fill(results, batchSize == rowsInserted? 1 : PreparedStatement.SUCCESS_NO_INFO);
+        return results;
+    }
+}

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/JdbcUtils.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/JdbcUtils.java
@@ -285,6 +285,19 @@ public class JdbcUtils {
                 .replace("\"", "\\\"");
     }
 
+    private static Pattern UNQUOTE_TABLE_NAME = Pattern.compile(
+            "^[\\\"`]?(.+?)[\\\"`]?$"
+    );
+
+    public static String unQuoteTableName(String str) {
+        Matcher matcher = UNQUOTE_TABLE_NAME.matcher(str.trim());
+        if (matcher.find()) {
+            return matcher.group(1);
+        } else {
+            return str;
+        }
+    }
+
     public static final String NULL = "NULL";
 
     private static final Pattern REPLACE_Q_MARK_PATTERN = Pattern.compile("(\"[^\"]*\"|`[^`]*`|'[^']*')|(\\?)");

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/JdbcUtilsTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/JdbcUtilsTest.java
@@ -59,6 +59,16 @@ public class JdbcUtilsTest {
         }
     }
 
+    @Test
+    public void testUnQuoteTableName() {
+        String[] names = new String[]{"test", "`test name1`", "\"test name 2\""};
+        String[] expected = new String[]{"test", "test name1", "test name 2"};
+
+        for (int i = 0; i < names.length; i++) {
+            assertEquals(JdbcUtils.unQuoteTableName(names[i]), expected[i]);
+        }
+    }
+
     @Test(dataProvider = "testReplaceQuestionMark_dataProvider")
     public void testReplaceQuestionMark(String sql, String result) {
         assertEquals(JdbcUtils.replaceQuestionMarks(sql, "NULL"), result);


### PR DESCRIPTION
## Summary
Adds support for RowBinaryFormatWriter and fixes some issues:
- Implementation forks PreparedStatementImpl and uses RowBinaryFormatWriter for simple "INSERT INTO t VALUES ()" case
- Implementation is simply collecting values as encoded bytes and writes out when batch is executed.

Additional work is needed further: 
- support "INSER INTO t (col1, col2) VALUES (?, ?)". It requires better parsing code. 


Closes https://github.com/ClickHouse/clickhouse-java/issues/2171
## Checklist
Delete items not relevant to your PR:
- [ ] Closes #2171 
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
