### PR TITLE
[jdbc-v2] fix backward compatibility for getPrimaryKeys

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java
@@ -987,7 +987,7 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
                     "system.tables.database AS TABLE_SCHEM, " +
                     "system.tables.name AS TABLE_NAME, " +
                     "trim(c.1) AS COLUMN_NAME, " +
-                    "c.2::Int16 AS KEY_SEQ, " +
+                    "CAST(c.2 AS Int16) AS KEY_SEQ, " +
                     "'PRIMARY' AS PK_NAME " +
                     "FROM system.tables " +
                     "ARRAY JOIN arrayZip(splitByChar(',', primary_key), arrayEnumerate(splitByChar(',', primary_key))) as c " +


### PR DESCRIPTION
## Summary
#2654 Associated issue
This fixes backward incompatibility with old ClickHouse builds (19.x, 20.x, etc.).
Closes <!-- Link to an issue to close on merge. -->
## Checklist
Delete items not relevant to your PR:
- [ ] Closes #2654 

