### PR TITLE
[JDBC-V2] Fix some metadata resultsets return inconsistent data on `getObject()` 

### DIFF
--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseColumn.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseColumn.java
@@ -38,6 +38,7 @@ import com.clickhouse.data.value.array.ClickHouseShortArrayValue;
 import java.io.Serializable;
 import java.lang.reflect.Array;
 import java.math.BigInteger;
+import java.sql.SQLException;
 import java.time.OffsetDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -90,6 +91,7 @@ public final class ClickHouseColumn implements Serializable {
     private List<ClickHouseColumn> nested;
     private List<String> parameters;
     private ClickHouseEnum enumConstants;
+    private ValueFunction valueFunction;
 
     private int arrayLevel;
     private ClickHouseColumn arrayBaseColumn;
@@ -787,6 +789,18 @@ public final class ClickHouseColumn implements Serializable {
         return dataType.isNested();
     }
 
+    public boolean hasValueFunction() {
+        return valueFunction != null;
+    }
+
+    public void setValueFunction(ValueFunction valueFunction) {
+        this.valueFunction = valueFunction;
+    }
+
+    public ValueFunction getValueFunction() {
+        return valueFunction;
+    }
+
     public int getArrayNestedLevel() {
         return arrayLevel;
     }
@@ -1125,5 +1139,10 @@ public final class ClickHouseColumn implements Serializable {
             builder.append(columnName);
         }
         return builder.append(' ').append(originalTypeName).toString();
+    }
+
+    public interface ValueFunction {
+
+        Object produceValue(Object[] row);
     }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/ClickHouseBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/ClickHouseBinaryFormatReader.java
@@ -1,6 +1,7 @@
 package com.clickhouse.client.api.data_formats;
 
 import com.clickhouse.client.api.metadata.TableSchema;
+import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.value.ClickHouseBitmap;
 import com.clickhouse.data.value.ClickHouseGeoMultiPolygonValue;
 import com.clickhouse.data.value.ClickHouseGeoPointValue;
@@ -545,4 +546,13 @@ public interface ClickHouseBinaryFormatReader extends AutoCloseable {
     TemporalAmount getTemporalAmount(int index);
 
     TemporalAmount getTemporalAmount(String colName);
+
+    /**
+     * ! Experimental ! Might change in the future.
+     * Sets a value function of a column. If column has a value function then reader will pass current row
+     * as Object[] to a function. The least is responsible for returning correct value or null.
+     * @param index - column index starting with 1
+     * @param function - function that will be used to calculate column value from current row.
+     */
+    default void setValueFunction(int index, ClickHouseColumn.ValueFunction function) {}
 }

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/ResultSetImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/ResultSetImpl.java
@@ -3,6 +3,7 @@ package com.clickhouse.jdbc;
 import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatReader;
 import com.clickhouse.client.api.metadata.TableSchema;
 import com.clickhouse.client.api.query.QueryResponse;
+import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseDataType;
 import com.clickhouse.jdbc.internal.ExceptionUtils;
 import com.clickhouse.jdbc.internal.JdbcUtils;
