### PR TITLE
Restore IPv6 address support in the JDBC URL connection.

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/JdbcConfiguration.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/JdbcConfiguration.java
@@ -126,7 +126,7 @@ public class JdbcConfiguration {
      *     <li>5 - query parameters as is (optional)</li>
      * </ul>
      */
-    private static final Pattern URL_REGEXP = Pattern.compile("(https?:)?\\/\\/([\\w\\.\\-]+):?([\\d]*)(?:\\/([\\w]+))?\\/?\\??(.*)$");
+    private static final Pattern URL_REGEXP = Pattern.compile("(https?:)?\\/\\/([\\w\\.\\-]+|\\[[0-9a-fA-F:]+\\]):?([\\d]*)(?:\\/([\\w]+))?\\/?\\??(.*)$");
 
     /**
      * Extracts positions of parameters names.

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/JdbcConfigurationTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/JdbcConfigurationTest.java
@@ -40,6 +40,9 @@ public class JdbcConfigurationTest {
 
         return new Object[][] {
                 {"jdbc:clickhouse://localhost:8123/", "http://localhost:8123", defaultProps, defaultParams},
+                {"jdbc:clickhouse://127.0.0.1:8123/", "http://127.0.0.1:8123", defaultProps, defaultParams},
+                {"jdbc:clickhouse://[::1]:8123/", "http://[::1]:8123", defaultProps, defaultParams},
+                {"jdbc:clickhouse://[::1]/", "http://[::1]", defaultProps, defaultParams},
                 {"jdbc:clickhouse://localhost:8443/clickhouse?param1=value1&param2=value2", "http://localhost:8443", defaultProps, simpleParams},
                 {"jdbc:clickhouse:https://localhost:8123/clickhouse?param1=value1&param2=value2", "https://localhost:8123", defaultProps, simpleParams},
                 {"jdbc:clickhouse://localhost:8443/", "https://localhost:8443", useSSL, useSSLParams},


### PR DESCRIPTION
## Summary
Restore IPv6 address support in the JDBC URL connection.
Prior to 1.8.0 it was working properly. As of 1.8.x, the `URL_REGEXP` rejected URLs like `jdbc:clickhouse://[::1]/`.

## Checklist
- [x] Closes #2384
- [x] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided to include in CHANGELOG
