### PR TITLE
fix reading Array(Varian(String, Int32)) and similar when array has no common component class 

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -624,7 +624,7 @@ public class BinaryStreamReader {
 
     public ArrayValue readArrayItem(ClickHouseColumn itemTypeColumn, int len) throws IOException {
         ArrayValue array;
-        if (itemTypeColumn.isNullable()) {
+        if (itemTypeColumn.isNullable() || itemTypeColumn.getDataType() == ClickHouseDataType.Variant) {
             array = new ArrayValue(Object.class, len);
             for (int i = 0; i < len; i++) {
                 array.set(i, readValue(itemTypeColumn));

--- a/client-v2/src/test/java/com/clickhouse/client/datatypes/DataTypeTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/datatypes/DataTypeTests.java
@@ -348,6 +348,18 @@ public class DataTypeTests extends BaseIntegrationTest {
                         "[[a, b], [c, d]]",
                         "[[e, f], [j, h]]",
                 });
+
+        testVariantWith("arrays", new String[]{"field Array(Variant(String, Int32))"},
+                new Object[]{
+                        new Object[]{1, 2},
+                        new Object[]{"a", 3},
+                        new Object[]{3, "d"}
+                },
+                new String[]{
+                        "[1, 2]",
+                        "[a, 3]",
+                        "[3, d]",
+                });
     }
 
     @Test(groups = {"integration"})


### PR DESCRIPTION
## Summary
fixed reading Array(Variant(String, Int32)) columns by using Object[] for such cases, similar to nullable columns


Closes https://github.com/ClickHouse/clickhouse-java/issues/2602 
## Checklist
Delete items not relevant to your PR:
- [x] Closes #<issue ref>
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
