### PR TITLE
[JDBC] Fixes

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/JdbcUtils.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/JdbcUtils.java
@@ -232,7 +232,8 @@ public class JdbcUtils {
             } else if (type == String.class) {
                 return value.toString();
             } else if (type == Boolean.class || type == boolean.class) {
-                return Boolean.parseBoolean(value.toString());
+                String str = value.toString();
+                return !("false".equalsIgnoreCase(str) || "0".equalsIgnoreCase(str));
             } else if (type == Byte.class || type == byte.class) {
                 return Byte.parseByte(value.toString());
             } else if (type == Short.class || type == short.class) {

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataTest.java
@@ -37,7 +37,7 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
             final String tableName = "get_columns_metadata_test";
             try (Statement stmt = conn.createStatement()) {
                 stmt.executeUpdate("" +
-                        "CREATE TABLE " + tableName + " (id Int32, name String, v1 Nullable(Int8)) " +
+                        "CREATE TABLE " + tableName + " (id Int32, name String NOT NULL, v1 Nullable(Int8)) " +
                         "ENGINE MergeTree ORDER BY ()");
             }
 
@@ -109,6 +109,7 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
                 assertEquals(rs.getInt("DATA_TYPE"), Types.INTEGER);
                 assertEquals(rs.getObject("DATA_TYPE"), Types.INTEGER);
                 assertEquals(rs.getString("TYPE_NAME"), "Int32");
+                assertFalse(rs.getBoolean("NULLABLE"));
 
                 assertTrue(rs.next());
                 assertEquals(rs.getString("TABLE_SCHEM"), getDatabase());
@@ -117,6 +118,7 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
                 assertEquals(rs.getInt("DATA_TYPE"), Types.VARCHAR);
                 assertEquals(rs.getObject("DATA_TYPE"), Types.VARCHAR);
                 assertEquals(rs.getString("TYPE_NAME"), "String");
+                assertFalse(rs.getBoolean("NULLABLE"));
 
                 assertTrue(rs.next());
                 assertEquals(rs.getString("TABLE_SCHEM"), getDatabase());
@@ -125,6 +127,7 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
                 assertEquals(rs.getInt("DATA_TYPE"), Types.TINYINT);
                 assertEquals(rs.getObject("DATA_TYPE"), Types.TINYINT);
                 assertEquals(rs.getString("TYPE_NAME"), "Nullable(Int8)");
+                assertTrue(rs.getBoolean("NULLABLE"));
             }
         }
     }


### PR DESCRIPTION
## Summary
- Fixes issue reading int value as boolean when `getObject` used

Closes https://github.com/ClickHouse/clickhouse-java/issues/2586

## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
