### PR TITLE
[JDBC-V2] fix(`StatementImpl`/`PreparedStatementImpl`): prevent duplicate data insertion by clearing batch after execution for issue-2548

### DIFF
--- a/examples/jdbc/src/main/java/com/clickhouse/examples/jdbc/Basic.java
+++ b/examples/jdbc/src/main/java/com/clickhouse/examples/jdbc/Basic.java
@@ -59,11 +59,18 @@ public class Basic {
                 pstmt.setString(3, "Alice");//Set the third parameter to "Alice"
                 pstmt.setObject(4, Collections.singletonMap("key1", "value1"));
                 pstmt.addBatch();//Add the current parameters to the batch
+                pstmt.executeBatch();//Execute the batch
 
                 pstmt.setObject(1, ZonedDateTime.now());
                 pstmt.setInt(2, 2);//Set the second parameter to 2
                 pstmt.setString(3, "Bob");//Set the third parameter to "Bob"
                 pstmt.setObject(4, Collections.singletonMap("key2", "value2"));
+                pstmt.addBatch();//Add the current parameters to the batch
+
+                pstmt.setObject(1, ZonedDateTime.now());
+                pstmt.setInt(2, 2);//Set the second parameter to 2
+                pstmt.setString(3, "Chris");//Set the third parameter to "Chris"
+                pstmt.setObject(4, Collections.singletonMap("key3", "value3"));
                 pstmt.addBatch();//Add the current parameters to the batch
 
                 pstmt.executeBatch();//Execute the batch

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/PreparedStatementImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/PreparedStatementImpl.java
@@ -332,15 +332,23 @@ public class PreparedStatementImpl extends StatementImpl implements PreparedStat
     }
 
     private List<Integer> executeBatchImpl() throws SQLException {
+        List<Integer> results;
         if (insertStmtWithValues) {
-            return executeInsertBatch();
+            results = executeInsertBatch();
         } else {
-            List<Integer> results = new ArrayList<>();
+            results = new ArrayList<>();
             for (String sql : batch) {
                 results.add((int) executeUpdateImpl(sql, localSettings));
             }
-            return results;
         }
+        clearBatch();
+        return results;
+    }
+
+    @Override
+    public void clearBatch() throws SQLException {
+        super.clearBatch(); /// clear super#batch
+        batchValues.clear();
     }
 
     private List<Integer> executeInsertBatch() throws SQLException {

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/StatementImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/StatementImpl.java
@@ -416,6 +416,7 @@ public class StatementImpl implements Statement, JdbcV2Wrapper {
         for (String sql : batch) {
             results.add(executeUpdate(sql));
         }
+        clearBatch();
         return results;
     }
 

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/PreparedStatementTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/PreparedStatementTest.java
@@ -954,6 +954,114 @@ public class PreparedStatementTest extends JdbcIntegrationTest {
     }
 
     @Test(groups = {"integration"})
+    void testBatchInsertNoValuesReuse() throws Exception {
+        String table = "test_pstmt_batch_novalues_reuse";
+        String sql = "INSERT INTO %s (v1, v2) VALUES (?, ?)";
+        long seed = System.currentTimeMillis();
+        Random rnd = new Random(seed);
+        try (Connection conn = getJdbcConnection()) {
+
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("CREATE TABLE IF NOT EXISTS " + table +
+                        " (v1 Int32, v2 Int32) Engine MergeTree ORDER BY ()");
+            }
+
+            final int nBatches = 10;
+            try (PreparedStatement stmt = conn.prepareStatement(String.format(sql, table))) {
+                Assert.assertEquals(stmt.getClass(), PreparedStatementImpl.class);
+                // add a batch with invalid values
+                stmt.setString(1, "invalid");
+                stmt.setInt(2, rnd.nextInt());
+                stmt.addBatch();
+                assertThrows(SQLException.class, stmt::executeBatch);
+                // should fail due to the previous batch data.
+                assertThrows(SQLException.class, stmt::executeBatch);
+                // clear previous batch data
+                stmt.clearBatch();
+
+                for (int step = 0; step < 2; step++) {
+                    for (int bI = 0; bI < (nBatches >> 1); bI++) {
+                        stmt.setInt(1, rnd.nextInt());
+                        stmt.setInt(2, rnd.nextInt());
+                        stmt.addBatch();
+                    }
+
+                    // reuse the same statement
+                    int[] result = stmt.executeBatch();
+                    for (int r : result) {
+                        Assert.assertEquals(r, 1);
+                    }
+                }
+            }
+
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT * FROM " + table);) {
+
+                int count = 0;
+                while (rs.next()) {
+                    assertTrue(rs.getInt(1) != 0);
+                    assertTrue(rs.getInt(2) != 0);
+                    count++;
+                }
+                assertEquals(count, nBatches);
+            }
+        }
+    }
+
+    @Test()
+    void testBatchInsertValuesReuse() throws Exception {
+        String table = "test_pstmt_batch_values_reuse";
+        String sql = "INSERT INTO %s (v1, v2) VALUES (1, ?)";
+        long seed = System.currentTimeMillis();
+        Random rnd = new Random(seed);
+        try (Connection conn = getJdbcConnection()) {
+
+            try (Statement stmt = conn.createStatement()) {
+                stmt.execute("CREATE TABLE IF NOT EXISTS " + table +
+                        " (v1 Int32, v2 Int32) Engine MergeTree ORDER BY ()");
+            }
+
+            final int nBatches = 10;
+            try (PreparedStatement stmt = conn.prepareStatement(String.format(sql, table))) {
+                Assert.assertEquals(stmt.getClass(), PreparedStatementImpl.class);
+                // add a batch with invalid values
+                stmt.setString(1, "invalid");
+                stmt.addBatch();
+                assertThrows(SQLException.class, stmt::executeBatch);
+                // should fail due to the previous batch data.
+                assertThrows(SQLException.class, stmt::executeBatch);
+                // clear previous batch data
+                stmt.clearBatch();
+
+                for (int step = 0; step < 2; step++) {
+                    for (int bI = 0; bI < (nBatches >> 1); bI++) {
+                        stmt.setInt(1, rnd.nextInt());
+                        stmt.addBatch();
+                    }
+
+                    // reuse the same statement
+                    int[] result = stmt.executeBatch();
+                    for (int r : result) {
+                        Assert.assertEquals(r, 1);
+                    }
+                }
+            }
+
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT * FROM " + table);) {
+
+                int count = 0;
+                while (rs.next()) {
+                    assertTrue(rs.getInt(1) != 0);
+                    assertTrue(rs.getInt(2) != 0);
+                    count++;
+                }
+                assertEquals(count, nBatches);
+            }
+        }
+    }
+
+    @Test(groups = {"integration"})
     void testWriteUUID() throws Exception {
         String sql = "insert into `test_issue_2327` (`id`, `uuid`) values (?, ?)";
         try (Connection conn = getJdbcConnection();


### PR DESCRIPTION
## Summary
- Override `clearBatch` for `PreparedStatementImpl`
- Clears the internal batch state immediately after executeBatch() to prevent parameter leakage and enable safe statement reuse.

Closes #2548

## Checklist
Delete items not relevant to your PR:
- [x] Closes #2548
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
