### PR TITLE
upgraded version of antlr4

### DIFF
--- a/jdbc-v2/pom.xml
+++ b/jdbc-v2/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
-            <version>4.9.3</version>
+            <version>4.13.2</version>
         </dependency>
 
         <dependency>
@@ -401,7 +401,7 @@
             <plugin>
                 <groupId>org.antlr</groupId>
                 <artifactId>antlr4-maven-plugin</artifactId>
-                <version>4.9.3</version>
+                <version>4.13.2</version>
                 <executions>
                     <execution>
                         <phase>generate-sources</phase>


### PR DESCRIPTION
## Summary
There was an error while running Metabase tests: 
```
       java.lang.NoClassDefFoundError: Could not initialize class com.clickhouse.jdbc.internal.ClickHouseLexer
java.lang.ExceptionInInitializerError: Exception java.lang.UnsupportedOperationException: java.io.InvalidClassException: org.antlr.v4.runtime.atn.ATN; Could not deserialize ATN with version 3 (expected 4). [in thread "CLI-agent-send-off-pool-1"]
       
```

This PR upgrades to the latest version to fix it. 

## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
