### PR TITLE
[jdbc-v2] Parser issues fix

### DIFF
--- a/jdbc-v2/src/main/antlr4/com/clickhouse/jdbc/internal/ClickHouseParser.g4
+++ b/jdbc-v2/src/main/antlr4/com/clickhouse/jdbc/internal/ClickHouseParser.g4
@@ -41,15 +41,20 @@ query
 
 // CTE statement
 ctes
-    : LPAREN? WITH namedQuery (',' namedQuery)* RPAREN?
+    : LPAREN? WITH (cteUnboundCol COMMA)* namedQuery (COMMA namedQuery)* RPAREN?
     ;
 
 namedQuery
-    : name = identifier (columnAliases)? AS '(' query ')'
+    : name = identifier (columnAliases)? AS LPAREN query RPAREN
     ;
 
 columnAliases
-    : '(' identifier (',' identifier)* ')'
+    : LPAREN? identifier (',' identifier)* RPAREN?
+    ;
+
+cteUnboundCol
+    : (literal AS identifier) # CteUnboundColLiteral
+    | (QUERY AS identifier) # CteUnboundColParam
     ;
 
 // ALTER statement
@@ -407,7 +412,7 @@ projectionSelectStmt
 // SELECT statement
 
 selectUnionStmt
-    : selectStmtWithParens (UNION ALL selectStmtWithParens)*
+    : selectStmtWithParens (UNION (ALL|DISTINCT)? selectStmtWithParens)*
     ;
 
 selectStmtWithParens
@@ -1228,6 +1233,12 @@ keywordForAlias
     | VIEW
     | PRIMARY
     | GRANT
+    | YEAR
+    | DAY
+    | MONTH
+    | HOUR
+    | MINUTE
+    | SECOND
     ;
 
 alias

--- a/jdbc-v2/src/main/antlr4/com/clickhouse/jdbc/internal/ClickHouseParser.g4
+++ b/jdbc-v2/src/main/antlr4/com/clickhouse/jdbc/internal/ClickHouseParser.g4
@@ -49,7 +49,7 @@ namedQuery
     ;
 
 columnAliases
-    : LPAREN? identifier (',' identifier)* RPAREN?
+    : LPAREN identifier (',' identifier)* RPAREN
     ;
 
 cteUnboundCol

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/ParsedPreparedStatement.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/ParsedPreparedStatement.java
@@ -173,6 +173,11 @@ public class ParsedPreparedStatement extends ClickHouseParserBaseListener {
     }
 
     @Override
+    public void enterCteUnboundColParam(ClickHouseParser.CteUnboundColParamContext ctx) {
+        appendParameter(ctx.start.getStartIndex());
+    }
+
+    @Override
     public void visitErrorNode(ErrorNode node) {
         setHasErrors(true);
     }

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/SqlParserTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/SqlParserTest.java
@@ -281,6 +281,7 @@ public class SqlParserTest {
             {"insert into `events` (s) values ('a')", 0},
             {"SELECT COUNT(*) > 0 FROM system.databases WHERE name = ?", 1},
             {"SELECT count(*) > 0 FROM system.databases WHERE c1 = ?", 1},
+            {"SELECT COUNT() FROM system.databases WHERE name = ?", 1},
             {"alter table user delete where reg_time = ?", 1},
             {"SELECT * FROM a,b WHERE id > ?", 1},
             {"DROP USER IF EXISTS default_impersonation_user", 0},
@@ -304,8 +305,17 @@ public class SqlParserTest {
             {"GRANT ON CLUSTER '{cluster}' `metabase_test_role`, `metabase-test-role` TO `metabase_test_user`", 0},
             {"SELECT * FROM `test_data`.`categories` WHERE id = 1::String or id = ?", 1},
             {"SELECT * FROM `test_data`.`categories` WHERE id = cast(1 as String) or id = ?", 1},
+            {"select * from test_data.categories WHERE test_data.categories.name = ? limit 4", 1},
             {INSERT_INLINE_DATA, 0},
                 {"select sum(value) from `uuid_filter_db`.`uuid_filter_table` WHERE `uuid_filter_db`.`uuid_filter_table`.`uuid` IN (CAST('36f7f85c-d7f4-49e2-af05-f45d5f6636ad' AS UUID))", 0},
+                {"SELECT DISTINCT ON (column) FROM table WHER column > ?", 1},
+                {"SELECT * FROM test_table \nUNION\n DISTINCT SELECT * FROM test_table", 0},
+                {"SELECT * FROM test_table1 \nUNION\n SELECT * FROM test_table2 WHERE test_table2.column1 = ?", 1},
+            {PARAMETRIZED_VIEW, 0},
+            {COMPLEX_CTE, 0},
+            {"select toYear(dt) year from test WHERE val=?", 1},
+            {"select toYear(dt) AS year from test WHERE val=?", 1},
+            {"select toYear(dt) AS yearx from test WHERE val=?", 1},
         };
     }
 
