### PR TITLE
Solve issue 2329 - StringIndexOutOfBoundsException on empty collection

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/PreparedStatementImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/PreparedStatementImpl.java
@@ -596,7 +596,9 @@ public class PreparedStatementImpl extends StatementImpl implements PreparedStat
                 for (Object item : (Collection<?>) x) {
                     listString.append(encodeObject(item)).append(", ");
                 }
-                listString.delete(listString.length() - 2, listString.length());
+                if (listString.length() > 1) {
+                    listString.delete(listString.length() - 2, listString.length());
+                }
                 listString.append("]");
 
                 return listString.toString();

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/PreparedStatementTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/PreparedStatementTest.java
@@ -13,9 +13,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.Statement;
 import java.sql.Types;
-import java.util.Arrays;
-import java.util.GregorianCalendar;
-import java.util.TimeZone;
+import java.util.*;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -580,4 +578,32 @@ public class PreparedStatementTest extends JdbcIntegrationTest {
             ps.execute();
         }
     }
+
+    @Test(groups = {"integration"})
+    void testWriteCollection() throws Exception {
+        String sql = "insert into `test_issue_2329` (`id`, `name`, `age`, `arr`) values (?, ?, ?, ?)";
+        try (Connection conn = getJdbcConnection();
+             PreparedStatementImpl ps = (PreparedStatementImpl) conn.prepareStatement(sql)) {
+
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("CREATE TABLE IF NOT EXISTS `test_issue_2329` (`id` Nullable(String), `name` Nullable(String), `age` Int32, `arr` Array(String)) ENGINE Memory;");
+            }
+
+            Assert.assertEquals(ps.getParametersCount(), 4);
+            Collection<String> arr = new ArrayList<String>();
+            ps.setString(1, "testId01");
+            ps.setString(2, "testName");
+            ps.setInt(3, 18);
+            ps.setObject(4, arr);
+            ps.execute();
+
+            try (Statement stmt = conn.createStatement()) {
+                ResultSet rs = stmt.executeQuery("SELECT count(*) FROM `test_issue_2329`");
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getInt(1), 1);
+            }
+        }
+
+    }
+
 }


### PR DESCRIPTION
## Summary
StringIndexOutOfBoundsException on empty collection in the encodeObject method.

Closes #2329
## Checklist
Delete items not relevant to your PR:
- [X] Closes #2329
- [X] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
