### PR TITLE
Solves issue-2191

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/ClientConfigProperties.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/ClientConfigProperties.java
@@ -36,6 +36,8 @@ public enum ClientConfigProperties {
 
     USE_TIMEZONE("use_time_zone"),
 
+    SERVER_VERSION("server_version"),
+
     SERVER_TIMEZONE("server_time_zone"),
 
     ASYNC_OPERATIONS("async"),

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/ConnectionTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/ConnectionTest.java
@@ -2,12 +2,9 @@ package com.clickhouse.jdbc;
 
 import java.nio.charset.StandardCharsets;
 import java.sql.*;
-import java.util.Arrays;
-import java.util.Base64;
-import java.util.Properties;
+import java.util.*;
 
 import java.util.Properties;
-import java.util.UUID;
 
 import com.clickhouse.client.ClickHouseNode;
 import com.clickhouse.client.ClickHouseProtocol;
@@ -552,6 +549,22 @@ public class ConnectionTest extends JdbcIntegrationTest {
              ResultSet rs = stmt.executeQuery("SELECT 1")) {
              Assert.assertTrue(rs.next());
         }
+    }
+    @Test(groups = { "integration" })
+    public void testDisableExtraCallToServer() throws Exception {
+        Properties properties = new Properties();
+        properties.put(ClientConfigProperties.SERVER_TIMEZONE.getKey(), "GMT");
+        properties.put(ClientConfigProperties.SERVER_VERSION.getKey(), "1.0.0");
+        try (Connection conn = getJdbcConnection(properties);
+             Statement stmt = conn.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT 1")) {
+             Assert.assertTrue(rs.next());
+             ConnectionImpl connImpl = (ConnectionImpl) conn;
+
+             Assert.assertEquals(connImpl.getClient().getServerVersion(), "1.0.0");
+             Assert.assertEquals(connImpl.getClient().getServerTimeZone(), "GMT");
+        }
+
     }
 
 }


### PR DESCRIPTION
## Summary
If the client wants to disable the retrieval of the server version & server timezone (extra query when init of JDBC Connection)
Example (how to disable)
```
properties.put(ClientConfigProperties.SERVER_TIMEZONE.getKey(), "GMT");
properties.put(ClientConfigProperties.SERVER_VERSION.getKey(), "1.0.0");
```
Closes #2191
## Checklist
Delete items not relevant to your PR:
- [X] Closes #2191
- [X] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
