### PR TITLE
Adjust format of ResultSet.getString() for DateTime

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
@@ -341,10 +341,16 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
         } else if (value instanceof ZonedDateTime) {
             ClickHouseDataType dataType = column.getDataType();
             ZonedDateTime zdt = (ZonedDateTime) value;
-            if (dataType == ClickHouseDataType.Date) {
-                return zdt.format(com.clickhouse.client.api.DataTypeUtils.DATE_FORMATTER);
+            switch (dataType) { // should not be null
+                case Date:
+                case Date32:
+                    return zdt.format(DataTypeUtils.DATE_FORMATTER);
+                case DateTime:
+                case DateTime32:
+                    return zdt.format(DataTypeUtils.DATETIME_FORMATTER);
+                default:
+                    return value.toString();
             }
-            return value.toString();
         } else if (value instanceof BinaryStreamReader.EnumValue) {
             return ((BinaryStreamReader.EnumValue)value).name;
         } else if (value instanceof Number ) {

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/StatementTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/StatementTest.java
@@ -136,8 +136,8 @@ public class StatementTest extends JdbcIntegrationTest {
                     assertEquals(rs.getString("date"), "2020-01-01");
                     assertEquals(rs.getDate(2).toString(), "2020-01-01");
                     assertEquals(rs.getDate("datetime").toString(), "2020-01-01");
-                    assertEquals(rs.getString(2), "2020-01-01T10:11:12+03:00[Asia/Istanbul]");
-                    assertEquals(rs.getString("datetime"), "2020-01-01T10:11:12+03:00[Asia/Istanbul]");
+                    assertEquals(rs.getString(2), "2020-01-01 10:11:12");
+                    assertEquals(rs.getString("datetime"), "2020-01-01 10:11:12");
                     assertFalse(rs.next());
                 }
             }


### PR DESCRIPTION
## Summary
This PR makes changes the format of `ResultSet.getString()` for Date32, DateTime, and DateTime32 columns to a more traditional format, i.e.

- YYYY-MM-dd for Date / Date32
- YYYY-MM-dd HH:mm:ss for DateTime / DateTime32

This PR does _not_ change any of the existing time zone magic.

Closes #2408 #2448

## Checklist
Delete items not relevant to your PR:
- [ :heavy_check_mark: ] Closes #2448
- [ :heavy_check_mark:  ] Unit and integration tests covering the common scenarios were added

