### PR TITLE
2524-setSocketLinger type in config properties not matching docs

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/ClientConfigProperties.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/ClientConfigProperties.java
@@ -75,7 +75,7 @@ public enum ClientConfigProperties {
 
     SOCKET_TCP_NO_DELAY_OPT("socket_tcp_nodelay", Boolean.class),
 
-    SOCKET_LINGER_OPT("socket_linger", Boolean.class),
+    SOCKET_LINGER_OPT("socket_linger", Integer.class),
 
     DATABASE("database", String.class, "default"),
 


### PR DESCRIPTION

## Summary
2524-setSocketLinger type in config properties not matching docs, socket linger is expecting an integer of seconds, but config properties validates to require boolean


Closes https://github.com/ClickHouse/clickhouse-java/issues/2524
