### PR TITLE
Implement Connection#isValid

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/ConnectionImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/ConnectionImpl.java
@@ -495,7 +495,9 @@ public class ConnectionImpl implements Connection, JdbcV2Wrapper {
         if (isClosed()) {
             return false;
         }
-        return client.ping(Duration.ofSeconds(timeout).toMillis());
+        return timeout == 0
+            ? client.ping()
+            : client.ping(Duration.ofSeconds(timeout).toMillis());
     }
 
     @Override

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/ConnectionImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/ConnectionImpl.java
@@ -36,6 +36,7 @@ import java.sql.SQLXML;
 import java.sql.Savepoint;
 import java.sql.Statement;
 import java.sql.Struct;
+import java.time.Duration;
 import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Collections;
@@ -494,7 +495,7 @@ public class ConnectionImpl implements Connection, JdbcV2Wrapper {
         if (isClosed()) {
             return false;
         }
-        return client.ping(timeout * 1_000);
+        return client.ping(Duration.ofSeconds(timeout).toMillis());
     }
 
     @Override

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/ConnectionImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/ConnectionImpl.java
@@ -15,6 +15,7 @@ import com.clickhouse.jdbc.internal.JdbcUtils;
 import com.clickhouse.jdbc.internal.ParsedPreparedStatement;
 import com.clickhouse.jdbc.internal.SqlParser;
 import com.clickhouse.jdbc.metadata.DatabaseMetaDataImpl;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -487,13 +488,13 @@ public class ConnectionImpl implements Connection, JdbcV2Wrapper {
 
     @Override
     public boolean isValid(int timeout) throws SQLException {
-        checkOpen();
         if (timeout < 0) {
             throw new SQLException("Timeout must be >= 0", ExceptionUtils.SQL_STATE_CLIENT_ERROR);
         }
-
-        //TODO: This is a placeholder implementation
-        return true;
+        if (isClosed()) {
+            return false;
+        }
+        return client.ping(timeout * 1_000);
     }
 
     @Override

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/ConnectionTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/ConnectionTest.java
@@ -13,6 +13,7 @@ import com.github.tomakehurst.wiremock.WireMockServer;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -33,7 +34,6 @@ import java.util.UUID;
 
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.fail;
-
 
 public class ConnectionTest extends JdbcIntegrationTest {
 
@@ -569,8 +569,32 @@ public class ConnectionTest extends JdbcIntegrationTest {
         connCheck.close();
     }
 
+    @Test(groups = { "integration" })
+    public void closedConnectionIsInvalid() throws Exception {
+        if (isCloud()) {
+            return;
+        }
+        Connection connection = this.getJdbcConnection();
+        Assert.assertTrue(connection.isValid(3));
+        connection.close();
+        Assert.assertFalse(connection.isValid(3));
+    }
+
+    @Test(groups = { "integration" })
+    public void connectionWithWrongCredentialsIsInvalid() throws Exception {
+        if (isCloud()) {
+            return;
+        }
+        Connection connection = this.getJdbcConnection();
+        Assert.assertTrue(connection.isValid(3));
+        Properties properties = new Properties();
+        properties.put("password", "invalid");
+        connection = this.getJdbcConnection(properties);
+        Assert.assertFalse(connection.isValid(3));
+    }
+
     @DataProvider(name = "validDatabaseNames")
-    public Object[][] createValidDatabaseNames() {
+    private static Object[][] createValidDatabaseNames() {
         return new Object[][] {
             { "foo" },
             { "with-dashes" },


### PR DESCRIPTION
## Summary

The [API doc for Connection](https://docs.oracle.com/en/java/javase/24/docs/api/java.sql/java/sql/Connection.html#isValid(int)) says:

> Returns true if the connection has not been closed and is still valid. The driver shall submit a query on the connection or use some other mechanism that positively verifies the connection is still valid when this method is called.

1. Do not throw Exception when connection is closed.
2. Check that connection may be used to perform queries.

`Client` already provides ping method with timeout which is used here.

Closes #2472 

## Checklist
- [ ✅ ] Closes #2472
- [ ✅ ] Unit and integration tests covering the common scenarios were added
