### PR TITLE
Add Apache Flink and Apache Nifi to frameworks detection

### DIFF
--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/DriverV1.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/DriverV1.java
@@ -47,7 +47,7 @@ public class DriverV1 implements Driver {
     public static String frameworksDetected = null;
 
     public static class FrameworksDetection {
-        private static final List<String> FRAMEWORKS_TO_DETECT = Arrays.asList("apache.spark");
+        private static final List<String> FRAMEWORKS_TO_DETECT = Arrays.asList("apache.spark", "apache.flink", "apache.nifi");
         static volatile String frameworksDetected = null;
 
         private FrameworksDetection() {

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/Driver.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/Driver.java
@@ -34,7 +34,7 @@ public class Driver implements java.sql.Driver {
     public static String frameworksDetected = null;
 
     public static class FrameworksDetection {
-        private static final List<String> FRAMEWORKS_TO_DETECT = Arrays.asList("apache.spark");
+        private static final List<String> FRAMEWORKS_TO_DETECT = Arrays.asList("apache.spark", "apache.flink", "apache.nifi");
         static volatile String frameworksDetected = null;
 
         private FrameworksDetection() {


### PR DESCRIPTION
## Summary
To improve our metrics and tracking, we added two more frameworks that can use the JDBC package: [Flink JDBC](https://nightlies.apache.org/flink/flink-docs-master/docs/connectors/datastream/jdbc/) and [NIFI JDBC](https://nifi.apache.org/docs/nifi-docs/components/org.apache.nifi/nifi-dbcp-service-nar/1.17.0/org.apache.nifi.dbcp.DBCPConnectionPool/index.html).

This feature was verified for the Flink JDBC connector.
