### PR TITLE
[jdbc-v2] Fixes arguments with casts

### DIFF
--- a/jdbc-v2/src/main/antlr4/com/clickhouse/jdbc/internal/ClickHouseLexer.g4
+++ b/jdbc-v2/src/main/antlr4/com/clickhouse/jdbc/internal/ClickHouseLexer.g4
@@ -223,6 +223,8 @@ OCTAL_LITERAL       : '0' OCT_DIGIT+;
 DECIMAL_LITERAL     : DEC_DIGIT+;
 HEXADECIMAL_LITERAL : '0' X HEX_DIGIT+;
 
+CAST_OP   : '::';
+
 // It's important that quote-symbol is a single character.
 STRING_LITERAL:
     QUOTE_SINGLE (~([\\']) | (BACKSLASH .) | (QUOTE_SINGLE QUOTE_SINGLE))* QUOTE_SINGLE

--- a/jdbc-v2/src/main/antlr4/com/clickhouse/jdbc/internal/ClickHouseParser.g4
+++ b/jdbc-v2/src/main/antlr4/com/clickhouse/jdbc/internal/ClickHouseParser.g4
@@ -649,6 +649,7 @@ columnExpr
     | LBRACKET columnExprList? RBRACKET                            # ColumnExprArray
     | columnIdentifier                                             # ColumnExprIdentifier
     | QUERY                                                        # ColumnExprParam
+    | QUERY CAST_OP identifier                                     # ColumnExprParamWithCast
     ;
 
 columnArgList

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/ParsedPreparedStatement.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/ParsedPreparedStatement.java
@@ -168,6 +168,11 @@ public class ParsedPreparedStatement extends ClickHouseParserBaseListener {
     }
 
     @Override
+    public void enterColumnExprParamWithCast(ClickHouseParser.ColumnExprParamWithCastContext ctx) {
+        appendParameter(ctx.start.getStartIndex());
+    }
+
+    @Override
     public void visitErrorNode(ErrorNode node) {
         setHasErrors(true);
     }

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/PreparedStatementTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/PreparedStatementTest.java
@@ -3,6 +3,7 @@ package com.clickhouse.jdbc;
 import com.clickhouse.data.ClickHouseVersion;
 import com.clickhouse.jdbc.internal.DriverProperties;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.testcontainers.shaded.com.fasterxml.jackson.databind.deser.std.UUIDDeserializer;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Ignore;
@@ -1048,6 +1049,29 @@ public class PreparedStatementTest extends JdbcIntegrationTest {
                 }
 
                 assertEquals(count, 2);
+            }
+        }
+    }
+
+    @Test
+    public void testParamWithCast() throws Exception {
+        final String sql = " SELECT ?::integer, '?::integer', 123, ?:: UUID, ?";
+        try (Connection conn = getJdbcConnection()) {
+            try (PreparedStatement stmt = conn.prepareStatement(sql)) {
+                stmt.setString(1, "1000");
+                UUID uuid = UUID.randomUUID();
+                stmt.setString(1, "1000");
+                stmt.setString(2, uuid.toString());
+                stmt.setInt(3, 3003001);
+
+                try (ResultSet rs = stmt.executeQuery()) {
+                    assertTrue(rs.next());
+                    Assert.assertEquals(rs.getInt(1), 1000);
+                    Assert.assertEquals(rs.getString(2), "?::integer");
+                    Assert.assertEquals(rs.getInt(3), 123);
+                    Assert.assertEquals(rs.getString(4), uuid.toString());
+                    Assert.assertEquals(rs.getInt(5), 3003001);
+                }
             }
         }
     }

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/SqlParserTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/SqlParserTest.java
@@ -1,6 +1,7 @@
 package com.clickhouse.jdbc.internal;
 
 
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -192,5 +193,21 @@ public class SqlParserTest {
         for (int i = 0; i < inStr.length; i++) {
             assertEquals(SqlParser.escapeQuotes(inStr[i]), outStr[i]);
         }
+    }
+
+    @Test
+    public void testStmtWithCasts() {
+        String sql = "SELECT ?::integer, ?, '?::integer' FROM table WHERE v = ?::integer"; // CAST(?, INTEGER)
+        SqlParser parser = new SqlParser();
+        ParsedPreparedStatement stmt = parser.parsePreparedStatement(sql);
+        Assert.assertEquals(stmt.getArgCount(), 3);
+    }
+
+    @Test
+    public void testStmtWithFunction() {
+        String sql = "SELECT `parseDateTimeBestEffort`(?, ?) as dt FROM table WHERE v > `parseDateTimeBestEffort`(?, ?)  ";
+        SqlParser parser = new SqlParser();
+        ParsedPreparedStatement stmt = parser.parsePreparedStatement(sql);
+        Assert.assertEquals(stmt.getArgCount(), 4);
     }
 }


### PR DESCRIPTION
## Summary
Adds grammar for cast operation: `?:: integer` or `?::UUID` 

Closes  https://github.com/ClickHouse/clickhouse-java/issues/2422

## Checklist
Delete items not relevant to your PR:
- [x] Closes #<issue ref>
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
