### PR TITLE
[JDBC-V2] Fix DatabaseMetadata to return empty ResultSet where expected

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java
@@ -903,7 +903,6 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
     @Override
     public ResultSet getColumnPrivileges(String catalog, String schema, String table, String columnNamePattern) throws SQLException {
         //Return an empty result set with the required columns
-        log.warn("getColumnPrivileges is not supported and may return invalid results");
         try {
             return connection.createStatement().executeQuery("SELECT NULL::Nullable(String) AS TABLE_CAT, " +
                     "NULL::Nullable(String) AS TABLE_SCHEM, " +
@@ -922,7 +921,6 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
     @Override
     public ResultSet getTablePrivileges(String catalog, String schemaPattern, String tableNamePattern) throws SQLException {
         //Return an empty result set with the required columns
-        log.warn("getTablePrivileges is not supported and may return invalid results");
         try {
             return connection.createStatement().executeQuery("SELECT NULL::Nullable(String) AS TABLE_CAT, " +
                     "NULL::Nullable(String) AS TABLE_SCHEM, " +
@@ -940,7 +938,6 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
     @Override
     public ResultSet getBestRowIdentifier(String catalog, String schema, String table, int scope, boolean nullable) throws SQLException {
         //Return an empty result set with the required columns
-        log.warn("getBestRowIdentifier is not supported and may return invalid results");
         try {
             return connection.createStatement().executeQuery("SELECT NULL::Nullable(Int16) AS SCOPE, " +
                     "NULL::Nullable(String) AS COLUMN_NAME, " +
@@ -959,7 +956,6 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
     @Override
     public ResultSet getVersionColumns(String catalog, String schema, String table) throws SQLException {
         //Return an empty result set with the required columns
-        log.warn("getVersionColumns is not supported and may return invalid results");
         try {
             return connection.createStatement().executeQuery("SELECT NULL::Nullable(Int16) AS SCOPE, " +
                     "NULL::Nullable(String) AS COLUMN_NAME, " +
@@ -1025,7 +1021,6 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
     @Override
     public ResultSet getExportedKeys(String catalog, String schema, String table) throws SQLException {
         // ClickHouse has no notion of foreign key. This method should return empty resultset
-        log.warn("getExportedKeys is not supported and may return invalid results");
         try {
             return connection.createStatement().executeQuery("SELECT NULL::Nullable(String) AS PKTABLE_CAT, " +
                     "NULL::Nullable(String) AS PKTABLE_SCHEM, " +
@@ -1050,7 +1045,6 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
     @Override
     public ResultSet getCrossReference(String parentCatalog, String parentSchema, String parentTable, String foreignCatalog, String foreignSchema, String foreignTable) throws SQLException {
         //Return an empty result set with the required columns
-        log.warn("getCrossReference is not supported and may return invalid results");
         try {
             String columns = "NULL ::Nullable(String) AS PKTABLE_CAT, " +
                     "NULL::Nullable(String) AS PKTABLE_SCHEM, " +
@@ -1227,7 +1221,6 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
     @Override
     public ResultSet getUDTs(String catalog, String schemaPattern, String typeNamePattern, int[] types) throws SQLException {
         //Return an empty result set with the required columns
-        log.warn("getUDTs is not supported and may return invalid results");
         try {
             return connection.createStatement().executeQuery("SELECT " +
                     "NULL::Nullable(String) AS TYPE_CAT, " +
@@ -1274,7 +1267,6 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
     @Override
     public ResultSet getSuperTypes(String catalog, String schemaPattern, String typeNamePattern) throws SQLException {
         //Return an empty result set with the required columns
-        log.warn("getSuperTypes is not supported and may return invalid results");
         try {
             return connection.createStatement().executeQuery(
                     "SELECT NULL::Nullable(String) AS TYPE_CAT, "
@@ -1292,7 +1284,6 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
     @Override
     public ResultSet getSuperTables(String catalog, String schemaPattern, String tableNamePattern) throws SQLException {
         //Return an empty result set with the required columns
-        log.warn("getSuperTables is not supported and may return invalid results");
         try {
             return connection.createStatement().executeQuery(
                     "SELECT "
@@ -1309,7 +1300,6 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
     @Override
     public ResultSet getAttributes(String catalog, String schemaPattern, String typeNamePattern, String attributeNamePattern) throws SQLException {
         //Return an empty result set with the required columns
-        log.warn("getAttributes is not supported and may return invalid results");
         try {
             return connection.createStatement().executeQuery(
                     "SELECT "
@@ -1334,7 +1324,7 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
                     + "NULL::Nullable(String) AS SCOPE_SCHEMA, "
                     + "NULL::Nullable(String) AS SCOPE_TABLE, "
                     + "NULL::Nullable(Int16) AS SOURCE_DATA_TYPE" +
-                        "  LIMIT 0");
+                        " LIMIT 0");
         } catch (Exception e) {
             throw ExceptionUtils.toSqlState(e);
         }

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java
@@ -3,12 +3,12 @@ package com.clickhouse.jdbc.metadata;
 import com.clickhouse.client.api.sql.SQLUtils;
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseDataType;
+import com.clickhouse.jdbc.ClientInfoProperties;
 import com.clickhouse.jdbc.ConnectionImpl;
 import com.clickhouse.jdbc.Driver;
+import com.clickhouse.jdbc.DriverProperties;
 import com.clickhouse.jdbc.JdbcV2Wrapper;
 import com.clickhouse.jdbc.ResultSetImpl;
-import com.clickhouse.jdbc.ClientInfoProperties;
-import com.clickhouse.jdbc.DriverProperties;
 import com.clickhouse.jdbc.internal.ExceptionUtils;
 import com.clickhouse.jdbc.internal.JdbcUtils;
 import com.clickhouse.jdbc.internal.MetadataResultSet;
@@ -912,7 +912,8 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
                     "NULL::Nullable(String) AS GRANTOR, " +
                     "NULL::Nullable(String) AS GRANTEE, " +
                     "NULL::Nullable(String) AS PRIVILEGE, " +
-                    "NULL::Nullable(String) AS IS_GRANTABLE");
+                    "NULL::Nullable(String) AS IS_GRANTABLE" +
+                    " LIMIT 0");
         } catch (Exception e) {
             throw ExceptionUtils.toSqlState(e);
         }
@@ -929,7 +930,8 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
                     "NULL::Nullable(String) AS GRANTOR, " +
                     "NULL::Nullable(String) AS GRANTEE, " +
                     "NULL::Nullable(String) AS PRIVILEGE, " +
-                    "NULL::Nullable(String) AS IS_GRANTABLE");
+                    "NULL::Nullable(String) AS IS_GRANTABLE" +
+                    " LIMIT 0");
         } catch (Exception e) {
             throw ExceptionUtils.toSqlState(e);
         }
@@ -947,7 +949,8 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
                     "NULL::Nullable(Int32) AS COLUMN_SIZE, " +
                     "NULL::Nullable(Int32) AS BUFFER_LENGTH, " +
                     "NULL::Nullable(Int16) AS DECIMAL_DIGITS, " +
-                    "NULL::Nullable(Int16) AS PSEUDO_COLUMN");
+                    "NULL::Nullable(Int16) AS PSEUDO_COLUMN" +
+                    " LIMIT 0");
         } catch (Exception e) {
             throw ExceptionUtils.toSqlState(e);
         }
@@ -965,7 +968,8 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
                     "NULL::Nullable(Int32) AS COLUMN_SIZE, " +
                     "NULL::Nullable(Int32) AS BUFFER_LENGTH, " +
                     "NULL::Nullable(Int16) AS DECIMAL_DIGITS, " +
-                    "NULL::Nullable(Int16) AS PSEUDO_COLUMN");
+                    "NULL::Nullable(Int16) AS PSEUDO_COLUMN" +
+                    " LIMIT 0");
         } catch (Exception e) {
             throw ExceptionUtils.toSqlState(e);
         }
@@ -995,8 +999,7 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
 
     @Override
     public ResultSet getImportedKeys(String catalog, String schema, String table) throws SQLException {
-        //Return an empty result set with the required columns
-        log.warn("getImportedKeys is not supported and may return invalid results");
+        // ClickHouse has no notion of foreign key. This method should return empty resultset
         try {
             String sql = "SELECT NULL::Nullable(String) AS PKTABLE_CAT, " +
                     "NULL::Nullable(String) AS PKTABLE_SCHEM, " +
@@ -1011,7 +1014,8 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
                     "NULL::Nullable(Int16) AS DELETE_RULE, " +
                     "NULL::Nullable(String) AS FK_NAME, " +
                     "NULL::Nullable(String) AS PK_NAME, " +
-                    "NULL::Nullable(Int16) AS DEFERRABILITY";
+                    "NULL::Nullable(Int16) AS DEFERRABILITY" +
+                    " LIMIT 0";
             return connection.createStatement().executeQuery(sql);
         } catch (Exception e) {
             throw ExceptionUtils.toSqlState(e);
@@ -1020,7 +1024,7 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
 
     @Override
     public ResultSet getExportedKeys(String catalog, String schema, String table) throws SQLException {
-        //Return an empty result set with the required columns
+        // ClickHouse has no notion of foreign key. This method should return empty resultset
         log.warn("getExportedKeys is not supported and may return invalid results");
         try {
             return connection.createStatement().executeQuery("SELECT NULL::Nullable(String) AS PKTABLE_CAT, " +
@@ -1036,7 +1040,8 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
                     "NULL::Nullable(Int16) AS DELETE_RULE, " +
                     "NULL::Nullable(String) AS FK_NAME, " +
                     "NULL::Nullable(String) AS PK_NAME, " +
-                    "NULL::Nullable(Int16) AS DEFERRABILITY");
+                    "NULL::Nullable(Int16) AS DEFERRABILITY" +
+                    " LIMIT 0");
         } catch (Exception e) {
             throw ExceptionUtils.toSqlState(e);
         }
@@ -1060,7 +1065,8 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
                     "NULL::Nullable(Int16) AS DELETE_RULE, " +
                     "NULL::Nullable(String) AS FK_NAME, " +
                     "NULL::Nullable(String) AS PK_NAME, " +
-                    "NULL::Nullable(Int16) AS DEFERRABILITY";
+                    "NULL::Nullable(Int16) AS DEFERRABILITY" +
+                    " LIMIT 0";
             return connection.createStatement().executeQuery("SELECT " + columns);
         } catch (Exception e) {
             throw ExceptionUtils.toSqlState(e);
@@ -1150,7 +1156,8 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
                 "null::Nullable(String) AS ASC_OR_DESC, " +
                 "null::Nullable(Int64) AS CARDINALITY, " +
                 "null::Nullable(Int64) AS PAGES, " +
-                "null::Nullable(String) AS FILTER_CONDITION ";
+                "null::Nullable(String) AS FILTER_CONDITION " +
+                    " LIMIT 0";
             return connection.createStatement().executeQuery(sql);
         } catch (Exception e) {
             throw ExceptionUtils.toSqlState(e);
@@ -1229,7 +1236,8 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
                     "NULL::Nullable(String) AS CLASS_NAME, " +
                     "NULL::Nullable(Int32) AS DATA_TYPE, " +
                     "NULL::Nullable(String) AS REMARKS, " +
-                    "NULL::Nullable(Int16) AS BASE_TYPE");
+                    "NULL::Nullable(Int16) AS BASE_TYPE" +
+                    " LIMIT 0");
         } catch (Exception e) {
             throw ExceptionUtils.toSqlState(e);
         }
@@ -1274,7 +1282,8 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
                     + "NULL::Nullable(String) AS TYPE_NAME, "
                     + "NULL::Nullable(String) AS SUPERTYPE_CAT, "
                     + "NULL::Nullable(String) AS SUPERTYPE_SCHEM, "
-                    + "NULL::Nullable(String) AS SUPERTYPE_NAME");
+                    + "NULL::Nullable(String) AS SUPERTYPE_NAME" +
+                            " LIMIT 0");
         } catch (Exception e) {
             throw ExceptionUtils.toSqlState(e);
         }
@@ -1290,7 +1299,8 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
                     + "NULL::Nullable(String) AS TABLE_CAT, "
                     + "NULL::Nullable(String) AS TABLE_SCHEM, "
                     + "NULL::Nullable(String) AS TABLE_NAME, "
-                    + "NULL::Nullable(String) AS SUPERTABLE_NAME");
+                    + "NULL::Nullable(String) AS SUPERTABLE_NAME" +
+                        " LIMIT 0");
         } catch (Exception e) {
             throw ExceptionUtils.toSqlState(e);
         }
@@ -1323,7 +1333,8 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
                     + "NULL::Nullable(String) AS SCOPE_CATALOG, "
                     + "NULL::Nullable(String) AS SCOPE_SCHEMA, "
                     + "NULL::Nullable(String) AS SCOPE_TABLE, "
-                    + "NULL::Nullable(Int16) AS SOURCE_DATA_TYPE");
+                    + "NULL::Nullable(Int16) AS SOURCE_DATA_TYPE" +
+                        "  LIMIT 0");
         } catch (Exception e) {
             throw ExceptionUtils.toSqlState(e);
         }

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataTest.java
@@ -3,9 +3,9 @@ package com.clickhouse.jdbc.metadata;
 import com.clickhouse.client.ClickHouseServerForTest;
 import com.clickhouse.data.ClickHouseDataType;
 import com.clickhouse.data.ClickHouseVersion;
-import com.clickhouse.jdbc.JdbcIntegrationTest;
 import com.clickhouse.jdbc.ClientInfoProperties;
 import com.clickhouse.jdbc.DriverProperties;
+import com.clickhouse.jdbc.JdbcIntegrationTest;
 import com.clickhouse.jdbc.internal.JdbcUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -467,7 +467,7 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
         try (Connection conn = getJdbcConnection()) {
             DatabaseMetaData dbmd = conn.getMetaData();
             try (ResultSet rs = dbmd.getFunctionColumns(null, null, "mapContains", null)) {
-
+                assertFalse(rs.next());
                 List<String> expectedColumnNames = Arrays.asList(
                         "FUNCTION_CAT",
                         "FUNCTION_SCHEM",
@@ -577,6 +577,7 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
             );
 
             ResultSet rs = dbmd.getIndexInfo(null, null, null, false, false);
+            assertFalse(rs.next());
             ResultSetMetaData rsmd = rs.getMetaData();
             assertProcedureColumns(rsmd, expectedColumnNames, expectedColumnTypes);
         }
@@ -592,6 +593,7 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
                     Types.SMALLINT, Types.SMALLINT, Types.VARCHAR, Types.SMALLINT, Types.VARCHAR);
 
             ResultSet rs = dbmd.getProcedures(null, null, null);
+            assertFalse(rs.next());
             ResultSetMetaData rsmd = rs.getMetaData();
             assertProcedureColumns(rsmd, columnNames, columnTypes);
         }
@@ -645,6 +647,7 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
                     Types.VARCHAR,
                     Types.VARCHAR);
             ResultSetMetaData rsmd = dbmd.getProcedureColumns(null, null, null, null).getMetaData();
+
             assertProcedureColumns(rsmd, expectedColumnNames, columnTypes);
         }
     }
