### PR TITLE
[JDBC] added out of index test for parameter metadata

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/ParameterMetaDataImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/ParameterMetaDataImpl.java
@@ -127,6 +127,8 @@ public class ParameterMetaDataImpl implements ParameterMetaData, JdbcV2Wrapper {
     @Override
     public int getParameterMode(int param) throws SQLException {
         checkParamIndex(param);
+        // only in parameter mode IN is supported by prepared statement
+        // other modes are designed for callable statements
         return parameterModeIn;
     }
 }

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/metadata/ParameterMetaDataImplTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/metadata/ParameterMetaDataImplTest.java
@@ -5,7 +5,9 @@ import org.testng.annotations.Test;
 import java.sql.SQLException;
 import java.sql.Types;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertThrows;
 
 
 public class ParameterMetaDataImplTest {
@@ -80,5 +82,18 @@ public class ParameterMetaDataImplTest {
 
         assertThrows(() -> metaData.getParameterMode(0));
         assertThrows(() -> metaData.getParameterMode(2));
+    }
+
+    @Test(groups = {"integration"})
+    public void testColumnOutOfIndex() throws SQLException {
+        ParameterMetaDataImpl metaData = new ParameterMetaDataImpl(1);
+        int indexAfterLastColumn = 2;
+        assertThrows(SQLException.class, () -> metaData.getParameterMode(indexAfterLastColumn));
+        assertThrows(SQLException.class, () -> metaData.getParameterType(indexAfterLastColumn));
+        assertThrows(SQLException.class, () -> metaData.getScale(indexAfterLastColumn));
+        assertThrows(SQLException.class, () -> metaData.getPrecision(indexAfterLastColumn));
+        assertThrows(SQLException.class, () -> metaData.getParameterClassName(indexAfterLastColumn));
+        assertThrows(SQLException.class, () -> metaData.isNullable(indexAfterLastColumn));
+        assertThrows(SQLException.class, () -> metaData.isSigned(indexAfterLastColumn));
     }
 }


### PR DESCRIPTION
## Summary
- adds out of index test for all methods of Parameter metadata 

Closes https://github.com/ClickHouse/clickhouse-java/issues/2535
## Checklist
Delete items not relevant to your PR:
- [x] Closes #<issue ref>
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
