### PR TITLE
Override getObject for integer metadata

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/MetadataResultSet.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/MetadataResultSet.java
@@ -50,6 +50,25 @@ public class MetadataResultSet extends ResultSetImpl {
     }
 
     @Override
+    public Object getObject(String columnLabel) throws SQLException {
+        try {
+            return getInt(columnLabel);
+        } catch (SQLException e) {
+            // If the column is not an integer, fall back to the default behavior
+            return super.getObject(columnLabel);
+        }
+    }
+
+    @Override
+    public Object getObject(int columnIndex) throws SQLException {
+        if (columnIndex < 1 || columnIndex > cachedColumnLabels.length) {
+            throw new SQLException("Invalid column index: " + columnIndex);
+        }
+        return getObject(cachedColumnLabels[columnIndex - 1]);
+    }
+
+
+    @Override
     public String getString(String columnLabel) throws SQLException {
         String value = super.getString(columnLabel);
         UnaryOperator<String> transformer = columnTransformers.get(columnLabel.toUpperCase());

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataTest.java
@@ -62,6 +62,7 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
                 assertEquals(rs.getString("TABLE_NAME"), tableName);
                 assertEquals(rs.getString("TYPE_NAME"), columnTypeNames.get(colIndex));
                 assertEquals(rs.getInt("DATA_TYPE"), columnJDBCDataTypes.get(colIndex));
+                assertEquals(rs.getObject("DATA_TYPE"), columnJDBCDataTypes.get(colIndex));
                 assertEquals(rs.getInt("COLUMN_SIZE"), columnSizes.get(colIndex));
                 assertEquals(rs.getInt("ORDINAL_POSITION"), colIndex + 1);
                 assertEquals(rs.getInt("NULLABLE"), columnNullable.get(colIndex) ? DatabaseMetaData.attributeNullable : DatabaseMetaData.attributeNoNulls);


### PR DESCRIPTION
## Summary
* Added an override for getObject as well, so that we use getInteger (and fall back to the super when that fails)

Closes https://github.com/ClickHouse/clickhouse-java/issues/2240
## Checklist
Delete items not relevant to your PR:
- [x] Closes #<issue ref>
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
