### PR TITLE
[repo] Force using JDK 1.8 toolchain to build for JDK 8 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
             21
           cache: "maven"
       - name: Build and install libraries
-        run: mvn --batch-mode --no-transfer-progress --show-version --strict-checksums --threads 2 -Dmaven.wagon.rto=30000 -Dj8 -Dmaven.test.skip=true install
+        run: mvn --batch-mode --no-transfer-progress --show-version --strict-checksums --threads 2 -Dmaven.wagon.rto=30000 -Dj8 -DskipITs install
       - name: Compile examples
         run: |
           export LIB_VER=$(grep '<revision>' pom.xml | sed -e 's|[[:space:]]*<[/]*revision>[[:space:]]*||g')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
             21
           cache: "maven"
       - name: Build and install libraries
-        run: mvn --batch-mode --no-transfer-progress --show-version --strict-checksums --threads 2 -Dmaven.wagon.rto=30000 -Dj8 -DskipITs install
+        run: mvn --batch-mode --no-transfer-progress --show-version --strict-checksums --threads 2 -Dmaven.wagon.rto=30000 -Dj8 -Dmaven.test.skip=true install
       - name: Compile examples
         run: |
           export LIB_VER=$(grep '<revision>' pom.xml | sed -e 's|[[:space:]]*<[/]*revision>[[:space:]]*||g')

