### PR TITLE
Expose several methods as public

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/SerializerUtils.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/SerializerUtils.java
@@ -411,6 +411,9 @@ public class SerializerUtils {
         }
     }
 
+    /**
+     DO NOT USE - part of internal API that will be changed
+     */
     public static void serializeArrayData(OutputStream stream, Object value, ClickHouseColumn column) throws IOException {
         if (value == null) {
             writeVarInt(stream, 0);
@@ -437,6 +440,9 @@ public class SerializerUtils {
         }
     }
 
+    /**
+     DO NOT USE - part of internal API that will be changed
+     */
     public static void serializeTupleData(OutputStream stream, Object value, ClickHouseColumn column) throws IOException {
         //Serialize the tuple to the stream
         //The tuple is a list of values
@@ -455,6 +461,9 @@ public class SerializerUtils {
         }
     }
 
+    /**
+     DO NOT USE - part of internal API that will be changed
+     */
     public static void serializeMapData(OutputStream stream, Object value, ClickHouseColumn column) throws IOException {
         //Serialize the map to the stream
         //The map is a list of key-value pairs


### PR DESCRIPTION
## Summary
Exposes several methods in SerializerUtils to the public so serialization logic can be reused.

## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
