### PR TITLE
[JDBC] Make date/time to be encoded allways as the string

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/PreparedStatementImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/PreparedStatementImpl.java
@@ -469,7 +469,7 @@ public class PreparedStatementImpl extends StatementImpl implements PreparedStat
     @Override
     public void setDate(int parameterIndex, Date x, Calendar cal) throws SQLException {
         ensureOpen();
-        values[parameterIndex - 1] = encodeObject(sqlDateToInstant(x, cal));
+        values[parameterIndex - 1] = encodeObject(x);
     }
 
     protected Instant sqlDateToInstant(Date x, Calendar cal) {
@@ -483,7 +483,7 @@ public class PreparedStatementImpl extends StatementImpl implements PreparedStat
     @Override
     public void setTime(int parameterIndex, Time x, Calendar cal) throws SQLException {
         ensureOpen();
-        values[parameterIndex - 1] = encodeObject(sqlTimeToInstant(x, cal));
+        values[parameterIndex - 1] = encodeObject(x);
     }
 
     protected Instant sqlTimeToInstant(Time x, Calendar cal) {

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java
@@ -781,7 +781,8 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
                 " JOIN system.databases d ON system.tables.database = system.databases.name" +
                 " WHERE t.database LIKE '" + (schemaPattern == null ? "%" : schemaPattern) + "'" +
                 " AND t.name LIKE '" + (tableNamePattern == null ? "%" : tableNamePattern) + "'" +
-                " AND TABLE_TYPE IN ('" + String.join("','", types) + "')";
+                " AND TABLE_TYPE IN ('" + String.join("','", types) + "') " +
+                " ORDER BY TABLE_SCHEM, TABLE_TYPE, TABLE_NAME";
 
         try {
             return connection.createStatement().executeQuery(sql);


### PR DESCRIPTION
## Summary
- Make `java.sql.Date` & `java.sql.Time` to be encoded in same way when passed to `setObject()` methods and `setTime()`, `setDate()` methods. Previously last two were converted to unix timestamp value. As time and date do not care timezone and represent only time values no conversion should happen on write. 
- This fixes correct data type in result query.


Closes: https://github.com/ClickHouse/clickhouse-java/issues/2381
Closes: https://github.com/ClickHouse/clickhouse-java/issues/2557

## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
