### PR TITLE
[JDBC-v2] Removed too verbose logs. Lowered some logs level to debug

### DIFF
--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDriver.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/ClickHouseDriver.java
@@ -20,8 +20,7 @@ public class ClickHouseDriver implements java.sql.Driver {
     }
 
     public ClickHouseDriver() {
-//        log.debug("Creating a new instance of the 'proxy' ClickHouseDriver");
-        log.info("ClickHouse JDBC driver version: {}", ClickHouseDriver.class.getPackage().getImplementationVersion());
+        log.debug("ClickHouse JDBC driver version: {}", ClickHouseDriver.class.getPackage().getImplementationVersion());
         urlFlagSent = false;
         this.driver = getDriver(null);
     }
@@ -52,7 +51,7 @@ public class ClickHouseDriver implements java.sql.Driver {
         log.debug("Checking if V1 driver is requested. V2 is the default driver.");
         boolean v1Flag = Boolean.parseBoolean(System.getProperty("clickhouse.jdbc.v1", "false"));
         if (v1Flag) {
-            log.info("V1 driver is requested through system property.");
+            log.debug("V1 driver is requested through system property.");
             return false;
         }
 
@@ -60,13 +59,13 @@ public class ClickHouseDriver implements java.sql.Driver {
             urlFlagSent = true;
 
             if (url.contains("clickhouse.jdbc.v1=true")) {
-                log.info("V1 driver is requested through URL.");
+                log.debug("V1 driver is requested through URL.");
                 return false;
             } if (url.contains("clickhouse.jdbc.v2=false")) {
-                log.info("V1 driver is requested through URL.");
+                log.debug("V1 driver is requested through URL.");
                 return false;
             } else {
-                log.info("V2 driver is requested through URL.");
+                log.debug("V2 driver is requested through URL.");
                 return true;
             }
         }
@@ -81,10 +80,10 @@ public class ClickHouseDriver implements java.sql.Driver {
         }
 
         if (isV2(url)) {
-            log.info("v2 driver");
+            log.debug("v2 driver");
             driver = new com.clickhouse.jdbc.Driver();
         } else {
-            log.info("v1 driver");
+            log.debug("v1 driver");
             driver = new DriverV1();
         }
 

--- a/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/DriverV1.java
+++ b/clickhouse-jdbc/src/main/java/com/clickhouse/jdbc/DriverV1.java
@@ -109,7 +109,7 @@ public class DriverV1 implements Driver {
 
     public static void load() {
         try {
-            log.info("Registering ClickHouse JDBC driver v1 ({})", driverVersion);
+            log.debug("Registering ClickHouse JDBC driver v1 ({})", driverVersion);
             DriverManager.registerDriver(new DriverV1());
         } catch (SQLException e) {
             throw new IllegalStateException(e);
@@ -120,7 +120,7 @@ public class DriverV1 implements Driver {
 
     public static void unload() {
         try {
-            log.info("Unregistering ClickHouse JDBC driver v1 ({})", driverVersion);
+            log.debug("Unregistering ClickHouse JDBC driver v1 ({})", driverVersion);
             DriverManager.deregisterDriver(new DriverV1());
         } catch (SQLException e) {
             throw new IllegalStateException(e);

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/ConnectionImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/ConnectionImpl.java
@@ -67,7 +67,6 @@ public class ConnectionImpl implements Connection, JdbcV2Wrapper {
 
     public ConnectionImpl(String url, Properties info) throws SQLException {
         try {
-            log.debug("Creating connection to {}", url);
             this.url = url;//Raw URL
             this.config = new JdbcConfiguration(url, info);
             this.onCluster = false;

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/Driver.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/Driver.java
@@ -64,7 +64,7 @@ public class Driver implements java.sql.Driver {
         log.debug("Initializing ClickHouse JDBC driver V2");
 
         driverVersion = ClickHouseClientOption.readVersionFromResource("jdbc-v2-version.properties");
-        log.info("ClickHouse JDBC driver version: {}", driverVersion);
+        log.debug("ClickHouse JDBC driver version: {}", driverVersion);
 
         int tmpMajorVersion;
         int tmpMinorVersion;

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java
@@ -744,7 +744,7 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
      */
     @Override
     public ResultSet getTables(String catalog, String schemaPattern, String tableNamePattern, String[] types) throws SQLException {
-        log.info("getTables: catalog={}, schemaPattern={}, tableNamePattern={}, types={}", catalog, schemaPattern, tableNamePattern, types);
+        log.debug("getTables: catalog={}, schemaPattern={}, tableNamePattern={}, types={}", catalog, schemaPattern, tableNamePattern, types);
         // TODO: when switch between catalog and schema is implemented, then TABLE_SCHEMA and TABLE_CAT should be populated accordingly
 //        String commentColumn = connection.getServerVersion().check("[21.6,)") ? "t.comment" : "''";
         // TODO: handle useCatalogs == true and return schema catalog name


### PR DESCRIPTION
## Summary
- Removes too verbose and unsafe logging 
- Lowers some logs level to `debug`.

Closes https://github.com/ClickHouse/clickhouse-java/issues/2148
## Checklist
Delete items not relevant to your PR:
- [x] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
