### PR TITLE
Fix a small bug with server metrics parsing + a few code cleanups.

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/ProcessParser.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/ProcessParser.java
@@ -22,7 +22,7 @@ public class ProcessParser {
     };
 
     public static void parseSummary(String text, OperationMetrics metrics) {
-        Map<String, Integer> map = parse(text == null ? "{}" : text);
+        Map<String, Long> map = parse(text == null ? "{}" : text);
 
         for (ServerMetrics m : ServerMetrics.values()) {
             metrics.updateMetric(m, -1);
@@ -30,7 +30,7 @@ public class ProcessParser {
 
         for (int i = 0; i < SUMMARY_FIELDS.length; i++) {
             String field = SUMMARY_FIELDS[i];
-            Integer value = map.get(field);
+            Long value = map.get(field);
             if (value != null) {
                 metrics.updateMetric(SUMMARY_METRICS[i], value);
             }
@@ -38,7 +38,7 @@ public class ProcessParser {
     }
 
 
-    public static Map<String, Integer> parse(String json) {
+    public static Map<String, Long> parse(String json) {
         if (json == null) {
             throw new IllegalArgumentException("json is null");
         }
@@ -50,7 +50,7 @@ public class ProcessParser {
             throw new IllegalArgumentException("JSON must start with '{' and end with '}'");
         }
 
-        Map<String, Integer> result = new HashMap<>();
+        Map<String, Long> result = new HashMap<>();
 
         String content = json.substring(1, json.length() - 1).trim();
         if (content.isEmpty()) {
@@ -79,7 +79,7 @@ public class ProcessParser {
             }
 
             try {
-                int value = Integer.parseInt(valueStr);
+                long value = Long.parseLong(valueStr);
                 result.put(key, value);
             } catch (NumberFormatException e) {
                 // ignore error

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/Gauge.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/Gauge.java
@@ -6,8 +6,8 @@ public class Gauge implements Metric {
 
     private volatile long value;
 
-    public Gauge(long readRows) {
-        this.value = readRows;
+    public Gauge(long value) {
+        this.value = value;
     }
 
     public void set(long value) {

--- a/client-v2/src/main/java/com/clickhouse/client/api/metrics/ClientMetrics.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/metrics/ClientMetrics.java
@@ -3,12 +3,12 @@ package com.clickhouse.client.api.metrics;
 public enum ClientMetrics {
 
     /**
-     * Operation duration in nanoseconds.
+     * Operation duration in milliseconds.
      */
     OP_DURATION("client.opDuration"),
 
     /**
-     * Duration of the operation serialization step in nanoseconds.
+     * Duration of the operation serialization step in milliseconds.
      */
     OP_SERIALIZATION("client.opSerialization");
 


### PR DESCRIPTION
## Summary
- Fix bug with incorrect usage of Integer where Long is expected.
Metrics returned from the server can overflow Integer e.g. when elapsed time is higher than 2 seconds (it's in nanoseconds).
- Use generic name instead of specific metric name.
- Update misleading Javadocs for client side metrics.
Stopwatch metrics always convert nanoseconds to milliseconds when getLong() is called on them.