### PR TITLE
[client-v2] Move default values to Enum

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/ClientConfigProperties.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/ClientConfigProperties.java
@@ -22,7 +22,7 @@ public enum ClientConfigProperties {
 
     USER("user", "default"),
 
-    PASSWORD("password", ""),
+    PASSWORD("password"),
 
     /**
      * Maximum number of active connection in internal connection pool.

--- a/client-v2/src/main/java/com/clickhouse/client/api/ClientConfigProperties.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/ClientConfigProperties.java
@@ -1,5 +1,7 @@
 package com.clickhouse.client.api;
 
+import com.clickhouse.client.api.internal.ClickHouseLZ4OutputStream;
+
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -16,7 +18,7 @@ public enum ClientConfigProperties {
 
     SETTING_LOG_COMMENT(serverSetting("log_comment")),
 
-    HTTP_USE_BASIC_AUTH("http_use_basic_auth"),
+    HTTP_USE_BASIC_AUTH("http_use_basic_auth", "true"),
 
     USER("user", "default"),
 
@@ -32,27 +34,27 @@ public enum ClientConfigProperties {
      */
     HTTP_KEEP_ALIVE_TIMEOUT("http_keep_alive_timeout"),
 
-    USE_SERVER_TIMEZONE("use_server_time_zone"),
+    USE_SERVER_TIMEZONE("use_server_time_zone", "true"),
 
     USE_TIMEZONE("use_time_zone"),
 
     SERVER_VERSION("server_version"),
 
-    SERVER_TIMEZONE("server_time_zone"),
+    SERVER_TIMEZONE("server_time_zone", "UTC"),
 
-    ASYNC_OPERATIONS("async"),
+    ASYNC_OPERATIONS("async", "false"),
 
-    CONNECTION_TTL("connection_ttl"),
+    CONNECTION_TTL("connection_ttl", "-1"),
 
     CONNECTION_TIMEOUT("connection_timeout"),
 
-    CONNECTION_REUSE_STRATEGY("connection_reuse_strategy"),
+    CONNECTION_REUSE_STRATEGY("connection_reuse_strategy", String.valueOf(ConnectionReuseStrategy.FIFO)),
 
-    SOCKET_OPERATION_TIMEOUT("socket_timeout"),
+    SOCKET_OPERATION_TIMEOUT("socket_timeout", "0"),
 
-    SOCKET_RCVBUF_OPT("socket_rcvbuf"),
+    SOCKET_RCVBUF_OPT("socket_rcvbuf", "8196"),
 
-    SOCKET_SNDBUF_OPT("socket_sndbuf"),
+    SOCKET_SNDBUF_OPT("socket_sndbuf", "8196"),
 
     SOCKET_REUSEADDR_OPT("socket_reuseaddr"),
 
@@ -64,13 +66,13 @@ public enum ClientConfigProperties {
 
     DATABASE("database", "default"),
 
-    COMPRESS_SERVER_RESPONSE("compress"), // actually a server setting, but has client effect too
+    COMPRESS_SERVER_RESPONSE("compress", "true"), // actually a server setting, but has client effect too
 
-    COMPRESS_CLIENT_REQUEST("decompress"), // actually a server setting, but has client effect too
+    COMPRESS_CLIENT_REQUEST("decompress", "false"), // actually a server setting, but has client effect too
 
-    USE_HTTP_COMPRESSION("client.use_http_compression"),
+    USE_HTTP_COMPRESSION("client.use_http_compression", "false"),
 
-    COMPRESSION_LZ4_UNCOMPRESSED_BUF_SIZE("compression.lz4.uncompressed_buffer_size"),
+    COMPRESSION_LZ4_UNCOMPRESSED_BUF_SIZE("compression.lz4.uncompressed_buffer_size", String.valueOf(ClickHouseLZ4OutputStream.UNCOMPRESSED_BUFF_SIZE)),
 
     DISABLE_NATIVE_COMPRESSION("disable_native_compression", "false"),
 
@@ -84,7 +86,7 @@ public enum ClientConfigProperties {
 
     PROXY_PASSWORD("proxy_password"),
 
-    MAX_EXECUTION_TIME("max_execution_time"),
+    MAX_EXECUTION_TIME("max_execution_time", "0"),
 
     SSL_TRUST_STORE("trust_store"),
 
@@ -100,23 +102,25 @@ public enum ClientConfigProperties {
 
     SSL_CERTIFICATE("sslcert"),
 
-    RETRY_ON_FAILURE("retry"),
+    RETRY_ON_FAILURE("retry", "3"),
 
     INPUT_OUTPUT_FORMAT("format"),
 
-    MAX_THREADS_PER_CLIENT("max_threads_per_client"),
+    MAX_THREADS_PER_CLIENT("max_threads_per_client", "0"),
 
     QUERY_ID("query_id"), // actually a server setting, but has client effect too
 
-    CLIENT_NETWORK_BUFFER_SIZE("client_network_buffer_size", String.valueOf(Client.Builder.DEFAULT_BUFFER_SIZE)),
+    CLIENT_NETWORK_BUFFER_SIZE("client_network_buffer_size", "300000"),
 
     ACCESS_TOKEN("access_token"), SSL_AUTH("ssl_authentication"),
 
-    CONNECTION_POOL_ENABLED("connection_pool_enabled"),
+    CONNECTION_POOL_ENABLED("connection_pool_enabled", "true"),
 
-    CONNECTION_REQUEST_TIMEOUT("connection_request_timeout"),
+    CONNECTION_REQUEST_TIMEOUT("connection_request_timeout", "10000"),
 
-    CLIENT_RETRY_ON_FAILURE("client_retry_on_failures"),
+    CLIENT_RETRY_ON_FAILURE("client_retry_on_failures",
+            String.join(",", ClientFaultCause.NoHttpResponse.name(), ClientFaultCause.ConnectTimeout.name(),
+            ClientFaultCause.ConnectionRequestTimeout.name())),
 
     CLIENT_NAME("client_name"),
 
@@ -130,18 +134,19 @@ public enum ClientConfigProperties {
     /**
      * Indicates that data provided for write operation is compressed by application.
      */
-    APP_COMPRESSED_DATA("app_compressed_data"),
+    APP_COMPRESSED_DATA("app_compressed_data", "false"),
+
     /**
-     *
+     * Name of the group under which client metrics appear
      */
     METRICS_GROUP_NAME("metrics_name"),
     ;
 
-    private String key;
+    private final String key;
 
-    private String defaultValue;
+    private final String defaultValue;
 
-    private List<String> choices;
+    private final List<String> choices;
 
 
     ClientConfigProperties(String key) {

--- a/client-v2/src/test/java/com/clickhouse/client/ClientTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/ClientTests.java
@@ -197,7 +197,8 @@ public class ClientTests extends BaseIntegrationTest {
 
     @Test(groups = {"integration"})
     public void testDefaultSettings() {
-        try (Client client = new Client.Builder().setUsername("default").addEndpoint("http://localhost:8123").build()) {
+        try (Client client = new Client.Builder().setUsername("default").setPassword("secret")
+                .addEndpoint("http://localhost:8123").build()) {
             Map<String, String> config = client.getConfiguration();
             for (ClientConfigProperties p : ClientConfigProperties.values()) {
                 if (p.getDefaultValue() != null) {
@@ -210,6 +211,7 @@ public class ClientTests extends BaseIntegrationTest {
 
         try (Client client = new Client.Builder()
                 .setUsername("default")
+                .setPassword("secret")
                 .addEndpoint("http://localhost:8123")
                 .setDefaultDatabase("mydb")
                 .setExecutionTimeout(10, MILLIS)
@@ -268,6 +270,7 @@ public class ClientTests extends BaseIntegrationTest {
     public void testWithOldDefaults() {
         try (Client client = new Client.Builder()
                 .setUsername("default")
+                .setPassword("seceret")
                 .addEndpoint("http://localhost:8123")
                 .setDefaultDatabase("default")
                 .setExecutionTimeout(0, MILLIS)

--- a/client-v2/src/test/java/com/clickhouse/client/ClientTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/ClientTests.java
@@ -3,7 +3,11 @@ package com.clickhouse.client;
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.client.api.ClientException;
+import com.clickhouse.client.api.ClientFaultCause;
+import com.clickhouse.client.api.ConnectionReuseStrategy;
 import com.clickhouse.client.api.enums.Protocol;
+import com.clickhouse.client.api.internal.ClickHouseLZ4OutputStream;
+import com.clickhouse.client.api.metadata.DefaultColumnToMethodMatchingStrategy;
 import com.clickhouse.client.api.query.GenericRecord;
 import com.clickhouse.client.api.query.QueryResponse;
 import com.clickhouse.client.api.query.QuerySettings;
@@ -23,6 +27,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import static java.time.temporal.ChronoUnit.MILLIS;
+import static java.time.temporal.ChronoUnit.SECONDS;
 
 public class ClientTests extends BaseIntegrationTest {
     private static final Logger LOGGER = LoggerFactory.getLogger(ClientTests.class);
@@ -185,6 +192,118 @@ public class ClientTests extends BaseIntegrationTest {
     public void testDisableNative() {
         try (Client client = newClient().disableNativeCompression(true).build()) {
             Assert.assertTrue(client.toString().indexOf("JavaUnsafe") != -1);
+        }
+    }
+
+    @Test(groups = {"integration"})
+    public void testDefaultSettings() {
+        try (Client client = new Client.Builder().setUsername("default").addEndpoint("http://localhost:8123").build()) {
+            Map<String, String> config = client.getConfiguration();
+            for (ClientConfigProperties p : ClientConfigProperties.values()) {
+                if (p.getDefaultValue() != null) {
+                    Assert.assertTrue(config.containsKey(p.getKey()), "Default value should be set for " + p.getKey());
+                    Assert.assertEquals(config.get(p.getKey()), p.getDefaultValue(), "Default value doesn't match");
+                }
+            }
+            Assert.assertEquals(config.size(), 27); // to check everything is set. Increment when new added.
+        }
+
+        try (Client client = new Client.Builder()
+                .setUsername("default")
+                .addEndpoint("http://localhost:8123")
+                .setDefaultDatabase("mydb")
+                .setExecutionTimeout(10, MILLIS)
+                .setLZ4UncompressedBufferSize(300_000)
+                .disableNativeCompression(true)
+                .useServerTimeZone(false)
+                .setServerTimeZone("America/Los_Angeles")
+                .useTimeZone("America/Los_Angeles")
+                .useAsyncRequests(true)
+                .setMaxConnections(330)
+                .setConnectionRequestTimeout(20, SECONDS)
+                .setConnectionReuseStrategy(ConnectionReuseStrategy.LIFO)
+                .enableConnectionPool(false)
+                .setConnectionTTL(30, SECONDS)
+                .retryOnFailures(ClientFaultCause.NoHttpResponse)
+                .setClientNetworkBufferSize(500_000)
+                .setMaxRetries(10)
+                .useHTTPBasicAuth(false)
+                .compressClientRequest(true)
+                .compressServerResponse(false)
+                .useHttpCompression(true)
+                .appCompressedData(true)
+                .setSocketTimeout(20, SECONDS)
+                .setSocketRcvbuf(100000)
+                .setSocketSndbuf(100000)
+                .build()) {
+            Map<String, String> config = client.getConfiguration();
+            Assert.assertEquals(config.size(), 28); // to check everything is set. Increment when new added.
+            Assert.assertEquals(config.get(ClientConfigProperties.DATABASE.getKey()), "mydb");
+            Assert.assertEquals(config.get(ClientConfigProperties.MAX_EXECUTION_TIME.getKey()), "10");
+            Assert.assertEquals(config.get(ClientConfigProperties.COMPRESSION_LZ4_UNCOMPRESSED_BUF_SIZE.getKey()), "300000");
+            Assert.assertEquals(config.get(ClientConfigProperties.DISABLE_NATIVE_COMPRESSION.getKey()), "true");
+            Assert.assertEquals(config.get(ClientConfigProperties.USE_SERVER_TIMEZONE.getKey()), "false");
+            Assert.assertEquals(config.get(ClientConfigProperties.SERVER_TIMEZONE.getKey()), "America/Los_Angeles");
+            Assert.assertEquals(config.get(ClientConfigProperties.ASYNC_OPERATIONS.getKey()), "true");
+            Assert.assertEquals(config.get(ClientConfigProperties.HTTP_MAX_OPEN_CONNECTIONS.getKey()), "330");
+            Assert.assertEquals(config.get(ClientConfigProperties.CONNECTION_REQUEST_TIMEOUT.getKey()), "20000");
+            Assert.assertEquals(config.get(ClientConfigProperties.CONNECTION_REUSE_STRATEGY.getKey()), "LIFO");
+            Assert.assertEquals(config.get(ClientConfigProperties.CONNECTION_POOL_ENABLED.getKey()), "false");
+            Assert.assertEquals(config.get(ClientConfigProperties.CONNECTION_TTL.getKey()), "30000");
+            Assert.assertEquals(config.get(ClientConfigProperties.CLIENT_RETRY_ON_FAILURE.getKey()), "NoHttpResponse");
+            Assert.assertEquals(config.get(ClientConfigProperties.CLIENT_NETWORK_BUFFER_SIZE.getKey()), "500000");
+            Assert.assertEquals(config.get(ClientConfigProperties.RETRY_ON_FAILURE.getKey()), "10");
+            Assert.assertEquals(config.get(ClientConfigProperties.HTTP_USE_BASIC_AUTH.getKey()), "false");
+            Assert.assertEquals(config.get(ClientConfigProperties.COMPRESS_CLIENT_REQUEST.getKey()), "true");
+            Assert.assertEquals(config.get(ClientConfigProperties.COMPRESS_SERVER_RESPONSE.getKey()), "false");
+            Assert.assertEquals(config.get(ClientConfigProperties.USE_HTTP_COMPRESSION.getKey()), "true");
+            Assert.assertEquals(config.get(ClientConfigProperties.APP_COMPRESSED_DATA.getKey()), "true");
+            Assert.assertEquals(config.get(ClientConfigProperties.SOCKET_OPERATION_TIMEOUT.getKey()), "20000");
+            Assert.assertEquals(config.get(ClientConfigProperties.SOCKET_RCVBUF_OPT.getKey()), "100000");
+            Assert.assertEquals(config.get(ClientConfigProperties.SOCKET_SNDBUF_OPT.getKey()), "100000");
+        }
+    }
+
+    @Test(groups = {"integration"})
+    public void testWithOldDefaults() {
+        try (Client client = new Client.Builder()
+                .setUsername("default")
+                .addEndpoint("http://localhost:8123")
+                .setDefaultDatabase("default")
+                .setExecutionTimeout(0, MILLIS)
+                .setLZ4UncompressedBufferSize(ClickHouseLZ4OutputStream.UNCOMPRESSED_BUFF_SIZE)
+                .disableNativeCompression(false)
+                .useServerTimeZone(true)
+                .setServerTimeZone("UTC")
+                .useAsyncRequests(false)
+                .setMaxConnections(10)
+                .setConnectionRequestTimeout(10, SECONDS)
+                .setConnectionReuseStrategy(ConnectionReuseStrategy.FIFO)
+                .enableConnectionPool(true)
+                .setConnectionTTL(-1, MILLIS)
+                .retryOnFailures(ClientFaultCause.NoHttpResponse, ClientFaultCause.ConnectTimeout,
+                        ClientFaultCause.ConnectionRequestTimeout)
+                .setClientNetworkBufferSize(300_000)
+                .setMaxRetries(3)
+                .allowBinaryReaderToReuseBuffers(false)
+                .columnToMethodMatchingStrategy(DefaultColumnToMethodMatchingStrategy.INSTANCE)
+                .useHTTPBasicAuth(true)
+                .compressClientRequest(false)
+                .compressServerResponse(true)
+                .useHttpCompression(false)
+                .appCompressedData(false)
+                .setSocketTimeout(0, SECONDS)
+                .setSocketRcvbuf(8196)
+                .setSocketSndbuf(8196)
+                .build()) {
+            Map<String, String> config = client.getConfiguration();
+            for (ClientConfigProperties p : ClientConfigProperties.values()) {
+                if (p.getDefaultValue() != null) {
+                    Assert.assertTrue(config.containsKey(p.getKey()), "Default value should be set for " + p.getKey());
+                    Assert.assertEquals(config.get(p.getKey()), p.getDefaultValue(), "Default value doesn't match");
+                }
+            }
+            Assert.assertEquals(config.size(), 27); // to check everything is set. Increment when new added.
         }
     }
 

--- a/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
@@ -90,7 +90,6 @@ public class HttpTransportTests extends BaseIntegrationTest {
                 .addEndpoint(server.getBaseUri())
                 .setUsername("default")
                 .setPassword(getPassword())
-                .useNewImplementation(true)
                 .addProxy(ProxyType.HTTP, "localhost", proxyPort);
         if (connectionTtl != null) {
             clientBuilder.setConnectionTTL(connectionTtl, ChronoUnit.MILLIS);
@@ -180,7 +179,6 @@ public class HttpTransportTests extends BaseIntegrationTest {
                 .setUsername("default")
                 .setPassword(getPassword())
                 .retryOnFailures(ClientFaultCause.None)
-                .useNewImplementation(true)
                 .setMaxConnections(1)
                 .setOption(ClickHouseClientOption.ASYNC.getKey(), "true")
                 .setSocketTimeout(10000, ChronoUnit.MILLIS)
@@ -215,7 +213,6 @@ public class HttpTransportTests extends BaseIntegrationTest {
                 .addEndpoint(server.getBaseUri())
                 .setUsername("default")
                 .setPassword(getPassword())
-                .useNewImplementation(true)
                 .setConnectionReuseStrategy(ConnectionReuseStrategy.LIFO)
                 .build()) {
 
@@ -286,7 +283,6 @@ public class HttpTransportTests extends BaseIntegrationTest {
                 .addEndpoint(Protocol.HTTP, "localhost", faultyServer.port(), false)
                 .setUsername("default")
                 .setPassword(ClickHouseServerForTest.getPassword())
-                .useNewImplementation(true) // because of the internal differences
                 .compressClientRequest(false)
                 .setMaxRetries(maxRetries)
                 .build();
@@ -438,7 +434,6 @@ public class HttpTransportTests extends BaseIntegrationTest {
                 .setUsername("default")
                 .setPassword(ClickHouseServerForTest.getPassword())
                 .compressServerResponse(false)
-                .useNewImplementation(true)
                 .build()) {
             mockServer.addStubMapping(WireMock.post(WireMock.anyUrl())
                     .willReturn(WireMock.aResponse()
@@ -537,7 +532,6 @@ public class HttpTransportTests extends BaseIntegrationTest {
         try (Client client = new Client.Builder().addEndpoint(Protocol.HTTP, "localhost", mockServer.port(), false)
                 .setUsername("default")
                 .setPassword(ClickHouseServerForTest.getPassword())
-                .useNewImplementation(true)
                 .httpHeader("X-ClickHouse-Test", "default_value")
                 .httpHeader("X-ClickHouse-Test-2", Arrays.asList("default_value1", "default_value2"))
                 .httpHeader("X-ClickHouse-Test-3", Arrays.asList("default_value1", "default_value2"))
@@ -581,7 +575,6 @@ public class HttpTransportTests extends BaseIntegrationTest {
         try (Client client = new Client.Builder().addEndpoint(Protocol.HTTP, "localhost", mockServer.port(), false)
                 .setUsername("default")
                 .setPassword(ClickHouseServerForTest.getPassword())
-                .useNewImplementation(true)
                 .serverSetting("max_threads", "10")
                 .serverSetting("async_insert", "1")
                 .serverSetting("roles", Arrays.asList("role1", "role2"))
@@ -779,7 +772,6 @@ public class HttpTransportTests extends BaseIntegrationTest {
         try (Client client = new Client.Builder().addEndpoint(Protocol.HTTP, "localhost",server.getPort(), false)
                 .setUsername("default")
                 .setPassword(ClickHouseServerForTest.getPassword())
-                .useNewImplementation(true)
                 .build()) {
 
             try (CommandResponse resp = client.execute("DROP TABLE IF EXISTS test_omm_table").get()) {
@@ -1051,7 +1043,6 @@ public class HttpTransportTests extends BaseIntegrationTest {
         try (Client client = new Client.Builder().addEndpoint(Protocol.HTTP, "localhost", proxyPort, false)
                 .setUsername("default")
                 .setPassword(ClickHouseServerForTest.getPassword())
-                .useNewImplementation(true)
                 .build()) {
             int startTime = (int) System.currentTimeMillis();
             try {
@@ -1126,7 +1117,6 @@ public class HttpTransportTests extends BaseIntegrationTest {
                 .setPassword(ClickHouseServerForTest.getPassword())
                 .compressClientRequest(false)
                 .setDefaultDatabase(ClickHouseServerForTest.getDatabase())
-                .serverSetting(ServerSettings.WAIT_END_OF_QUERY, "1")
-                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "true").equals("true"));
+                .serverSetting(ServerSettings.WAIT_END_OF_QUERY, "1");
     }
 }

--- a/client-v2/src/test/java/com/clickhouse/client/ProxyTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/ProxyTests.java
@@ -207,8 +207,6 @@ public class ProxyTests extends BaseIntegrationTest{
                 .addEndpoint(Protocol.HTTP, "clickhouse", 8123, false)
                 .setUsername("default")
                 .setPassword(ClickHouseServerForTest.getPassword())
-                .useNewImplementation(onlyNewImplementation ? onlyNewImplementation :
-                        System.getProperty("client.tests.useNewImplementation", "true").equals("true"))
                 .addProxy(ProxyType.HTTP, "localhost", proxyPort);
     }
 

--- a/client-v2/src/test/java/com/clickhouse/client/command/CommandTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/command/CommandTests.java
@@ -59,7 +59,6 @@ public class CommandTests extends BaseIntegrationTest {
                 .setPassword(ClickHouseServerForTest.getPassword())
                 .compressClientRequest(false)
                 .setDefaultDatabase(ClickHouseServerForTest.getDatabase())
-                .serverSetting(ServerSettings.WAIT_END_OF_QUERY, "1")
-                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "true").equals("true"));
+                .serverSetting(ServerSettings.WAIT_END_OF_QUERY, "1");
     }
 }

--- a/client-v2/src/test/java/com/clickhouse/client/metadata/MetadataTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/metadata/MetadataTests.java
@@ -114,7 +114,6 @@ public class MetadataTests extends BaseIntegrationTest {
                 .setUsername("default")
                 .setPassword(ClickHouseServerForTest.getPassword())
                 .setDefaultDatabase(ClickHouseServerForTest.getDatabase())
-                .serverSetting(ServerSettings.WAIT_END_OF_QUERY, "1")
-                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "true").equals("true"));
+                .serverSetting(ServerSettings.WAIT_END_OF_QUERY, "1");
     }
 }

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -2045,8 +2045,7 @@ public class QueryTests extends BaseIntegrationTest {
                 .allowBinaryReaderToReuseBuffers(usePreallocatedBuffers)
                 .setDefaultDatabase(ClickHouseServerForTest.getDatabase())
                 .serverSetting(ServerSettings.WAIT_ASYNC_INSERT, "1")
-                .serverSetting(ServerSettings.ASYNC_INSERT, "0")
-                .useNewImplementation(System.getProperty("client.tests.useNewImplementation", "true").equals("true"));
+                .serverSetting(ServerSettings.ASYNC_INSERT, "0");
     }
 
     @Test(groups = {"integration"})

--- a/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/BigDatasetExamples.java
+++ b/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/BigDatasetExamples.java
@@ -40,7 +40,6 @@ public class BigDatasetExamples {
                 .compressServerResponse(false)
                 .compressClientRequest(false)
                 .setLZ4UncompressedBufferSize(1048576)
-                .useNewImplementation(true)
                 // when network buffer and socket buffer are the same size - it is less IO calls and more efficient
                 .setSocketRcvbuf(1_000_000)
                 .setClientNetworkBufferSize(1_000_000)

--- a/examples/demo-kotlin-service/src/main/kotlin/com/clickhouse/examples/service/Database.kt
+++ b/examples/demo-kotlin-service/src/main/kotlin/com/clickhouse/examples/service/Database.kt
@@ -13,7 +13,6 @@ object Database {
             .addEndpoint(dbUrl)
             .setUsername(dbUser)
             .setPassword(dbPassword)
-            .useNewImplementation(true)
             .build()
     }
 


### PR DESCRIPTION
## Summary

- moves setting defaults the the client builder constructor 
- retires `Client.Builder#useNewImplementation()` 

Closes https://github.com/ClickHouse/clickhouse-java/issues/2269

## Checklist
Delete items not relevant to your PR:
- [x] Closes #<issue ref>
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