@@ -655,7 +658,7 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
         try (Connection conn = getJdbcConnection()) {
             DatabaseMetaData dbmd = conn.getMetaData();
             ResultSet rs = dbmd.getColumnPrivileges(null, null, null, null);
-
+            assertFalse(rs.next());
             List<String> expectedColumnNames = Arrays.asList("TABLE_CAT",
                     "TABLE_SCHEM",
                     "TABLE_NAME",
@@ -686,7 +689,7 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
         try (Connection conn = getJdbcConnection()) {
             DatabaseMetaData dbmd = conn.getMetaData();
             ResultSet rs = dbmd.getTablePrivileges(null, null, null);
-
+            assertFalse(rs.next());
             List<String> expectedColumnNames = Arrays.asList("TABLE_CAT",
                     "TABLE_SCHEM",
                     "TABLE_NAME",
@@ -714,7 +717,7 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
         try (Connection conn = getJdbcConnection()) {
             DatabaseMetaData dbmd = conn.getMetaData();
             ResultSet rs = dbmd.getVersionColumns(null, null, null);
-
+            assertFalse(rs.next());
             List<String> expectedColumnNames = Arrays.asList("SCOPE",
                     "COLUMN_NAME",
                     "DATA_TYPE",
@@ -771,8 +774,10 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
         try (Connection conn = getJdbcConnection()) {
             DatabaseMetaData dbmd = conn.getMetaData();
             ResultSet rs = dbmd.getImportedKeys(null, null, null);
+            assertFalse(rs.next());
 
-            List<String> expectedColumnNames = Arrays.asList("PKTABLE_CAT",
+            List<String> expectedColumnNames = Arrays.asList(
+                    "PKTABLE_CAT",
                     "PKTABLE_SCHEM",
                     "PKTABLE_NAME",
                     "PKCOLUMN_NAME",
@@ -813,7 +818,7 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
         try (Connection conn = getJdbcConnection()) {
             DatabaseMetaData dbmd = conn.getMetaData();
             ResultSet rs = dbmd.getExportedKeys(null, null, null);
-
+            assertFalse(rs.next());
             List<String> expectedColumnNames = Arrays.asList("PKTABLE_CAT",
                     "PKTABLE_SCHEM",
                     "PKTABLE_NAME",
@@ -856,7 +861,7 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
         try (Connection conn = getJdbcConnection()) {
             DatabaseMetaData dbmd = conn.getMetaData();
             ResultSet rs = dbmd.getCrossReference(null, null, null, null, null, null);
-
+            assertFalse(rs.next());
             List<String> expectedColumnNames = Arrays.asList("PKTABLE_CAT",
                     "PKTABLE_SCHEM",
                     "PKTABLE_NAME",
@@ -898,7 +903,7 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
         try (Connection conn = getJdbcConnection()) {
             DatabaseMetaData dbmd = conn.getMetaData();
             ResultSet rs = dbmd.getUDTs(null, null, null, null);
-
+            assertFalse(rs.next());
             List<String> expectedColumnNames = Arrays.asList("TYPE_CAT",
                     "TYPE_SCHEM",
                     "TYPE_NAME",
@@ -927,7 +932,7 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
         try (Connection conn = getJdbcConnection()) {
             DatabaseMetaData dbmd = conn.getMetaData();
             ResultSet rs = dbmd.getSuperTypes(null, null, null);
-
+            assertFalse(rs.next());
             List<String> expectedColumnNames = Arrays.asList("TYPE_CAT",
                     "TYPE_SCHEM",
                     "TYPE_NAME",
@@ -953,7 +958,7 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
         try (Connection conn = getJdbcConnection()) {
             DatabaseMetaData dbmd = conn.getMetaData();
             ResultSet rs = dbmd.getSuperTables(null, null, null);
-
+            assertFalse(rs.next());
             List<String> expectedColumnNames = Arrays.asList("TABLE_CAT",
                     "TABLE_SCHEM",
                     "TABLE_NAME",
@@ -976,7 +981,7 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
         try (Connection conn = getJdbcConnection()) {
             DatabaseMetaData dbmd = conn.getMetaData();
             ResultSet rs = dbmd.getBestRowIdentifier(null, null, null, 0, true);
-
+            assertFalse(rs.next());
             List<String> expectedColumnNames = Arrays.asList("SCOPE",
                     "COLUMN_NAME",
                     "DATA_TYPE",
@@ -1007,7 +1012,7 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
         try (Connection conn = getJdbcConnection()) {
             DatabaseMetaData dbmd = conn.getMetaData();
             ResultSet rs = dbmd.getAttributes(null, null, null, null);
-
+            assertFalse(rs.next());
             List<String> expectedColumnNames = Arrays.asList("TYPE_CAT",
                     "TYPE_SCHEM",
                     "TYPE_NAME",
@@ -1064,7 +1069,7 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
         try (Connection conn = getJdbcConnection()) {
             DatabaseMetaData dbmd = conn.getMetaData();
             ResultSet rs = dbmd.getPseudoColumns(null, null, null, null);
-
+            assertFalse(rs.next());
             List<String> expectedColumnNames = Arrays.asList("TABLE_CAT",
                     "TABLE_SCHEM",
                     "TABLE_NAME",


### PR DESCRIPTION
## Summary
 There are some method in metadata that should return empty dataset with specific structure. Previously a single row with default values was returned. This breaks UI tools because they use this data for further work. 

Closes https://github.com/ClickHouse/clickhouse-java/issues/2517
## Checklist
Delete items not relevant to your PR:
- [x] Closes #<issue ref>
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
