### PR TITLE
Adds CTE to FROM clause

### DIFF
--- a/jdbc-v2/src/main/antlr4/com/clickhouse/jdbc/internal/ClickHouseParser.g4
+++ b/jdbc-v2/src/main/antlr4/com/clickhouse/jdbc/internal/ClickHouseParser.g4
@@ -427,6 +427,7 @@ topClause
 fromClause
     : FROM joinExpr
     | FROM identifier LPAREN QUERY RPAREN
+    | FROM ctes
     ;
 
 arrayJoinClause

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/SqlParserTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/SqlParserTest.java
@@ -264,6 +264,7 @@ public class SqlParserTest {
                 {"(with a as (select ?) select * from a);", 1},
                 {"with a as (select 1) select * from a; ", 0},
                 {"(with ? as a select a);", 1},
+                {"select * from ( with x as ( select 9 ) select * from x );", 0}
 
         };
     }


### PR DESCRIPTION
## Summary
Adds CTE clause to FROM clause to parse `select * from ( with x as ( select 9 ) select * from x )` 
Closes https://github.com/ClickHouse/clickhouse-java/issues/2442
## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
