### PR TITLE
[client-v2] fixed NPE and added test

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -39,7 +39,6 @@ import com.clickhouse.client.api.query.Records;
 import com.clickhouse.client.config.ClickHouseClientOption;
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseFormat;
-import net.jpountz.lz4.LZ4Compressor;
 import net.jpountz.lz4.LZ4Factory;
 import org.apache.hc.core5.concurrent.DefaultThreadFactory;
 import org.apache.hc.core5.http.ClassicHttpResponse;
@@ -192,24 +191,16 @@ public class Client implements AutoCloseable {
      *
      */
     public void loadServerInfo() {
-        // only if 2 properties are set disable retrieval from server
-        if (!this.configuration.containsKey(ClientConfigProperties.SERVER_TIMEZONE.getKey()) && !this.configuration.containsKey(ClientConfigProperties.SERVER_VERSION.getKey())) {
-            try (QueryResponse response = this.query("SELECT currentUser() AS user, timezone() AS timezone, version() AS version LIMIT 1").get()) {
-                try (ClickHouseBinaryFormatReader reader = this.newBinaryFormatReader(response)) {
-                    if (reader.next() != null) {
-                        this.configuration.put(ClientConfigProperties.USER.getKey(), reader.getString("user"));
-                        this.configuration.put(ClientConfigProperties.SERVER_TIMEZONE.getKey(), reader.getString("timezone"));
-                        serverVersion = reader.getString("version");
-                    }
+        try (QueryResponse response = this.query("SELECT currentUser() AS user, timezone() AS timezone, version() AS version LIMIT 1").get()) {
+            try (ClickHouseBinaryFormatReader reader = this.newBinaryFormatReader(response)) {
+                if (reader.next() != null) {
+                    this.configuration.put(ClientConfigProperties.USER.getKey(), reader.getString("user"));
+                    this.configuration.put(ClientConfigProperties.SERVER_TIMEZONE.getKey(), reader.getString("timezone"));
+                    serverVersion = reader.getString("version");
                 }
-            } catch (Exception e) {
-                throw new ClientException("Failed to get server info", e);
             }
-        } else {
-            LOG.info("Using server version " + this.configuration.get(ClientConfigProperties.SERVER_VERSION.getKey()) + " and timezone " + this.configuration.get(ClientConfigProperties.SERVER_TIMEZONE.getKey()) );
-            if (this.configuration.containsKey(ClientConfigProperties.SERVER_VERSION.getKey())) {
-                serverVersion = this.configuration.get(ClientConfigProperties.SERVER_VERSION.getKey());
-            }
+        } catch (Exception e) {
+            throw new ClientException("Failed to get server info", e);
         }
     }
 
@@ -1213,8 +1204,11 @@ public class Client implements AutoCloseable {
      */
     public boolean ping(long timeout) {
         long startTime = System.nanoTime();
-        try (QueryResponse response = query("SELECT 1 FORMAT TabSeparated").get(timeout, TimeUnit.MILLISECONDS)) {
-            return true;
+        try {
+            CompletableFuture<QueryResponse> future = query("SELECT 1 FORMAT TabSeparated");
+            try (QueryResponse response = timeout > 0 ? future.get(timeout, TimeUnit.MILLISECONDS) : future.get()) {
+                return true;
+            }
         } catch (Exception e) {
             LOG.debug("Failed to connect to the server (Duration: {})", System.nanoTime() - startTime, e);
             return false;
@@ -2194,7 +2188,7 @@ public class Client implements AutoCloseable {
     }
 
     public String getServerVersion() {
-        return this.serverVersion;
+        return this.serverVersion == null ? "unknown" : this.serverVersion;
     }
 
     public String getServerTimeZone() {

--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -184,6 +184,8 @@ public class Client implements AutoCloseable {
         } else {
             this.lz4Factory = LZ4Factory.fastestJavaInstance();
         }
+
+        this.serverVersion = configuration.getOrDefault(ClientConfigProperties.SERVER_VERSION.getKey(), "unknown");
     }
 
     /**
@@ -2188,7 +2190,7 @@ public class Client implements AutoCloseable {
     }
 
     public String getServerVersion() {
-        return this.serverVersion == null ? "unknown" : this.serverVersion;
+        return this.serverVersion;
     }
 
     public String getServerTimeZone() {

--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -2153,7 +2153,11 @@ public class Client implements AutoCloseable {
 
     private <T> CompletableFuture<T> runAsyncOperation(Supplier<T> resultSupplier, Map<String, Object> requestSettings) {
         boolean isAsync = MapUtils.getFlag(requestSettings, configuration, ClientConfigProperties.ASYNC_OPERATIONS.getKey());
-        return isAsync ? CompletableFuture.supplyAsync(resultSupplier, sharedOperationExecutor) : CompletableFuture.completedFuture(resultSupplier.get());
+        if (isAsync) {
+            return sharedOperationExecutor == null ? CompletableFuture.supplyAsync(resultSupplier) :
+                    CompletableFuture.supplyAsync(resultSupplier, sharedOperationExecutor);
+        }
+        return CompletableFuture.completedFuture(resultSupplier.get());
     }
 
     @Override

--- a/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
@@ -203,7 +203,7 @@ public class HttpTransportTests extends BaseIntegrationTest {
         }
     }
 
-    @Test
+    @Test(groups = {"integration"})
     public void testConnectionReuseStrategy() {
         if (isCloud()) {
             return; // mocked server

--- a/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/insert/InsertTests.java
@@ -27,6 +27,7 @@ import com.clickhouse.client.api.query.QuerySettings;
 import com.clickhouse.data.ClickHouseFormat;
 import com.clickhouse.data.ClickHouseVersion;
 import com.clickhouse.data.format.BinaryStreamUtils;
+import lombok.Data;
 import net.jpountz.lz4.LZ4Compressor;
 import net.jpountz.lz4.LZ4Factory;
 import net.jpountz.lz4.LZ4SafeDecompressor;
@@ -270,8 +271,8 @@ public class InsertTests extends BaseIntegrationTest {
         assertEquals(records.size(), 1000);
     }
 
-    @Test(groups = { "integration" }, enabled = true)
-    public void insertRawDataAsync() throws Exception {
+    @Test(groups = { "integration" }, dataProvider = "insertRawDataAsyncProvider", dataProviderClass = InsertTests.class)
+    public void insertRawDataAsync(boolean async) throws Exception {
         final String tableName = "raw_data_table_async";
         final String createSQL = "CREATE TABLE " + tableName +
                 " (Id UInt32, event_ts Timestamp, name String, p1 Int64, p2 String) ENGINE = MergeTree() ORDER BY ()";
@@ -279,7 +280,7 @@ public class InsertTests extends BaseIntegrationTest {
         initTable(tableName, createSQL);
 
         InsertSettings localSettings = new InsertSettings(settings.getAllSettings());
-        localSettings.setOption(ClientConfigProperties.ASYNC_OPERATIONS.getKey(), true);
+        localSettings.setOption(ClientConfigProperties.ASYNC_OPERATIONS.getKey(), async);
         ByteArrayOutputStream data = new ByteArrayOutputStream();
         PrintWriter writer = new PrintWriter(data);
         for (int i = 0; i < 1000; i++) {
@@ -293,8 +294,18 @@ public class InsertTests extends BaseIntegrationTest {
 
                 List<GenericRecord> records = client.queryAll("SELECT * FROM " + tableName);
                 assertEquals(records.size(), 1000);
+                assertTrue(Thread.currentThread().getName()
+                        .startsWith(async ? "ForkJoinPool.commonPool" : "main"), "Threads starts with " + Thread.currentThread().getName());
         })
                 .join(); // wait operation complete. only for tests
+    }
+
+    @DataProvider
+    public static Object[][] insertRawDataAsyncProvider(){
+        return new Object[][] {
+                {true}, // async
+                {false} // blocking
+        };
     }
 
     @Test(groups = { "integration" }, dataProvider = "insertRawDataSimpleDataProvider", dataProviderClass = InsertTests.class)

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/ConnectionImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/ConnectionImpl.java
@@ -95,7 +95,11 @@ public class ConnectionImpl implements Connection, JdbcV2Wrapper {
             this.client = this.config.applyClientProperties(new Client.Builder())
                     .setClientName(clientName)
                     .build();
-            this.client.loadServerInfo();
+            String serverTimezone = this.client.getServerTimeZone();
+            if (serverTimezone == null) {
+                // we cannot operate without timezone
+                this.client.loadServerInfo();
+            }
             this.schema = client.getDefaultDatabase();
             this.defaultQuerySettings = new QuerySettings()
                     .serverSetting(ServerSettings.ASYNC_INSERT, "0")


### PR DESCRIPTION
## Summary
Fixes #2355 by using default JVM pool in case executor is no specified by client nor client is configured for async operations 

## Checklist
Delete items not relevant to your PR:
- [x] Closes #2355 
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
