### PR TITLE
Instant / DateTime64 via parameter

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -7,7 +7,6 @@ import com.clickhouse.client.api.data_formats.NativeFormatReader;
 import com.clickhouse.client.api.data_formats.RowBinaryFormatReader;
 import com.clickhouse.client.api.data_formats.RowBinaryWithNamesAndTypesFormatReader;
 import com.clickhouse.client.api.data_formats.RowBinaryWithNamesFormatReader;
-import com.clickhouse.client.api.data_formats.internal.AbstractBinaryFormatReader;
 import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
 import com.clickhouse.client.api.data_formats.internal.MapBackedRecord;
 import com.clickhouse.client.api.data_formats.internal.ProcessParser;
@@ -37,7 +36,6 @@ import com.clickhouse.client.api.serde.POJOSerDe;
 import com.clickhouse.client.api.transport.Endpoint;
 import com.clickhouse.client.api.transport.HttpEndpoint;
 import com.clickhouse.client.config.ClickHouseClientOption;
-import com.clickhouse.config.ClickHouseOption;
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseDataType;
 import com.clickhouse.data.ClickHouseFormat;
@@ -1575,7 +1573,9 @@ public class Client implements AutoCloseable {
         Supplier<QueryResponse> responseSupplier;
 
             if (queryParams != null) {
-                settings.setOption("statement_params", queryParams);
+                settings.setOption(
+                    HttpAPIClientHelper.KEY_STATEMENT_PARAMS,
+                    formatQueryParameters(queryParams));
             }
             final QuerySettings finalSettings = new QuerySettings(buildRequestSettings(settings.getAllSettings()));
             responseSupplier = () -> {
@@ -2099,5 +2099,13 @@ public class Client implements AutoCloseable {
         requestSettings.putAll(configuration);
         requestSettings.putAll(opSettings);
         return requestSettings;
+    }
+
+    private Map<String, String> formatQueryParameters(Map<String, Object> queryParams) {
+        HashMap<String, String> newMap = new HashMap<>(queryParams.size());
+        for (String key : queryParams.keySet()) {
+            newMap.put(key, DataTypeUtils.format(queryParams.get(key)));
+        }
+        return newMap;
     }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/DataTypeUtils.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/DataTypeUtils.java
@@ -1,6 +1,12 @@
 package com.clickhouse.client.api;
 
+import java.time.Instant;
+import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
+import java.util.Objects;
+
+import com.clickhouse.data.ClickHouseDataType;
 
 public class DataTypeUtils {
 
@@ -18,5 +24,117 @@ public class DataTypeUtils {
      * Formatter for the DateTime type with nanoseconds.
      */
     public static DateTimeFormatter DATETIME_WITH_NANOS_FORMATTER = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.nnnnnnnnn");
+
+    /**
+     * Formats a Java object for use in SQL statements or as query parameter.
+     *
+     * Note, that this method returns the empty {@link java.lang.String}
+     * &quot;&quot; for {@code null} objects.
+     *
+     * @param object
+     *            the Java object to format
+     * @return a suitable String representation of {@code object}, or the empty
+     *         String for {@code null} objects
+     */
+    public static String format(Object object) {
+        return format(object, null);
+    }
+
+    /**
+     * Formats a Java object for use in SQL statements or as query parameter.
+     *
+     * This method uses the {@code dataTypeHint} parameter to find be best
+     * suitable format for the object.
+     *
+     * Note, that this method returns the empty {@link java.lang.String}
+     * &quot;&quot; for {@code null} objects. This might not be the correct
+     * default value for the {@code dataTypeHint}
+     *
+     * @param object
+     *            the Java object to format
+     * @param dataTypeHint
+     *            the ClickHouse data type {@code object} should be used for
+     * @return a suitable String representation of {@code object}, or the empty
+     *         String for {@code null} objects
+     */
+    public static String format(Object object, ClickHouseDataType dataTypeHint) {
+        return format(object, dataTypeHint, null);
+    }
+
+    /**
+     * Formats a Java object for use in SQL statements or as query parameter.
+     *
+     * This method uses the {@code dataTypeHint} parameter to find be best
+     * suitable format for the object.
+     *
+     * For <em>some</em> formatting operations, providing a {@code timeZone} is
+     * mandatory: When formatting time-zone-based values (e.g.
+     * {@link java.time.OffsetDateTime}, {@link java.time.ZonedDateTime}, etc.)
+     * for use as ClickHouse data types which are not time-zone-based, e.g.
+     * {@link ClickHouseDataType#Date}, or vice-versa when formatting
+     * non-time-zone-based Java objects (e.g. {@link java.time.LocalDateTime} or
+     * any {@link java.util.Calendar} based objects without time-zone) for use
+     * as time-zone-based ClickHouse data types, e.g.
+     * {@link ClickHouseDataType#DateTime64}. Although the ClickHouse server
+     * might understand simple wall-time Strings (&quot;2025-08-20 13:37:42&quot;)
+     * even for those data types, it is preferable to use timestamp values.
+     *
+     * Note, that this method returns the empty {@link java.lang.String}
+     * &quot;&quot; for {@code null} objects. This might not be the correct
+     * default value for {@code dataTypeHint}.
+     *
+     * @param object
+     *            the Java object to format
+     * @param dataTypeHint
+     *            the ClickHouse data type {@code object} should be used for
+     * @param timeZone
+     *            the time zone to be used when formatting time-zone-based Java
+     *            objects for use in non-time-zone-based ClickHouse data types
+     *            and vice versa
+     * @return a suitable String representation of {@code object}, or the empty
+     *         String for {@code null} objects
+     */
+    public static String format(Object object, ClickHouseDataType dataTypeHint,
+        ZoneId timeZone)
+    {
+        if (object == null) {
+            return "";
+        }
+        if (object instanceof Instant) {
+            return formatInstant((Instant) object, dataTypeHint, timeZone);
+        }
+        return String.valueOf(object);
+    }
+
+    private static String formatInstant(Instant instant, ClickHouseDataType dataTypeHint,
+        ZoneId timeZone)
+    {
+        if (dataTypeHint == null) {
+            return formatInstantDefault(instant);
+        }
+        switch (dataTypeHint) {
+            case Date:
+            case Date32:
+                Objects.requireNonNull(
+                    timeZone,
+                    "TimeZone required for formatting Instant for '" + dataTypeHint + "' use");
+                return DATE_FORMATTER.format(
+                    instant.atZone(timeZone).toLocalDate());
+            case DateTime:
+            case DateTime32:
+                return String.valueOf(instant.getEpochSecond());
+            default:
+                return formatInstantDefault(instant);
+        }
+    }
+
+    private static String formatInstantDefault(Instant instant) {
+        String nanos = String.valueOf(instant.getNano());
+        char[] n = new char[9];
+        Arrays.fill(n, '0');
+        int nanosLength = Math.min(9, nanos.length());
+        nanos.getChars(0, nanosLength, n, 9 - nanosLength);
+        return String.valueOf(instant.getEpochSecond()) + "." + new String(n);
+    }
 
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryFormatSerializer.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/RowBinaryFormatSerializer.java
@@ -3,7 +3,6 @@ package com.clickhouse.client.api.data_formats;
 import com.clickhouse.client.api.data_formats.internal.SerializerUtils;
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseDataType;
-import com.clickhouse.data.ClickHouseFormat;
 import com.clickhouse.data.format.BinaryStreamUtils;
 
 import java.io.IOException;
@@ -132,7 +131,7 @@ public class RowBinaryFormatSerializer {
     }
 
     public void writeDate(ZonedDateTime value) throws IOException {
-        SerializerUtils.writeDate(out, value, ZoneId.of("UTC"));
+        SerializerUtils.writeDate(out, value, value.getZone());
     }
 
     public void writeDate32(ZonedDateTime value, ZoneId targetTz) throws IOException {

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -104,7 +104,7 @@ public class BinaryStreamReader {
         if (column.isNullable()) {
             int isNull = readByteOrEOF(input);
             if (isNull == 1) { // is Null?
-                return (T) null;
+                return null;
             }
         }
 
@@ -588,7 +588,7 @@ public class BinaryStreamReader {
 
         return bytes;
     }
-    
+
     /**
      * Reads a array into an ArrayValue object.
      * @param column - column information
@@ -964,7 +964,7 @@ public class BinaryStreamReader {
      */
     public static ZonedDateTime readDateTime32(InputStream input, byte[] buff, TimeZone tz) throws IOException {
         long time = readUnsignedIntLE(input, buff);
-        return LocalDateTime.ofInstant(Instant.ofEpochSecond(Math.max(time, 0L)), tz.toZoneId()).atZone(tz.toZoneId());
+        return Instant.ofEpochSecond(Math.max(time, 0L)).atZone(tz.toZoneId());
     }
 
     /**

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/SerializerUtils.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/SerializerUtils.java
@@ -17,9 +17,6 @@ import org.objectweb.asm.ClassWriter;
 import org.objectweb.asm.MethodVisitor;
 import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.io.OutputStream;
 import java.lang.reflect.Array;
@@ -29,7 +26,14 @@ import java.math.BigInteger;
 import java.net.Inet4Address;
 import java.net.Inet6Address;
 import java.sql.Timestamp;
-import java.time.*;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.Period;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -53,8 +57,6 @@ import static org.objectweb.asm.Opcodes.INVOKEVIRTUAL;
 import static org.objectweb.asm.Opcodes.RETURN;
 
 public class SerializerUtils {
-
-    private static final Logger LOG = LoggerFactory.getLogger(SerializerUtils.class);
 
     public static void serializeData(OutputStream stream, Object value, ClickHouseColumn column) throws IOException {
         //Serialize the value to the stream based on the data type
@@ -1070,6 +1072,9 @@ public class SerializerUtils {
         } else if (value instanceof ZonedDateTime) {
             ZonedDateTime dt = (ZonedDateTime) value;
             epochDays = (int)dt.withZoneSameInstant(targetTz).toLocalDate().toEpochDay();
+        } else if (value instanceof OffsetDateTime) {
+            OffsetDateTime dt = (OffsetDateTime) value;
+            epochDays = (int) dt.atZoneSameInstant(targetTz).toLocalDate().toEpochDay();
         } else {
             throw new IllegalArgumentException("Cannot convert " + value + " to Long");
         }

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
@@ -98,7 +98,10 @@ import java.util.function.Function;
 import java.util.regex.Pattern;
 
 public class HttpAPIClientHelper {
-    private static final Logger LOG = LoggerFactory.getLogger(Client.class);
+
+    public static final String KEY_STATEMENT_PARAMS = "statement_params";
+
+    private static final Logger LOG = LoggerFactory.getLogger(HttpAPIClientHelper.class);
 
     private static final int ERROR_BODY_BUFFER_SIZE = 1024; // Error messages are usually small
 
@@ -567,11 +570,9 @@ public class HttpAPIClientHelper {
         if (requestConfig.containsKey(ClientConfigProperties.QUERY_ID.getKey())) {
             req.addParameter(ClickHouseHttpProto.QPARAM_QUERY_ID, requestConfig.get(ClientConfigProperties.QUERY_ID.getKey()).toString());
         }
-        if (requestConfig.containsKey("statement_params")) {
-            Map<String, Object> params = (Map<String, Object>) requestConfig.get("statement_params");
-            for (Map.Entry<String, Object> entry : params.entrySet()) {
-                req.addParameter("param_" + entry.getKey(), String.valueOf(entry.getValue()));
-            }
+        if (requestConfig.containsKey(KEY_STATEMENT_PARAMS)) {
+            Map<?, ?> params = (Map<?, ?>) requestConfig.get(KEY_STATEMENT_PARAMS);
+            params.forEach((k, v) -> req.addParameter("param_" + k, (String.valueOf(v))));
         }
 
         boolean clientCompression = ClientConfigProperties.COMPRESS_CLIENT_REQUEST.getOrDefault(requestConfig);

--- a/client-v2/src/test/java/com/clickhouse/client/api/DataTypeUtilsTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/api/DataTypeUtilsTests.java
@@ -2,31 +2,124 @@ package com.clickhouse.client.api;
 
 import org.testng.annotations.Test;
 
+import com.clickhouse.data.ClickHouseDataType;
+
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.TimeZone;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 
-import static org.testng.AssertJUnit.assertEquals;
-
-public class DataTypeUtilsTests {
-
+class DataTypeUtilsTests {
 
     @Test
-    public void testDateTimeFormatter() {
+    void testDateTimeFormatter() {
         LocalDateTime dateTime = LocalDateTime.of(2021, 12, 31, 23, 59, 59);
         String formattedDateTime = dateTime.format(DataTypeUtils.DATETIME_FORMATTER);
-        assertEquals("2021-12-31 23:59:59", formattedDateTime);
+        assertEquals(formattedDateTime, "2021-12-31 23:59:59");
     }
 
     @Test
-    public void testDateFormatter() {
+    void testDateFormatter() {
         LocalDateTime date = LocalDateTime.of(2021, 12, 31, 10, 20);
         String formattedDate = date.toLocalDate().format(DataTypeUtils.DATE_FORMATTER);
-        assertEquals("2021-12-31", formattedDate);
+        assertEquals(formattedDate, "2021-12-31");
     }
 
     @Test
-    public void testDateTimeWithNanosFormatter() {
+    void testDateTimeWithNanosFormatter() {
         LocalDateTime dateTime = LocalDateTime.of(2021, 12, 31, 23, 59, 59, 123456789);
         String formattedDateTimeWithNanos = dateTime.format(DataTypeUtils.DATETIME_WITH_NANOS_FORMATTER);
-        assertEquals("2021-12-31 23:59:59.123456789", formattedDateTimeWithNanos);
+        assertEquals(formattedDateTimeWithNanos, "2021-12-31 23:59:59.123456789");
     }
+
+    @Test
+    void formatInstantForDateNullInstant() {
+        assertEquals("", DataTypeUtils.format(
+            null, ClickHouseDataType.Date, ZoneId.systemDefault()));
+    }
+
+    @Test
+    void formatInstantForDateNullTimeZone() {
+        assertThrows(
+            NullPointerException.class,
+            () -> DataTypeUtils.format(Instant.now(), ClickHouseDataType.Date, null));
+    }
+
+    @Test
+    void formatInstantForDate() {
+        ZoneId tzBER = ZoneId.of("Europe/Berlin");
+        ZoneId tzLAX = ZoneId.of("America/Los_Angeles");
+        Instant instant = ZonedDateTime.of(
+            2025, 7, 20, 5, 5, 42, 0, tzBER).toInstant();
+        assertEquals(DataTypeUtils.format(instant, ClickHouseDataType.Date, tzBER), "2025-07-20");
+        assertEquals(DataTypeUtils.format(instant, ClickHouseDataType.Date, tzLAX), "2025-07-19");
+    }
+
+    @Test
+    void formatNullValue() {
+        assertEquals("", DataTypeUtils.format(null));
+    }
+
+    @Test
+    void formatInstantForDateTime() {
+        TimeZone tzBER = TimeZone.getTimeZone("Europe/Berlin");
+        Instant instant = ZonedDateTime.of(
+            2025, 7, 20, 5, 5, 42, 232323, tzBER.toZoneId()).toInstant();
+        String formatted = DataTypeUtils.format(instant, ClickHouseDataType.DateTime);
+        assertEquals(formatted, "1752980742");
+        assertEquals(
+            Instant.ofEpochSecond(Long.parseLong(formatted)),
+            instant.truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    @Test
+    void formatInstantForDateTime64() {
+        TimeZone tzBER = TimeZone.getTimeZone("Europe/Berlin");
+        Instant instant = ZonedDateTime.of(
+            2025, 7, 20, 5, 5, 42, 232323232, tzBER.toZoneId()).toInstant();
+        String formatted = DataTypeUtils.format(instant);
+        assertEquals(formatted, "1752980742.232323232");
+        String[] formattedParts = formatted.split("\\.");
+        assertEquals(
+            Instant
+                .ofEpochSecond(Long.parseLong(formattedParts[0]))
+                .plusNanos(Long.parseLong(formattedParts[1])),
+            instant);
+    }
+
+    @Test
+    void formatInstantForDateTime64SmallerNanos() {
+        TimeZone tzBER = TimeZone.getTimeZone("Europe/Berlin");
+        Instant instant = ZonedDateTime.of(
+            2025, 7, 20, 5, 5, 42, 23, tzBER.toZoneId()).toInstant();
+        String formatted = DataTypeUtils.format(instant);
+        assertEquals(formatted, "1752980742.000000023");
+        String[] formattedParts = formatted.split("\\.");
+        assertEquals(
+            Instant
+                .ofEpochSecond(Long.parseLong(formattedParts[0]))
+                .plusNanos(Long.parseLong(formattedParts[1])),
+            instant);
+    }
+
+    @Test
+    void formatInstantForDateTime64Truncated() {
+        // precision is constant for Instant
+        TimeZone tzBER = TimeZone.getTimeZone("Europe/Berlin");
+        Instant instant = ZonedDateTime.of(
+            2025, 7, 20, 5, 5, 42, 232323232, tzBER.toZoneId()).toInstant();
+        assertEquals(
+            DataTypeUtils.format(
+                instant.truncatedTo(ChronoUnit.SECONDS)),
+            "1752980742.000000000");
+        assertEquals(
+            DataTypeUtils.format(
+                instant.truncatedTo(ChronoUnit.MILLIS)),
+            "1752980742.232000000");
+    }
+
 }

--- a/client-v2/src/test/java/com/clickhouse/client/api/data_formats/ClickHouseBinaryFormatReaderTest.java
+++ b/client-v2/src/test/java/com/clickhouse/client/api/data_formats/ClickHouseBinaryFormatReaderTest.java
@@ -14,7 +14,6 @@ import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.TimeZone;
-import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 
 public class ClickHouseBinaryFormatReaderTest {
@@ -70,11 +69,11 @@ public class ClickHouseBinaryFormatReaderTest {
             Assert.assertEquals(reader.getBoolean(name), Boolean.TRUE);
             Assert.assertEquals(reader.getByte(name), (byte)testValue);
             Assert.assertEquals(reader.getShort(name), (short)testValue);
-            Assert.assertEquals(reader.getInteger(name), (int)testValue);
-            Assert.assertEquals(reader.getLong(name), (long)testValue);
+            Assert.assertEquals(reader.getInteger(name), testValue);
+            Assert.assertEquals(reader.getLong(name), testValue);
 
-            Assert.assertEquals(reader.getFloat(name), (float) testValue);
-            Assert.assertEquals(reader.getDouble(name), (double) testValue);
+            Assert.assertEquals(reader.getFloat(name), testValue);
+            Assert.assertEquals(reader.getDouble(name), testValue);
             Assert.assertEquals(reader.getBigInteger(name), BigInteger.valueOf((testValue)));
 
             Assert.assertTrue(reader.getBigDecimal(name).compareTo(BigDecimal.valueOf((testValue))) == 0);

--- a/client-v2/src/test/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReaderTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReaderTests.java
@@ -1,10 +1,28 @@
 package com.clickhouse.client.api.data_formats.internal;
 
-import org.junit.Assert;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.TimeZone;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 public class BinaryStreamReaderTests {
 
+    private ZoneId tzLAX;
+    private ZoneId tzBER;
+
+    @BeforeClass
+    void beforeClass() {
+        tzLAX = ZoneId.of("America/Los_Angeles");
+        tzBER = ZoneId.of("Europe/Berlin");
+    }
 
     @Test
     public void testCachedByteAllocator() {
@@ -14,7 +32,7 @@ public class BinaryStreamReaderTests {
             int size = (int) Math.pow(2, i);
             byte[] firstAllocation = allocator.allocate(size);
             byte[] nextAllocation = allocator.allocate(size);
-            Assert.assertSame( "Should be the same buffer for size " + size, firstAllocation, nextAllocation);
+            Assert.assertTrue(firstAllocation == nextAllocation, "Should be the same buffer for size " + size);
         }
 
         for (int i = 6; i < 16; i++) {
@@ -24,4 +42,138 @@ public class BinaryStreamReaderTests {
             Assert.assertNotSame(firstAllocation, nextAllocation);
         }
     }
+
+    @Test(dataProvider = "dateTestData")
+    void readDateZonedDateTimeNoTimeZone(ZonedDateTime zdt, ZoneId writeTZ, ZoneId readTZ,
+        ZonedDateTime expectedZDT) throws IOException
+    {
+        /*
+         * Date is number of days since 1970-01-01 (unsigned)
+         * ... The date value is stored without the time zone.
+         */
+
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        SerializerUtils.writeDate(baos, zdt, writeTZ);
+        byte[] bytes = baos.toByteArray();
+        Assert.assertEquals(
+            BinaryStreamReader.readDate(
+                new ByteArrayInputStream(bytes),
+                bytes,
+                TimeZone.getTimeZone(readTZ)),
+            expectedZDT);
+    }
+
+    @Test(dataProvider = "dateTestData")
+    void readDateOffsetDateTimeNoTimeZone(ZonedDateTime zdt, ZoneId writeTZ, ZoneId readTZ,
+        ZonedDateTime expectedZDT) throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        SerializerUtils.writeDate(baos, zdt.toOffsetDateTime(), writeTZ);
+        byte[] bytes = baos.toByteArray();
+        Assert.assertEquals(
+            BinaryStreamReader.readDate(
+                new ByteArrayInputStream(bytes),
+                bytes,
+                TimeZone.getTimeZone(readTZ)).toOffsetDateTime(),
+            expectedZDT.toOffsetDateTime());
+    }
+
+    @DataProvider(name = "dateTestData")
+    private Object[][] provideDateTestData() {
+        ZonedDateTime zdtLAX = ZonedDateTime.of(
+            2025, 7, 20, 22, 23, 1, 232323232, tzLAX);
+        ZonedDateTime zdtBER = zdtLAX.withZoneSameInstant(tzBER);
+        return new Object[][] {
+            // no conversion at all
+            { zdtLAX, tzLAX, tzLAX, zdtLAX.truncatedTo(ChronoUnit.DAYS) },
+
+            // write using Berlin local date -> next day
+            { zdtLAX, tzBER, tzBER, zdtLAX.plusDays(1L).withZoneSameLocal(tzBER)
+                .truncatedTo(ChronoUnit.DAYS) },
+
+            // read using different time zone: local date same as original
+            { zdtLAX, tzLAX, tzBER, zdtLAX.withZoneSameLocal(tzBER)
+                .truncatedTo(ChronoUnit.DAYS) },
+
+            // write using different time zone: local date same as original
+            { zdtBER, tzLAX, tzBER, zdtLAX.withZoneSameLocal(tzBER)
+                .truncatedTo(ChronoUnit.DAYS) }
+        };
+
+    }
+
+    @Test(dataProvider = "dateTimeTestData")
+    void readDateTime32ZonedDateTime(ZonedDateTime zdt, ZoneId writeTZ, ZoneId readTZ,
+        ZonedDateTime expectedZDT) throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        SerializerUtils.writeDateTime32(baos, zdt, writeTZ);
+        byte[] bytes = baos.toByteArray();
+        Assert.assertEquals(
+            BinaryStreamReader.readDateTime32(
+                new ByteArrayInputStream(bytes),
+                bytes,
+                TimeZone.getTimeZone(readTZ)),
+            expectedZDT.truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    @Test(dataProvider = "dateTimeTestData")
+    void readDateTime32OffsetDateTime(ZonedDateTime zdt, ZoneId writeTZ, ZoneId readTZ,
+        ZonedDateTime expectedZDT) throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        SerializerUtils.writeDateTime32(baos, zdt.toOffsetDateTime(), writeTZ);
+        byte[] bytes = baos.toByteArray();
+        Assert.assertEquals(
+            BinaryStreamReader.readDateTime32(
+                new ByteArrayInputStream(bytes),
+                bytes,
+                TimeZone.getTimeZone(readTZ)).toOffsetDateTime(),
+            expectedZDT.toOffsetDateTime().truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    @Test(dataProvider = "dateTimeTestData")
+    void readDateTime32Instant(ZonedDateTime zdt, ZoneId writeTZ, ZoneId readTZ,
+        ZonedDateTime expectedZDT) throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        SerializerUtils.writeDateTime32(baos, zdt.toInstant(), writeTZ);
+        byte[] bytes = baos.toByteArray();
+        Assert.assertEquals(
+            BinaryStreamReader.readDateTime32(
+                new ByteArrayInputStream(bytes),
+                bytes,
+                TimeZone.getTimeZone(readTZ)),
+            expectedZDT.truncatedTo(ChronoUnit.SECONDS));
+    }
+
+    @Test(dataProvider = "dateTimeTestData")
+    void readDateTime64Instant(ZonedDateTime zdt, ZoneId writeTZ, ZoneId readTZ,
+        ZonedDateTime expectedZDT) throws IOException
+    {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        SerializerUtils.writeDateTime64(baos, zdt.toInstant(), 9, writeTZ);
+        byte[] bytes = baos.toByteArray();
+        Assert.assertEquals(
+            BinaryStreamReader.readDateTime64(
+                new ByteArrayInputStream(bytes),
+                bytes,
+                9,
+                TimeZone.getTimeZone(readTZ)),
+            expectedZDT);
+    }
+
+    @DataProvider(name = "dateTimeTestData")
+    private Object[][] provideDateTimeTestData() {
+        ZonedDateTime zdtLAX = ZonedDateTime.of(
+            2025, 7, 20, 22, 23, 1, 232323232, tzLAX);
+        ZonedDateTime zdtBER = zdtLAX.withZoneSameInstant(tzBER);
+        return new Object[][] {
+            { zdtLAX, tzLAX, tzLAX, zdtLAX },
+            { zdtLAX, tzBER, tzLAX, zdtLAX },
+            { zdtLAX, tzLAX, tzBER, zdtBER },
+            { zdtBER, tzLAX, tzBER, zdtBER }
+        };
+    }
+
 }

--- a/client-v2/src/test/java/com/clickhouse/client/e2e/ParameterizedQueryTest.java
+++ b/client-v2/src/test/java/com/clickhouse/client/e2e/ParameterizedQueryTest.java
@@ -1,0 +1,322 @@
+/*
+ * Copyright (c) 2025 Riege Software. All rights reserved.
+ * Use is subject to license terms.
+ */
+package com.clickhouse.client.e2e;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.clickhouse.client.BaseIntegrationTest;
+import com.clickhouse.client.ClickHouseNode;
+import com.clickhouse.client.ClickHouseProtocol;
+import com.clickhouse.client.ClickHouseServerForTest;
+import com.clickhouse.client.api.Client;
+import com.clickhouse.client.api.DataTypeUtils;
+import com.clickhouse.client.api.command.CommandSettings;
+import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatReader;
+import com.clickhouse.client.api.enums.Protocol;
+import com.clickhouse.client.api.internal.ServerSettings;
+import com.clickhouse.client.api.query.QueryResponse;
+import com.clickhouse.data.ClickHouseDataType;
+
+public class ParameterizedQueryTest extends BaseIntegrationTest {
+
+    private Client client;
+
+    @BeforeMethod(groups = {"integration"})
+    public void setUp() {
+        ClickHouseNode node = getServer(ClickHouseProtocol.HTTP);
+        client = newClient().build();
+    }
+
+    @AfterMethod(groups = {"integration"})
+    public void tearDown() {
+        client.close();
+    }
+
+    @Test(groups = {"integration"})
+    void testParamsWithInstant() throws Exception {
+        String tableName = "test_dt64_instant";
+        ZoneId tzBER = ZoneId.of("Europe/Berlin");
+        ZoneId tzLAX = ZoneId.of("America/Los_Angeles");
+        LocalDateTime localDateTime = LocalDateTime.of(2025, 7, 20, 5, 5, 42, 232323232);
+        List<ZonedDateTime> testValues = Arrays.asList(
+            localDateTime.atZone(tzBER),
+            localDateTime.atZone(tzLAX));
+
+        AtomicInteger rowId = new AtomicInteger(-1);
+
+        // Insert two rows via helper method
+
+        prepareDataSet(
+            tableName,
+            Arrays.asList(
+                "id UInt16",
+                "d Date",
+                "dt DateTime",
+                "dt64_3 DateTime64(3)",
+                "dt64_9 DateTime64(9)",
+                "dt64_3_lax DateTime64(3, 'America/Los_Angeles')"),
+            Arrays.asList(
+                () -> Integer.valueOf(rowId.incrementAndGet() % 2),
+                () -> testValues.get(rowId.get() % 2).toLocalDate()
+                    .toString(),
+                () -> DataTypeUtils.format(
+                    testValues.get(rowId.get() % 2).toInstant(),
+                    ClickHouseDataType.DateTime),
+                () -> DataTypeUtils.format(
+                    testValues.get(rowId.get() % 2).toInstant()),
+                () -> DataTypeUtils.format(
+                    testValues.get(rowId.get() % 2).toInstant()),
+                () -> DataTypeUtils.format(
+                    testValues.get(rowId.get() % 2).toInstant())),
+            2);
+
+        // Insert one row using query parameters
+
+        ZoneId tzUTC = ZoneId.of("UTC");
+        ZoneId tzServer = ZoneId.of(client.getServerTimeZone());
+        Instant manualTestValue = localDateTime.atZone(tzUTC).toInstant();
+        client.query(
+            "INSERT INTO " + tableName + " (id, d, dt, dt64_3, dt64_9, dt64_3_lax) "
+                + "VALUES ("
+                + rowId.incrementAndGet() + ", "
+                + "'" + DataTypeUtils.format(manualTestValue, ClickHouseDataType.Date, tzUTC) + "', "
+                + "'" + DataTypeUtils.format(manualTestValue, ClickHouseDataType.DateTime) + "', "
+                + "{manualTestValue:DateTime64}, "
+                + "{manualTestValue:DateTime64(9)}, "
+                + "{manualTestValue:DateTime64})",
+            Collections.singletonMap("manualTestValue", manualTestValue));
+
+        try (QueryResponse response = client.query(
+                "SELECT * FROM " + tableName + " ORDER by id ASC").get();
+            ClickHouseBinaryFormatReader reader = client.newBinaryFormatReader(response))
+        {
+            reader.next();
+            Assert.assertEquals(
+                reader.getLocalDate(2),
+                localDateTime.toLocalDate());
+            Assert.assertEquals(
+                reader.getZonedDateTime(3),
+                localDateTime.atZone(tzBER).withZoneSameInstant(tzServer)
+                    .truncatedTo(ChronoUnit.SECONDS));
+            Assert.assertEquals(
+                reader.getZonedDateTime(4),
+                localDateTime.atZone(tzBER).withZoneSameInstant(tzServer)
+                .truncatedTo(ChronoUnit.MILLIS));
+            Assert.assertEquals(
+                reader.getZonedDateTime(5),
+                localDateTime.atZone(tzBER).withZoneSameInstant(tzServer));
+            Assert.assertEquals(
+                reader.getZonedDateTime(6),
+                localDateTime.atZone(tzBER).withZoneSameInstant(tzLAX)
+                .truncatedTo(ChronoUnit.MILLIS));
+
+            reader.next();
+            Assert.assertEquals(
+                reader.getLocalDate(2),
+                localDateTime.toLocalDate());
+            Assert.assertEquals(
+                reader.getZonedDateTime(3),
+                localDateTime.atZone(tzLAX).withZoneSameInstant(tzServer)
+                    .truncatedTo(ChronoUnit.SECONDS));
+            Assert.assertEquals(
+                reader.getZonedDateTime(4),
+                localDateTime.atZone(tzLAX).withZoneSameInstant(tzServer)
+                .truncatedTo(ChronoUnit.MILLIS));
+            Assert.assertEquals(
+                reader.getZonedDateTime(5),
+                localDateTime.atZone(tzLAX).withZoneSameInstant(tzServer));
+            Assert.assertEquals(
+                reader.getZonedDateTime(6),
+                localDateTime.atZone(tzLAX).truncatedTo(ChronoUnit.MILLIS));
+
+            reader.next();
+            Assert.assertEquals(
+                reader.getLocalDate(2),
+                localDateTime.toLocalDate());
+            Assert.assertEquals(
+                reader.getZonedDateTime(3),
+                localDateTime.atZone(tzUTC).truncatedTo(ChronoUnit.SECONDS));
+            Assert.assertEquals(
+                reader.getZonedDateTime(4),
+                localDateTime.atZone(tzServer).truncatedTo(ChronoUnit.MILLIS));
+            Assert.assertEquals(
+                reader.getZonedDateTime(5),
+                localDateTime.atZone(tzServer));
+            Assert.assertEquals(
+                reader.getZonedDateTime(6),
+                localDateTime.atZone(tzServer).withZoneSameInstant(tzLAX)
+                .truncatedTo(ChronoUnit.MILLIS));
+        }
+
+        // test some queries with parameters
+
+        List<Object[]> queryTests = Arrays.<Object[]>asList(new Object[][]{
+            // date column
+            { "d", "=", Instant.now(), -1, new int[0] },
+            { "d", "=", testValues.get(1).toInstant(), -1, new int[0] },
+            { "d", "=", testValues.get(1).toInstant().truncatedTo(ChronoUnit.DAYS),
+                -1, new int[] { 0, 1, 2 } },
+            { "d", "<", testValues.get(1).toInstant(),
+                -1, new int[] { 0, 1, 2 } },
+            { "d", ">", testValues.get(1).toInstant(), -1, new int[0] },
+
+            // datetime column
+            { "dt", "=", Instant.now(), -1, new int[0] },
+            { "dt", "=", testValues.get(1).toInstant(), -1, new int[0] },
+            { "dt", "=", testValues.get(1).toInstant().truncatedTo(ChronoUnit.SECONDS),
+                -1, new int[] { 1 } },
+            { "dt", "<", testValues.get(1).toInstant(), -1, new int[] { 0, 1, 2 } },
+            { "dt", ">", testValues.get(1).toInstant(), -1, new int[0] },
+
+            // dt63_3 column
+            { "dt64_3", "=", Instant.now(), -1, new int[0] },
+            { "dt64_3", "=", testValues.get(1).toInstant(), -1, new int[]{ 1 } },
+            { "dt64_3", "=", testValues.get(1).toInstant().truncatedTo(ChronoUnit.MILLIS),
+                -1, new int[]{ 1 } },
+            { "dt64_3", "<", testValues.get(1).toInstant(),
+                -1, new int[] { 0, 2 } },
+            { "dt64_3", ">", testValues.get(1).toInstant(), -1, new int[0] },
+
+            // dt63_9 column
+            { "dt64_9", "=", Instant.now(), 9, new int[0] },
+            { "dt64_9", "=", testValues.get(1).toInstant(), 9,
+                new int[]{ 1 } },
+            { "dt64_9", "=", testValues.get(1).toInstant().truncatedTo(ChronoUnit.MILLIS),
+                9, new int[0] },
+            { "dt64_9", "<", testValues.get(1).toInstant(), 9, new int[] { 0, 2 } },
+            { "dt64_9", ">", testValues.get(1).toInstant(), 9, new int[0] },
+
+            // dt63_3_lax column
+            { "dt64_3_lax", "=", Instant.now(), -1, new int[0] },
+            { "dt64_3_lax", "=", testValues.get(1).toInstant(), -1,
+                new int[]{ 1 } },
+            { "dt64_3_lax", "=", testValues.get(1).toInstant().truncatedTo(ChronoUnit.MILLIS),
+                -1, new int[]{ 1 } },
+            { "dt64_3_lax", "<", testValues.get(1).toInstant(),
+                -1,  new int[] { 0, 2 } },
+            { "dt64_3_lax", ">", testValues.get(1).toInstant(), -1, new int[0] },
+
+        });
+        for (Object[] queryTest : queryTests) {
+            Assert.assertEquals(
+                queryInstant(
+                    tableName,
+                    (String) queryTest[0],
+                    (String) queryTest[1],
+                    (Instant) queryTest[2],
+                    ((Integer) queryTest[3]).intValue()),
+                queryTest[4],
+                "Test: " + (String) queryTest[0] + " " + (String) queryTest[1] + " "
+                    + queryTest[2]);
+        }
+    }
+
+    private int[] queryInstant(String tableName, String fieldName, String operator,
+        Instant param, int scale) throws InterruptedException, ExecutionException, Exception
+    {
+        try (QueryResponse response = client.query(
+                "SELECT id FROM " + tableName + " WHERE " + fieldName + " "
+                    + operator + " {x:DateTime64" + (scale > 0 ? "(" + scale  + ")" : "") + "} "
+                    + "ORDER by id ASC",
+                Collections.singletonMap("x", param)).get();
+            ClickHouseBinaryFormatReader reader = client.newBinaryFormatReader(response))
+        {
+            List<Integer> ints = new ArrayList<>(3);
+            while (reader.hasNext()) {
+                reader.next();
+                ints.add(Integer.valueOf(reader.getInteger(1)));
+            }
+            return ints.stream().mapToInt(Integer::intValue).toArray();
+        }
+    }
+
+    private Client.Builder newClient() {
+        ClickHouseNode node = getServer(ClickHouseProtocol.HTTP);
+        boolean isSecure = isCloud();
+        return new Client.Builder()
+                .addEndpoint(Protocol.HTTP, node.getHost(), node.getPort(), isSecure)
+                .setUsername("default")
+                .setPassword(ClickHouseServerForTest.getPassword())
+                .compressClientRequest(false)
+                .setDefaultDatabase(ClickHouseServerForTest.getDatabase())
+                .serverSetting(ServerSettings.WAIT_ASYNC_INSERT, "1")
+                .serverSetting(ServerSettings.ASYNC_INSERT, "0");
+    }
+
+    private void prepareDataSet(String table, List<String> columns, List<Supplier<Object>> valueGenerators,
+        int rows)
+    {
+        List<Map<String, Object>> data = new ArrayList<>(rows);
+        try {
+            // Drop table
+            client.execute("DROP TABLE IF EXISTS " + table).get(10, TimeUnit.SECONDS);
+
+            // Create table
+            CommandSettings settings = new CommandSettings();
+            StringBuilder createStmtBuilder = new StringBuilder();
+            createStmtBuilder.append("CREATE TABLE IF NOT EXISTS ").append(table).append(" (");
+            for (String column : columns) {
+                createStmtBuilder.append(column).append(", ");
+            }
+            createStmtBuilder.setLength(createStmtBuilder.length() - 2);
+            createStmtBuilder.append(") ENGINE = MergeTree ORDER BY tuple()");
+            client.execute(createStmtBuilder.toString(), settings).get(10, TimeUnit.SECONDS);
+
+            // Insert data
+            StringBuilder insertStmtBuilder = new StringBuilder();
+            insertStmtBuilder.append("INSERT INTO ").append(table).append(" VALUES ");
+            for (int i = 0; i < rows; i++) {
+                insertStmtBuilder.append("(");
+                Map<String, Object> values = writeValuesRow(insertStmtBuilder, columns, valueGenerators);
+                insertStmtBuilder.setLength(insertStmtBuilder.length() - 2);
+                insertStmtBuilder.append("), ");
+                data.add(values);
+            }
+            insertStmtBuilder.setLength(insertStmtBuilder.length() - 2);
+            String s = insertStmtBuilder.toString();
+            client.execute(s).get(10, TimeUnit.SECONDS);
+        } catch (Exception e) {
+            Assert.fail("failed to prepare data set", e);
+        }
+    }
+
+    private Map<String, Object> writeValuesRow(StringBuilder insertStmtBuilder, List<String> columns,
+        List<Supplier<Object>> valueGenerators)
+    {
+        Map<String, Object> values = new HashMap<>();
+        Iterator<String> columnIterator = columns.iterator();
+        for (Supplier<Object> valueGenerator : valueGenerators) {
+            Object value = valueGenerator.get();
+            if (value instanceof String) {
+                insertStmtBuilder.append('\'').append(value).append('\'').append(", ");
+            } else {
+                insertStmtBuilder.append(value).append(", ");
+            }
+            values.put(columnIterator.next().split(" ")[0], value);
+
+        }
+        return values;
+    }
+
+}


### PR DESCRIPTION
## Summary

This PR adds support for supplying a `java.time.Instant` as query parameter to a query. The driver will take care to translate the Java instant into a format ClikcHouse server will understand. In some use cases, user will have to perform the mapping themselves.

This is only the start into a great journey. As outlined in #2456 , clients will also expect this to work with [Array](https://clickhouse.com/docs/sql-reference/data-types/array), probably [Tuple](https://clickhouse.com/docs/sql-reference/data-types/tuple) etc. as well. Nice candidates with time zone madness are also `LocalDateTime` and friends.

This feels very similar to requirements from JDBC, where Java objects have to be serialized somehow (see [PreparedStatementImpl.encodeObject()](https://github.com/ClickHouse/clickhouse-java/blob/2f3b74127c77b173948415424d0effcba92523e2/jdbc-v2/src/main/java/com/clickhouse/jdbc/PreparedStatementImpl.java#L744). We have to be cautious not to have different ways of serializing stuff for ClickHouse queries.

I did not know where to place the integration tests, really. I first started adding a method to `QueryTests`, but I reckoned that this class' primary purpose was to ensure the same behavior using different configuration options (compression etc.) via sub classes. I also considered `DataTypeTests`, but this class mainly deals with some complex, nested stuff. So I created a new test, `com.clickhouse.client.e2e.ParameterizedQueryTest`.  Please let me know if you see a better place for this integration test.

The `format` methods in `DataTypeUtils` create an empty String for `null` values. This might not always be the best default value for every ClickHouse data type. There are different options:

1. Throw NPE or IAE if object is null
2. Provide default String values per data type, either directly in `ClickHouseDataType` or here, in the `DataTypeUils` class.

Some more general remarks:

1. There are many Java warnings which are correct, e.g. about unused imports, unused fields etc. It would really be great if we could improve code quality a little bit (related #304).
2. I was struggling with Java 8 target. There are so many API improvements, language features, bug fixes we are missing out on. Do maintainers have a sound strategy for Java version targets?
3. Then, on the other hand, there is a dependency on `lombok` library. This is not very practical because you have to set up your IDE to pre-compile this stuff etc. Either stick to "old-school" Java, let IDE generate getters/setters for you or go current Java standard, [records](https://docs.oracle.com/en/java/javase/17/language/records.html).

Closes #2456 
## Checklist
Delete items not relevant to your PR:
- [ ✅ ] Closes #2456
- [ ✅ ] Unit and integration tests covering the common scenarios were added