--- a/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseSimpleRecordTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseSimpleRecordTest.java
@@ -28,9 +28,9 @@ public class ClickHouseSimpleRecordTest {
     public void testMismatchedColumnsAndValues() {
 
         Assert.assertThrows(IllegalArgumentException.class, () -> ClickHouseSimpleRecord
-                .of(Map.of("a", 0), new ClickHouseValue[0]));
+                .of(Collections.singletonMap("a", 0), new ClickHouseValue[0]));
 
-        ClickHouseSimpleRecord record = new ClickHouseSimpleRecord(Map.of("a", 0),
+        ClickHouseSimpleRecord record = new ClickHouseSimpleRecord(Collections.singletonMap("a", 0),
                 new ClickHouseValue[0]);
         Assert.assertEquals(record.getValues(), new ClickHouseValue[0]);
     }

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/PreparedStatementImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/PreparedStatementImpl.java
@@ -403,21 +403,29 @@ public class PreparedStatementImpl extends StatementImpl implements PreparedStat
 
     private static final Pattern REPLACE_Q_MARK_PATTERN = Pattern.compile("(\"[^\"]*\"|`[^`]*`|'[^']*')|(\\?)");
 
-    public static String replaceQuestionMarks(String sql, String replacement) {
+    public static String replaceQuestionMarks(String sql, final String replacement) {
         Matcher matcher = REPLACE_Q_MARK_PATTERN.matcher(sql);
 
         StringBuilder result = new StringBuilder();
 
+        int lastPos = 0;
         while (matcher.find()) {
-            if (matcher.group(1) != null) {
+            String text;
+            if ((text = matcher.group(1)) != null) {
                 // Quoted string — keep as-is
-                matcher.appendReplacement(result, Matcher.quoteReplacement(matcher.group(1)));
+                String str = Matcher.quoteReplacement(text);
+                result.append(sql, lastPos, matcher.start()).append(str);
+                lastPos = matcher.end();
             } else if (matcher.group(2) != null) {
                 // Question mark outside quotes — replace it
-                matcher.appendReplacement(result, Matcher.quoteReplacement(replacement));
+                String str = Matcher.quoteReplacement(replacement);
+                result.append(sql, lastPos, matcher.start()).append(str);
+                lastPos = matcher.end();
             }
         }
-        matcher.appendTail(result);
+
+        // Add rest of the `sql`
+        result.append(sql, lastPos, sql.length());
         return result.toString();
     }
 

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java
@@ -1414,9 +1414,4 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
     public boolean supportsRefCursors() throws SQLException {
         return false;
     }
-
-    @Override
-    public boolean supportsSharding() throws SQLException {
-        return false;
-    }
 }

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/ConnectionTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/ConnectionTest.java
@@ -1,11 +1,5 @@
 package com.clickhouse.jdbc;
 
-import java.nio.charset.StandardCharsets;
-import java.sql.*;
-import java.util.*;
-
-import java.util.Properties;
-
 import com.clickhouse.client.ClickHouseNode;
 import com.clickhouse.client.ClickHouseProtocol;
 import com.clickhouse.client.ClickHouseServerForTest;
@@ -22,6 +16,20 @@ import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
+
+import java.nio.charset.StandardCharsets;
+import java.sql.Array;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Properties;
+import java.util.UUID;
 
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.fail;
@@ -345,32 +353,6 @@ public class ConnectionTest extends JdbcIntegrationTest {
     public void getNetworkTimeoutTest() throws SQLException {
         Connection localConnection = this.getJdbcConnection();
         assertThrows(SQLFeatureNotSupportedException.class, () -> localConnection.getNetworkTimeout());
-    }
-
-    @Test(groups = { "integration" })
-    public void beginRequestTest() throws SQLException {
-        Connection localConnection = this.getJdbcConnection();
-        localConnection.beginRequest();//No-op
-    }
-
-    @Test(groups = { "integration" })
-    public void endRequestTest() throws SQLException {
-        Connection localConnection = this.getJdbcConnection();
-        localConnection.endRequest();//No-op
-    }
-
-    @Test(groups = { "integration" })
-    public void setShardingKeyIfValidTest() throws SQLException {
-        Connection localConnection = this.getJdbcConnection();
-        assertThrows(SQLFeatureNotSupportedException.class, () -> localConnection.setShardingKeyIfValid(null, 0));
-        assertThrows(SQLFeatureNotSupportedException.class, () -> localConnection.setShardingKeyIfValid(null, null, 0));
-    }
-
-    @Test(groups = { "integration" })
-    public void setShardingKeyTest() throws SQLException {
-        Connection localConnection = this.getJdbcConnection();
-       assertThrows(SQLFeatureNotSupportedException.class, () -> localConnection.setShardingKey(null));
-       assertThrows(SQLFeatureNotSupportedException.class, () -> localConnection.setShardingKey(null, null));
     }
 
     @Test(groups = { "integration" })

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/PreparedStatementTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/PreparedStatementTest.java
@@ -22,7 +22,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;

--- a/pom.xml
+++ b/pom.xml
@@ -120,8 +120,8 @@
 
         <antrun-plugin.version>3.1.0</antrun-plugin.version>
         <assembly-plugin.version>3.6.0</assembly-plugin.version>
-        <clean-plugin.version>3.3.1</clean-plugin.version>
-        <compiler-plugin.version>3.13.0</compiler-plugin.version>
+        <clean-plugin.version>3.5.0</clean-plugin.version>
+        <compiler-plugin.version>3.14.0</compiler-plugin.version>
         <deploy-plugin.version>3.1.1</deploy-plugin.version>
         <enforcer-plugin.version>3.3.0</enforcer-plugin.version>
         <exec-plugin.version>3.1.0</exec-plugin.version>
@@ -131,23 +131,24 @@
         <gpg-plugin.version>3.1.0</gpg-plugin.version>
         <helper-plugin.version>3.4.0</helper-plugin.version>
         <jacoco-plugin.version>0.8.12</jacoco-plugin.version>
-        <jar-plugin.version>3.3.0</jar-plugin.version>
-        <javadoc-plugin.version>3.5.0</javadoc-plugin.version>
+        <jar-plugin.version>3.4.2</jar-plugin.version>
+        <javadoc-plugin.version>3.11.2</javadoc-plugin.version>
         <native-plugin.version>0.9.23</native-plugin.version>
         <os-plugin.version>1.7.1</os-plugin.version>
         <protobuf-plugin.version>0.6.1</protobuf-plugin.version>
-        <shade-plugin.version>3.5.0</shade-plugin.version>
-        <source-plugin.version>3.2.1</source-plugin.version>
+        <shade-plugin.version>3.6.0</shade-plugin.version>
+        <source-plugin.version>3.3.1</source-plugin.version>
         <staging-plugin.version>1.6.13</staging-plugin.version>
-        <surefire-plugin.version>3.2.5</surefire-plugin.version>
-        <toolchains-plugin.version>3.1.0</toolchains-plugin.version>
-        <versions-plugin.version>2.16.0</versions-plugin.version>
+        <surefire-plugin.version>3.5.3</surefire-plugin.version>
+        <toolchains-plugin.version>3.2.0</toolchains-plugin.version>
+        <versions-plugin.version>2.18.0</versions-plugin.version>
         <resource-plugin.version>3.3.1</resource-plugin.version>
         <jmh.version>1.37</jmh.version>
         <guava.version>33.4.6-jre</guava.version>
 
         <minTargetJdk>17</minTargetJdk>
         <minSourceJdk>17</minSourceJdk>
+        <javadoc.source.version>1.8</javadoc.source.version>
         <skipTests>false</skipTests>
         <skipITs>${skipTests}</skipITs>
         <skipUTs>${skipTests}</skipUTs>
@@ -962,7 +963,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
-                            <source>${minSourceJdk}</source>
+                            <source>${javadoc.source.version}</source>
                         </configuration>
                         <executions>
                             <execution>
@@ -1193,7 +1194,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
-                            <source>${minSourceJdk}</source>
+                            <source>${javadoc.source.version}</source>
                         </configuration>
                         <executions>
                             <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -146,7 +146,8 @@
         <jmh.version>1.37</jmh.version>
         <guava.version>33.4.6-jre</guava.version>
 
-        <minJdk>1.8</minJdk>
+        <minTargetJdk>17</minTargetJdk>
+        <minSourceJdk>17</minSourceJdk>
         <skipTests>false</skipTests>
         <skipITs>${skipTests}</skipITs>
         <skipUTs>${skipTests}</skipUTs>
@@ -591,10 +592,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>${minJdk}</source>
-                    <target>${minJdk}</target>
-                    <testSource>17</testSource>
-                    <testTarget>17</testTarget>
+                    <source>${minSourceJdk}</source>
+                    <target>${minSourceJdk}</target>
                     <showWarnings>true</showWarnings>
                     <compilerArgs>
                         <arg>-Xlint:all</arg>
@@ -812,6 +811,21 @@
                     <name>j8</name>
                 </property>
             </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <target>1.8</target>
+                            <source>1.8</source>
+                            <jdkToolchain>
+                                <version>1.8</version>
+                            </jdkToolchain>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
             <properties>
                 <caffeine.version>2.9.2</caffeine.version>
             </properties>
@@ -948,7 +962,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
-                            <source>${minJdk}</source>
+                            <source>${minSourceJdk}</source>
                         </configuration>
                         <executions>
                             <execution>
@@ -1044,8 +1058,8 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
-                            <source>${minJdk}</source>
-                            <target>${minJdk}</target>
+                            <source>1.8</source>
+                            <target>1.8</target>
                             <showWarnings>true</showWarnings>
                             <compilerArgs>
                                 <arg>-Xlint:all</arg>
@@ -1179,7 +1193,7 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <configuration>
-                            <source>${minJdk}</source>
+                            <source>${minSourceJdk}</source>
                         </configuration>
                         <executions>
                             <execution>


### PR DESCRIPTION
## Summary

This PR does a several build changes 
- minimal source version is 17
- minimal target version is 8
- when built with -Dj8 - the JDK 1.8 toolchain is required  


## Checklist
- [x] Closes #2404 
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
