### PR TITLE
add SSLContext for make dynamic ssl certification

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -717,6 +717,20 @@ public class Client implements AutoCloseable {
         }
 
         /**
+         * Sets a custom SSLContext supplier by class name. The class must implement
+         * {@code com.clickhouse.client.api.ssl.SslContextSupplier} and have a public
+         * no-arg constructor. Useful for providing an already-initialized SSLContext
+         * via properties (e.g., HikariCP data source properties).
+         *
+         * @param supplierClassName fully qualified class name of supplier
+         * @return this builder
+         */
+        public Builder setSSLContextSupplier(String supplierClassName) {
+            this.configuration.put(ClientConfigProperties.SSL_CONTEXT_SUPPLIER.getKey(), supplierClassName);
+            return this;
+        }
+
+        /**
          * Defines path to the key store file. It cannot be combined with
          * certificates. Either key store or certificates should be used.
          *

--- a/client-v2/src/main/java/com/clickhouse/client/api/ClientConfigProperties.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/ClientConfigProperties.java
@@ -182,6 +182,12 @@ public enum ClientConfigProperties {
      * SNI SSL parameter that will be set for each outbound SSL socket.
      */
     SSL_SOCKET_SNI("ssl_socket_sni", String.class,""),
+
+    /**
+     * Fully-qualified class name implementing com.clickhouse.client.api.ssl.SslContextSupplier.
+     * When set, this supplier is used to construct SSLContext instead of keystore/cert properties.
+     */
+    SSL_CONTEXT_SUPPLIER("ssl_context_supplier", String.class),
     ;
 
     private static final Logger LOG = LoggerFactory.getLogger(ClientConfigProperties.class);


### PR DESCRIPTION
Added support for supplying a preconfigured SSLContext via client properties:
New property ssl_context_supplier (FQCN of a class implementing com.clickhouse.client.api.ssl.SslContextSupplier)
Supplier takes precedence over keystore/cert properties (trust_store, sslcert, ssl_key)
Compatible with HikariCP via dataSourceProperties
Closes <!-- Link to an issue to close on merge. -->
Checklist
[ ] Closes #<issue ref>
[ ] Unit and integration tests covering the common scenarios were added
[ ] A human-readable description of the changes was provided to include in CHANGELOG
[ ] For significant changes, documentation in clickhouse-docs was updated with further explanations or tutorials