### PR TITLE
Solve 2327 - Does not escape correctly UUID

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/PreparedStatementImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/PreparedStatementImpl.java
@@ -43,13 +43,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 import java.time.temporal.ChronoField;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Calendar;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class PreparedStatementImpl extends StatementImpl implements PreparedStatement, JdbcV2Wrapper {
     private static final Logger LOG = LoggerFactory.getLogger(PreparedStatementImpl.class);
@@ -659,6 +653,8 @@ public class PreparedStatementImpl extends StatementImpl implements PreparedStat
                 }
                 tupleString.append(")");
                 return tupleString.toString();
+            } else if (x instanceof UUID) {
+                return "'" + escapeString(((UUID) x).toString()) + "'";
             }
 
             return escapeString(x.toString());//Escape single quotes


### PR DESCRIPTION
## Summary
Solve 2327 - Does not escape correctly UUID

Closes #2327
## Checklist
Delete items not relevant to your PR:
- [X] Closes #2327
- [X] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
