### PR TITLE
[client-v2] fix reading error

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/ClickHouseLZ4InputStream.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/ClickHouseLZ4InputStream.java
@@ -91,6 +91,14 @@ public class ClickHouseLZ4InputStream extends InputStream {
         return true;
     }
 
+    public byte[] getHeaderBuffer() {
+        return headerBuff;
+    }
+
+    public InputStream getInputStream() {
+        return in;
+    }
+
     private int refill() throws IOException {
 
         // read header


### PR DESCRIPTION
## Summary
There are cases when error response comes uncompressed even compression is requested. 
This PR detects the issue and fallback on reading response stream directly. 

This problem exists with the latest version of ClickHouse and this PR has no new test because fixes existing ones.

Affected test: `com.clickhouse.client.HttpTransportTests#testServerErrorHandling`. It check error handling for different formats. 

Closes https://github.com/ClickHouse/clickhouse-java/issues/2455
Closes https://github.com/ClickHouse/clickhouse-java/issues/2440

## Checklist
Delete items not relevant to your PR:
- [x] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
