### PR TITLE
Fix `ResultSet#findColumn` - return actual column's index instead of 0

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/metadata/TableSchema.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/metadata/TableSchema.java
@@ -104,10 +104,23 @@ public class TableSchema {
         return indexToName(index - 1);
     }
 
+    /**
+     * Takes column name and return corresponding index (starting from 1).
+     * Equals to {@code nameToIndex(name) + 1}.
+     *
+     * @param name - column name
+     * @return - column index starting from 1
+     */
     public int nameToColumnIndex(String name) {
         return nameToIndex(name) + 1;
     }
 
+    /**
+     * Takes column name and return corresponding index (starting from 0).
+     *
+     * @param name - column name
+     * @return - column index starting from 0
+     */
     public int nameToIndex(String name) {
         Integer index = colIndex.get(name);
         if (index == null) {

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/ResultSetImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/ResultSetImpl.java
@@ -469,7 +469,7 @@ public class ResultSetImpl implements ResultSet, JdbcV2Wrapper {
     public int findColumn(String columnLabel) throws SQLException {
         checkClosed();
         try {
-            return reader.getSchema().getColumnByName(columnLabel).getColumnIndex();
+            return reader.getSchema().nameToColumnIndex(columnLabel);
         } catch (Exception e) {
             throw ExceptionUtils.toSqlState(String.format("Method: findColumn(\"%s\") encountered an exception.", columnLabel), String.format("SQL: [%s]", parentStatement.getLastStatementSql()), e);
         }

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/ResultSetImplTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/ResultSetImplTest.java
@@ -1,0 +1,38 @@
+package com.clickhouse.jdbc;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+import org.testng.annotations.Test;
+
+public class ResultSetImplTest extends JdbcIntegrationTest {
+
+    @Test(groups = "integration")
+    public void shouldReturnColumnIndex() throws SQLException {
+        runQuery("CREATE TABLE rs_test_data (id UInt32, val UInt8) ENGINE = MergeTree ORDER BY (id)");
+        runQuery("INSERT INTO rs_test_data VALUES (1, 10), (2, 20)");
+
+        try (Connection conn = getJdbcConnection()) {
+            try (Statement stmt = conn.createStatement()) {
+                try (ResultSet rs = stmt.executeQuery("SELECT * FROM rs_test_data ORDER BY id")) {
+                    assertTrue(rs.next());
+                    assertEquals(rs.findColumn("id"), 1);
+                    assertEquals(rs.getInt(1), 1);
+                    assertEquals(rs.findColumn("val"), 2);
+                    assertEquals(rs.getInt(2), 10);
+
+                    assertTrue(rs.next());
+                    assertEquals(rs.findColumn("id"), 1);
+                    assertEquals(rs.getInt(1), 2);
+                    assertEquals(rs.findColumn("val"), 2);
+                    assertEquals(rs.getInt(2), 20);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Now `findColumn` returns actual column's index.

Closes https://github.com/ClickHouse/clickhouse-java/issues/2375.

The reason this method returns 0 is the following: this method obtains an instance of `ClickHouseColumn` to return its index. However, its private field `columnIndex` always equals 0 for any write/read path. This field is set in the constructor initially and never updated to reflect the actual column's index - https://github.com/gravity182/clickhouse-java/blob/a3f80b6476c6832a0f8e09c88b65f55e86b4e270/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseColumn.java#L670.

Interestingly, this method worked correctly in jdbc-v1. See the implementation - https://github.com/gravity182/clickhouse-java/blob/3ce1b09161e15bfd13695d7fb7bdd198b4672e00/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseResultSet.java#L219-L225. As you can see, it simply counted from 1 until the required column is found.

Having said that, we can proceed with this solution fixing only the `findColumn` method or fix this problem on the deeper level, setting `ClickHouseColumn#columnIndex` field to a correct column's index. There probably might be other methods affected by this problem as well.

## Checklist
Delete items not relevant to your PR:
- [x] Closes https://github.com/ClickHouse/clickhouse-java/issues/2375
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG

