### PR TITLE
[jdbc-v2] Fix Java 8 compatibility

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/DriverProperties.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/DriverProperties.java
@@ -2,6 +2,7 @@ package com.clickhouse.jdbc;
 
 import com.clickhouse.client.api.internal.ServerSettings;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -66,7 +67,7 @@ public enum DriverProperties {
      *     <li>JAVACC - parser extracts required information but PreparedStatement parameters parsed separately.</li>
      * </ul>
      */
-    SQL_PARSER("jdbc_sql_parser", "JAVACC", List.of("ANTLR4", "ANTLR4_PARAMS_PARSER", "JAVACC")),
+    SQL_PARSER("jdbc_sql_parser", "JAVACC", Arrays.asList("ANTLR4", "ANTLR4_PARAMS_PARSER", "JAVACC")),
     ;
 
 


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

Java 8 doesn't have `List.of()` method:
```
: java.lang.NoSuchMethodError: java.util.List.of(Ljava/lang/Object;Ljava/lang/Object;Ljava/lang/Object;)Ljava/util/List;
        at com.clickhouse.jdbc.DriverProperties.<clinit>(DriverProperties.java:69)
        at com.clickhouse.jdbc.internal.JdbcConfiguration.initProperties(JdbcConfiguration.java:269)
        at com.clickhouse.jdbc.internal.JdbcConfiguration.<init>(JdbcConfiguration.java:74)
        at com.clickhouse.jdbc.ConnectionImpl.<init>(ConnectionImpl.java:76)
        at com.clickhouse.jdbc.Driver.connect(Driver.java:109)
        at com.clickhouse.jdbc.ClickHouseDriver.connect(ClickHouseDriver.java:96)
        at org.apache.spark.sql.execution.datasources.jdbc.DriverWrapper.connect(DriverWrapper.scala:46)
        at java.sql.DriverManager.getConnection(DriverManager.java:664)
        at java.sql.DriverManager.getConnection(DriverManager.java:208)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at py4j.reflection.MethodInvoker.invoke(MethodInvoker.java:244)
        at py4j.reflection.ReflectionEngine.invoke(ReflectionEngine.java:374)
        at py4j.Gateway.invoke(Gateway.java:282)
        at py4j.commands.AbstractCommand.invokeMethod(AbstractCommand.java:132)
        at py4j.commands.CallCommand.execute(CallCommand.java:79)
        at py4j.ClientServerConnection.waitForCommands(ClientServerConnection.java:182)
        at py4j.ClientServerConnection.run(ClientServerConnection.java:106)
        at java.lang.Thread.run(Thread.java:750)
```

This was introduced in #2579
