### PR TITLE
fix(jdbc-v2): Correctly parse mixed-order CTEs in SqlParser

### DIFF
--- a/jdbc-v2/src/main/antlr4/com/clickhouse/jdbc/internal/ClickHouseParser.g4
+++ b/jdbc-v2/src/main/antlr4/com/clickhouse/jdbc/internal/ClickHouseParser.g4
@@ -41,7 +41,12 @@ query
 
 // CTE statement
 ctes
-    : LPAREN? WITH cteUnboundCol? (COMMA cteUnboundCol)* COMMA? namedQuery (COMMA namedQuery)* RPAREN?
+    : LPAREN? WITH cte (COMMA cte)* RPAREN?
+    ;
+
+cte
+    : namedQuery
+    | cteUnboundCol
     ;
 
 namedQuery


### PR DESCRIPTION
## Summary

The grammar for CTEs was too restrictive. It required a specific order for different CTE syntax styles.

The grammar expected all CTEs to be defined before all CSEs (Common Scalar Expression).

This commit refactors the `ctes` grammar rule to be more flexible. It introduces a new, more generic `cte` rule that can represent either CTE style. The main `ctes` rule is now defined as a list of these generic `cte` elements, allowing them to appear in any order.

## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
