### PR TITLE
[jdbc-v2] Convert Clickhouse `Array(T)` to Java `T[]` instead of `Object[]`

### DIFF
--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/JdbcUtilsTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/JdbcUtilsTest.java
@@ -19,15 +19,15 @@ public class JdbcUtilsTest {
 
     @Test(groups = {"unit"})
     public void testConvertPrimitiveTypes() throws SQLException {
-        assertEquals(JdbcUtils.convert(1, int.class), 1);
-        assertEquals(JdbcUtils.convert(1L, long.class), 1L);
+        assertEquals(JdbcUtils.convert(1, int.class), Integer.valueOf(1));
+        assertEquals(JdbcUtils.convert(1L, long.class), Long.valueOf(1));
         assertEquals(JdbcUtils.convert("1", String.class), "1");
-        assertEquals(JdbcUtils.convert(1.0f, float.class), 1.0f);
-        assertEquals(JdbcUtils.convert(1.0, double.class), 1.0);
-        assertEquals(JdbcUtils.convert(true, boolean.class), true);
-        assertEquals(JdbcUtils.convert((short) 1, short.class), (short) 1);
-        assertEquals(JdbcUtils.convert((byte) 1, byte.class), (byte) 1);
-        assertEquals(JdbcUtils.convert(1.0d, BigDecimal.class), BigDecimal.valueOf(1.0d));
+        assertEquals(JdbcUtils.convert(1.0f, float.class), Float.valueOf(1));
+        assertEquals(JdbcUtils.convert(1.0, double.class), Double.valueOf(1));
+        assertEquals(JdbcUtils.convert(true, boolean.class), Boolean.TRUE);
+        assertEquals(JdbcUtils.convert((short) 1, short.class), Short.valueOf("1"));
+        assertEquals(JdbcUtils.convert((byte) 1, byte.class), Byte.valueOf("1"));
+        assertEquals(JdbcUtils.convert(1.0d, BigDecimal.class), new BigDecimal("1.0"));
     }
 
 
@@ -40,8 +40,8 @@ public class JdbcUtilsTest {
         java.sql.Array array = (java.sql.Array) JdbcUtils.convert(arrayValue, java.sql.Array.class, column);
         Object arr = array.getArray();
         assertEquals(array.getBaseTypeName(), "Int32");
-        assertEquals(arr.getClass().getComponentType(), Object.class);
-        Object[] arrs = (Object[]) arr;
+        assertEquals(arr.getClass().getComponentType(), Integer.class);
+        Integer[] arrs = (Integer[]) arr;
         assertEquals(arrs[0], 1);
         assertEquals(arrs[1], 2);
     }
@@ -49,15 +49,17 @@ public class JdbcUtilsTest {
 
     @Test(groups = {"unit"})
     public void testConvertArray() throws Exception {
-        Object[] src = {1, 2, 3};
-        Object[] dst = JdbcUtils.convertArray(src, int.class);
-        assertEquals(dst.length, src.length);
-        assertEquals(dst[0], src[0]);
-        assertEquals(dst[1], src[1]);
-        assertEquals(dst[2], src[2]);
-
-        assertNull(JdbcUtils.convertArray(null, int.class));
-        assertEquals(JdbcUtils.convertArray(new Integer[] { 1, 2}, null), new Integer[] { 1, 2});
+        // primitive classes are unwrapped
+        assertEquals(JdbcUtils.convertArray(new Object[] { 0, 1 }, Boolean.class), new Boolean[] { false, true });
+        assertEquals(JdbcUtils.convertArray(new Object[] { 0, 1 }, Byte.class), new Byte[] { 0, 1 });
+        assertEquals(JdbcUtils.convertArray(new Object[] { 0, 1 }, Short.class), new Short[] { 0, 1 });
+        assertEquals(JdbcUtils.convertArray(new Object[] { 0, 1 }, Integer.class), new Integer[] { 0, 1 });
+        assertEquals(JdbcUtils.convertArray(new Object[] { 0, 1 }, Long.class), new Long[] { 0L, 1L });
+        assertEquals(JdbcUtils.convertArray(new Object[] { 0, 1 }, Float.class), new Float[] { 0.0f, 1.0f });
+        assertEquals(JdbcUtils.convertArray(new Object[] { 0, 1 }, Double.class), new Double[] { 0.0, 1.0 });
+        assertEquals(JdbcUtils.convertArray(new Object[] { 0, 1 }, String.class), new String[] { "0", "1" });
+        assertEquals(JdbcUtils.convertArray(new Object[] { 0, 1 }, BigDecimal.class), new BigDecimal[] { BigDecimal.valueOf(0), BigDecimal.valueOf(1) });
+        assertNull(JdbcUtils.convertArray(null, Integer.class));
     }
 
 
@@ -65,7 +67,7 @@ public class JdbcUtilsTest {
     public void testConvertList() throws Exception {
         ClickHouseColumn column = ClickHouseColumn.of("arr", "Array(Int32)");
         List<Integer> src = Arrays.asList(1, 2, 3);
-        Object[] dst = JdbcUtils.convertList(src, Integer.class);
+        Integer[] dst = JdbcUtils.convertList(src, Integer.class);
         assertEquals(dst.length, src.size());
         assertEquals(dst[0], src.get(0));
         assertEquals(dst[1], src.get(1));


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

I've faced an issue when reading `Array(Decimal)` with clickhouse-jdbc 0.9.2 and Spark 3.5.7 - instead of converting values to Spark's `DecimalType`, it failed with exception:
```
Exception java.lang.ClassCastException: class [Ljava.lang.Object; cannot be cast to class [Ljava.math.BigDecimal; ([Ljava.lang.Object; and [Ljava.math.BigDecimal; are in module java.base of loader 'bootstrap')
```

This is because `JdbcUtils.convert(value, java.math.BigDecimal.class, column)` returns `Object[]`, and Java doesn't allow casts like those:
```java
(java.math.BigDecimal[]) new Object[]{};
```

Even if each item of array is actually a `BigDecimal`.

Now this method returns `BigDecimal[]` for these arguments. This requires some reflection usage to construct `T[]` with T known only in runtime.

I haven't run integration tests on this yet.

## Checklist
Delete items not relevant to your PR:
- [X] Closes #2457
- [X] Unit and integration tests covering the common scenarios were added
