### PR TITLE
[jdbc-v2] Adds default port and restricts multiple endpoints

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/JdbcConfiguration.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/JdbcConfiguration.java
@@ -2,6 +2,7 @@ package com.clickhouse.jdbc.internal;
 
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ClientConfigProperties;
+import com.clickhouse.client.api.http.ClickHouseHttpProto;
 import com.clickhouse.jdbc.Driver;
 import com.google.common.collect.ImmutableMap;
 
@@ -128,7 +129,14 @@ public class JdbcConfiguration {
             : url;
         try {
             URI tmp = URI.create(adjustedURL);
-            return tmp.toASCIIString();
+            String asciiString = tmp.toASCIIString();
+            if (tmp.getPort() < 0) {
+                String port = ssl || adjustedURL.startsWith("https")
+                    ? ":" + ClickHouseHttpProto.DEFAULT_HTTPS_PORT
+                    : ":" + ClickHouseHttpProto.DEFAULT_HTTP_PORT;
+                asciiString += port;
+            }
+            return asciiString;
         } catch (IllegalArgumentException iae) {
             throw new SQLException("Failed to parse URL '" + url + "'", iae);
         }
@@ -169,6 +177,9 @@ public class JdbcConfiguration {
         if (uri.getAuthority() == null) {
             throw new SQLException(
                 "Invalid authority part JDBC URL '" + url + "'");
+        }
+        if (uri.getAuthority().contains(",")) {
+            throw new SQLException("Multiple endpoints not supported");
         }
         properties.put(PARSE_URL_CONN_URL_PROP, uri.getScheme() + "://"
             + uri.getRawAuthority()); // will be parsed again later

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/JdbcConfigurationTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/JdbcConfigurationTest.java
@@ -1,6 +1,8 @@
 package com.clickhouse.jdbc.internal;
 
+import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ClientConfigProperties;
+
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -23,15 +25,17 @@ public class JdbcConfigurationTest {
         new JdbcConfigurationTestData("jdbc:clickhouse://localhost"),
         new JdbcConfigurationTestData("jdbc:clickhouse:http://localhost"),
         new JdbcConfigurationTestData("jdbc:clickhouse:https://localhost")
-            .withExpectedConnectionURL("https://localhost"),
+            .withExpectedConnectionURL("https://localhost:8443"),
+        new JdbcConfigurationTestData("jdbc:clickhouse:https://localhost:8123")
+            .withExpectedConnectionURL("https://localhost:8123"),
         new JdbcConfigurationTestData("jdbc:clickhouse://localhost")
             .withAdditionalConnectionParameters(
                 Map.of(JdbcConfiguration.USE_SSL_PROP, "true"))
-            .withExpectedConnectionURL("https://localhost")
+            .withExpectedConnectionURL("https://localhost:8443")
             .withAdditionalExpectedClientProperties(
                 Map.of("ssl", "true")),
         new JdbcConfigurationTestData("jdbc:clickhouse://[::1]")
-            .withExpectedConnectionURL("http://[::1]"),
+            .withExpectedConnectionURL("http://[::1]:8123"),
         new JdbcConfigurationTestData("jdbc:clickhouse://[::1]:8123")
             .withExpectedConnectionURL("http://[::1]:8123"),
         new JdbcConfigurationTestData("jdbc:clickhouse://localhost:8443")
@@ -111,14 +115,22 @@ public class JdbcConfigurationTest {
                     ))
     };
 
+    @SuppressWarnings("deprecation")
     @Test(dataProvider = "validURLTestData")
     public void testParseURLValid(String jdbcURL, Properties properties,
-        String connectionUrl, Map<String, String> expectedClientProps)
+        String connectionURL, Map<String, String> expectedClientProps)
             throws Exception
     {
         JdbcConfiguration configuration = new JdbcConfiguration(jdbcURL, properties);
-        assertEquals(configuration.getConnectionUrl(), connectionUrl);
+        assertEquals(configuration.getConnectionUrl(), connectionURL);
         assertEquals(configuration.clientProperties, expectedClientProps);
+        Client.Builder bob = new Client.Builder();
+        configuration.applyClientProperties(bob);
+        Client client = bob.build();
+        assertEquals(client.getEndpoints().size(), 1);
+        assertEquals(
+            client.getEndpoints().iterator().next(),
+            connectionURL);
     }
 
     @Test(dataProvider = "invalidURLs")
@@ -198,6 +210,8 @@ public class JdbcConfigurationTest {
             { "jdbc:clickhouse://foo.bar?x&y=z" },
             { "jdbc:clickhouse://foo.bar?x==&y=z" },
             { "jdbc:clickhouse://localhost?☺=value1" },
+            { "jdbc:clickhouse://foo,bar" },
+            { "jdbc:clickhouse://foo,bar.com:8123" },
         };
     }
 
@@ -210,7 +224,7 @@ public class JdbcConfigurationTest {
             Map.of( "user", "default", "password", "");
 
         private static final String DEFAULT_EXPECTED_CONNECTION_URL =
-            "http://localhost";
+            "http://localhost:8123";
 
         private final String url;
         private final Properties connectionParameters;

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/JdbcConfigurationTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/JdbcConfigurationTest.java
@@ -210,6 +210,7 @@ public class JdbcConfigurationTest {
             { "jdbc:clickhouse://foo.bar?x&y=z" },
             { "jdbc:clickhouse://foo.bar?x==&y=z" },
             { "jdbc:clickhouse://localhost?☺=value1" },
+            // multiple endpoints are invalid
             { "jdbc:clickhouse://foo,bar" },
             { "jdbc:clickhouse://foo,bar.com:8123" },
         };


### PR DESCRIPTION
## Summary

This PR ensures that valid JDBC URLs are also accepted as endpoints by Client.

JDBC URLs which contain multiple endpoints are considered _invalid_

This is an alternative PR to #2488 which supports the use of multiple endpoints in JDBC URLs.

## Checklist

- [ ✅  ] Unit and integration tests covering the common scenarios were added

