### PR TITLE
[jdbc-v2] Fix parser grammar

### DIFF
--- a/jdbc-v2/src/main/antlr4/com/clickhouse/jdbc/internal/ClickHouseParser.g4
+++ b/jdbc-v2/src/main/antlr4/com/clickhouse/jdbc/internal/ClickHouseParser.g4
@@ -40,7 +40,7 @@ query
 
 // CTE statement
 ctes
-    : WITH namedQuery (',' namedQuery)*
+    : LPAREN? WITH namedQuery (',' namedQuery)* RPAREN?
     ;
 
 namedQuery

--- a/jdbc-v2/src/main/antlr4/com/clickhouse/jdbc/internal/ClickHouseParser.g4
+++ b/jdbc-v2/src/main/antlr4/com/clickhouse/jdbc/internal/ClickHouseParser.g4
@@ -644,7 +644,7 @@ columnExpr
     | CAST LPAREN columnExpr AS columnTypeExpr RPAREN                                    # ColumnExprCast
     | DATE STRING_LITERAL                                                                # ColumnExprDate
     | EXTRACT LPAREN interval FROM columnExpr RPAREN                                     # ColumnExprExtract
-    | INTERVAL columnExpr interval                                                       # ColumnExprInterval
+    | INTERVAL columnExpr interval?                                                      # ColumnExprInterval
     | SUBSTRING LPAREN columnExpr FROM columnExpr (FOR columnExpr)? RPAREN               # ColumnExprSubstring
     | TIMESTAMP STRING_LITERAL                                                           # ColumnExprTimestamp
     | TRIM LPAREN (BOTH | LEADING | TRAILING) STRING_LITERAL FROM columnExpr RPAREN      # ColumnExprTrim

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/ParsedPreparedStatement.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/ParsedPreparedStatement.java
@@ -166,6 +166,7 @@ public class ParsedPreparedStatement extends ClickHouseParserBaseListener {
         appendParameter(ctx.start.getStartIndex());
     }
 
+
     @Override
     public void enterColumnExprParamWithCast(ClickHouseParser.ColumnExprParamWithCastContext ctx) {
         appendParameter(ctx.start.getStartIndex());

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/SqlParserTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/SqlParserTest.java
@@ -241,4 +241,24 @@ public class SqlParserTest {
                 {"CREATE USER 'user01' IDENTIFIED BY 'qwerty'"},
         };
     }
+
+    @Test(dataProvider = "testCTEStmtsDP")
+    public void testCTEStatements(String sql, int args) {
+        SqlParser parser = new SqlParser();
+        ParsedPreparedStatement stmt = parser.parsePreparedStatement(sql);
+        Assert.assertFalse(stmt.isHasErrors());
+        Assert.assertEquals(stmt.getArgCount(), args);
+    }
+
+    @DataProvider
+    public static Object[][] testCTEStmtsDP() {
+        return new Object[][] {
+                {"with ? as a, ? as b select a, b; -- two CTEs of the first form", 2},
+                {"with a as (select ?), b as (select 2) select * from a, b; -- two CTEs of the second form", 1},
+                {"(with a as (select ?) select * from a);", 1},
+                {"with a as (select 1) select * from a; ", 0},
+                {"(with ? as a select a);", 1},
+
+        };
+    }
 }

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/SqlParserTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/SqlParserTest.java
@@ -261,4 +261,20 @@ public class SqlParserTest {
 
         };
     }
+
+    @Test(dataProvider = "testMiscStmtDp")
+    public void testMiscStatements(String sql, int args) {
+        SqlParser parser = new SqlParser();
+        ParsedPreparedStatement stmt = parser.parsePreparedStatement(sql);
+        Assert.assertFalse(stmt.isHasErrors());
+        Assert.assertEquals(stmt.getArgCount(), args);
+    }
+
+    @DataProvider
+    public Object[][] testMiscStmtDp() {
+        return new Object[][] {
+            {"SELECT INTERVAL '1 day'", 0},
+            {"SELECT INTERVAL 1 day", 0},
+        };
+    }
 }


### PR DESCRIPTION
## Summary
Fixes parser grammar for: 
- `SELECT INTERVAL '1 day'` - when interval is define like literal 
- `( WITH .... ) ` - wrapped CTEs 

Closes https://github.com/ClickHouse/clickhouse-java/issues/2431
Closes https://github.com/ClickHouse/clickhouse-java/issues/2429
## Checklist
Delete items not relevant to your PR:
- [x] Closes #<issue ref>
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