@@ -313,4 +323,72 @@ public class SqlParserTest {
             "INSERT INTO `interval_15_XUTLZWBLKMNZZPRZSKRF`.`checkins` (`timestamp`, `id`) " +
                     "VALUES ((`now64`(9) + INTERVAL -225 second), 1)";
 
+    private static final String PARAMETRIZED_VIEW = "CREATE VIEW default.test\n" +
+            "AS \n" +
+            "WITH    \n" +
+            "    toDateTime({from:String}, 'Asia/Seoul') AS FROM,    \n" +
+            "    date_add(FROM, INTERVAL 1 MINUTE) AS TO,    \n" +
+            "    {target_id:String} AS TARGET_ID \n" +
+            "SELECT FROM, TO, TARGET_ID";
+
+    private static final String COMPLEX_CTE = "WITH ? AS starting_time, ? AS ending_time, ? AS session_timeout, ? AS starting_event, ? AS ending_event, SessionData AS (\n" +
+            "    WITH\n" +
+            "        date,\n" +
+            "        arraySort(\n" +
+            "            groupArray(\n" +
+            "              (\n" +
+            "                  tracking.event.time,\n" +
+            "                  tracking.event.event\n" +
+            "              )\n" +
+            "            )\n" +
+            "        ) AS _sorted_events,\n" +
+            "        arrayEnumerate(_sorted_events) AS _event_serial,\n" +
+            "        arrayDifference(_sorted_events.1) AS _event_time_diff,\n" +
+            "        \n" +
+            "        arrayFilter(\n" +
+            "            (x, y, z) -> y > session_timeout OR z.2 = starting_event,\n" +
+            "            _event_serial,\n" +
+            "            _event_time_diff,\n" +
+            "            _sorted_events\n" +
+            "        ) AS _gap_index_1,\n" +
+            "\n" +
+            "        arrayFilter(\n" +
+            "            (x, y) -> y.2 = ending_event,\n" +
+            "            _event_serial,\n" +
+            "            _sorted_events\n" +
+            "        ) AS _gap_index_2_,\n" +
+            "        arrayMap(\n" +
+            "            x -> x + 1,\n" +
+            "            _gap_index_2_\n" +
+            "        ) AS _gap_index_2,\n" +
+            "\n" +
+            "        arrayMap(x -> if (has(_gap_index_1,x) OR has(_gap_index_2,x), 1, 0), _event_serial) AS _session_splitter,\n" +
+            "        arraySplit((x, y) -> y, _sorted_events, _session_splitter) AS _session_chain\n" +
+            "    SELECT\n" +
+            "        date,\n" +
+            "        user_id AS user_id,\n" +
+            "        arrayJoin(_session_chain) AS event_chain,\n" +
+            "        \n" +
+            "        arrayCompact(x -> x.2, event_chain) AS event_chain_dedup\n" +
+            "    FROM tracking.event\n" +
+            "    WHERE\n" +
+            "        project=? AND time>=starting_time AND time<ending_time\n" +
+            "        AND event NOT IN (?, ?, ?, ?)\n" +
+            "    GROUP BY\n" +
+            "        date,\n" +
+            "        user_id\n" +
+            "),\n" +
+            "SessionOverallInfo AS (\n" +
+            "    SELECT\n" +
+            "        date,\n" +
+            "        COUNT(*) AS number_of_sessions\n" +
+            "    FROM SessionData\n" +
+            "    GROUP BY date\n" +
+            ")\n" +
+            "SELECT\n" +
+            "    SessionOverallInfo.date, SessionOverallInfo.number_of_sessions AS number_of_total_sessions\n" +
+            "FROM\n" +
+            "    SessionOverallInfo\n" +
+            "ORDER BY\n" +
+            "    SessionOverallInfo.date";
 }


### PR DESCRIPTION
## Summary
This PR does fixes in parser grammar to handle:
1. CTE with unbound columns
2. IN expressions like "SELECT * FROM t WHERE v in (?)" 
3. keyword aliases 

Closes https://github.com/ClickHouse/clickhouse-java/issues/2500
Closes https://github.com/ClickHouse/clickhouse-java/issues/2493
Closes https://github.com/ClickHouse/clickhouse-java/issues/2478
Closes #2504 

## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