@@ -40,7 +41,7 @@ import java.util.Map;
 
 public class ResultSetImpl implements ResultSet, JdbcV2Wrapper {
     private static final Logger log = LoggerFactory.getLogger(ResultSetImpl.class);
-    private ResultSetMetaData metaData;
+    private ResultSetMetaDataImpl metaData;
     protected ClickHouseBinaryFormatReader reader;
     private QueryResponse response;
     private boolean closed;
@@ -136,6 +137,14 @@ public class ResultSetImpl implements ResultSet, JdbcV2Wrapper {
         if (e != null) {
             throw ExceptionUtils.toSqlState(e);
         }
+    }
+
+    public void setValueFunction(int colIndex, ClickHouseColumn.ValueFunction valueFunction) {
+        reader.setValueFunction(colIndex, valueFunction);
+    }
+
+    public void hideLastNColumns(int n) {
+        metaData.setColumnCount(metaData.getOriginalColumnCount() - n);
     }
 
     @Override

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/ResultSetMetaDataImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/ResultSetMetaDataImpl.java
@@ -5,6 +5,8 @@ import com.clickhouse.data.ClickHouseDataType;
 import com.clickhouse.jdbc.JdbcV2Wrapper;
 import com.clickhouse.jdbc.internal.ExceptionUtils;
 import com.clickhouse.jdbc.internal.JdbcUtils;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.UnmodifiableListIterator;
 
 import java.sql.SQLException;
 import java.util.List;
@@ -22,13 +24,16 @@ public class ResultSetMetaDataImpl implements java.sql.ResultSetMetaData, JdbcV2
 
     private final Map<ClickHouseDataType, Class<?>> typeClassMap;
 
+    private int columnCount;
+
     public ResultSetMetaDataImpl(List<ClickHouseColumn> columns, String schema, String catalog, String tableName,
                                  Map<ClickHouseDataType, Class<?>> typeClassMap) {
-        this.columns = columns;
+        this.columns = ImmutableList.copyOf(columns);
         this.schema = schema;
         this.catalog = catalog;
         this.tableName = tableName;
         this.typeClassMap = typeClassMap;
+        this.columnCount = columns.size();
     }
 
     private ClickHouseColumn getColumn(int column) throws SQLException {
@@ -41,7 +46,22 @@ public class ResultSetMetaDataImpl implements java.sql.ResultSetMetaData, JdbcV2
 
     @Override
     public int getColumnCount() throws SQLException {
+        return columnCount;
+    }
+
+    public int getOriginalColumnCount() {
         return columns.size();
+    }
+
+    /**
+     * This method used to truncate list of column so it is possible to
+     * "hide" columns from the end of the list.
+     * Note: we use this to implement column replacement. it is needed when DB calculation is too hard compare to a
+     * programmatic approach.
+     * @param columnCount
+     */
+    public void setColumnCount(int columnCount) {
+        this.columnCount = columnCount;
     }
 
     @Override

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataTest.java
@@ -15,6 +15,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
+import java.sql.Statement;
 import java.sql.Types;
 import java.util.Arrays;
 import java.util.Collections;
@@ -33,11 +34,17 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
     @Test(groups = { "integration" })
     public void testGetColumns() throws Exception {
         try (Connection conn = getJdbcConnection()) {
+            final String tableName = "get_columns_metadata_test";
+            try (Statement stmt = conn.createStatement()) {
+                stmt.executeUpdate("" +
+                        "CREATE TABLE " + tableName + " (id Int32, name String, v1 Nullable(Int8)) " +
+                        "ENGINE MergeTree ORDER BY ()");
+            }
+
             DatabaseMetaData dbmd = conn.getMetaData();
 
 
-            try (ResultSet rs = dbmd.getColumns(null, ClickHouseServerForTest.getDatabase(), "system.numbers"
-                    , null)) {
+            try (ResultSet rs = dbmd.getColumns(null, getDatabase(), tableName.substring(0, tableName.length() - 3) + "%", null)) {
 
                 List<String> expectedColumnNames = Arrays.asList(
                         "TABLE_CAT",
@@ -94,6 +101,30 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
                 );
 
                 assertProcedureColumns(rs.getMetaData(), expectedColumnNames, expectedColumnTypes);
+
+                assertTrue(rs.next());
+                assertEquals(rs.getString("TABLE_SCHEM"), getDatabase());
+                assertEquals(rs.getString("TABLE_NAME"), tableName);
+                assertEquals(rs.getString("COLUMN_NAME"), "id");
+                assertEquals(rs.getInt("DATA_TYPE"), Types.INTEGER);
+                assertEquals(rs.getObject("DATA_TYPE"), Types.INTEGER);
+                assertEquals(rs.getString("TYPE_NAME"), "Int32");
+
+                assertTrue(rs.next());
+                assertEquals(rs.getString("TABLE_SCHEM"), getDatabase());
+                assertEquals(rs.getString("TABLE_NAME"), tableName);
+                assertEquals(rs.getString("COLUMN_NAME"), "name");
+                assertEquals(rs.getInt("DATA_TYPE"), Types.VARCHAR);
+                assertEquals(rs.getObject("DATA_TYPE"), Types.VARCHAR);
+                assertEquals(rs.getString("TYPE_NAME"), "String");
+
+                assertTrue(rs.next());
+                assertEquals(rs.getString("TABLE_SCHEM"), getDatabase());
+                assertEquals(rs.getString("TABLE_NAME"), tableName);
+                assertEquals(rs.getString("COLUMN_NAME"), "v1");
+                assertEquals(rs.getInt("DATA_TYPE"), Types.TINYINT);
+                assertEquals(rs.getObject("DATA_TYPE"), Types.TINYINT);
+                assertEquals(rs.getString("TYPE_NAME"), "Nullable(Int8)");
             }
         }
     }
@@ -384,6 +415,8 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
                             "Type mismatch for " + dataType.name() + ": expected " +
                                     JdbcUtils.convertToSqlType(dataType).getVendorTypeNumber() +
                                     " but was " + rs.getInt("DATA_TYPE") + " for TYPE_NAME: " + rs.getString("TYPE_NAME"));
+
+                    assertEquals(rs.getInt("DATA_TYPE"), rs.getObject("DATA_TYPE"));
 
                     assertEquals(rs.getInt("PRECISION"), dataType.getMaxPrecision());
                     assertNull(rs.getString("LITERAL_PREFIX"));


### PR DESCRIPTION
## Summary

`DatabaseMetadata` has two methods `getColumns` and `getTypeInfo` which return a `ResultSet`. This result sets should contain ClickHouse data type name to an integer constant. Previously data was calculated on server but SQL became too hard to maintain. Then `MetadataResultSetImpl` was added to fix the issue to let override some columns. However it is not a good solution because need to do many compensation logic. 
This PR implements a new approach:
- Now value function can be added to a column. This lets reader to re-calculate value based on current row. It can be useful to do small transformations 
- Adds ability to ResultSetMetaDataImpl to "hide" last N columns. This lets to add needed information to a result set but hide it from user as they read `ResultSetMetadata` to find out columns.     
New approach do a few modification and what is important based on normal ResultSet implementation. 


Closes https://github.com/ClickHouse/clickhouse-java/issues/2396
## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
