### PR TITLE
Add example demonstrating Nested type serialization issue with custom POJOs

### DIFF
--- a/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/Main.java
+++ b/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/Main.java
@@ -1,5 +1,6 @@
 package com.clickhouse.examples.client_v2;
 
+import com.clickhouse.examples.client_v2.data.Address;
 import com.clickhouse.examples.client_v2.data.ArticleViewEvent;
 import lombok.extern.slf4j.Slf4j;
 
@@ -54,7 +55,8 @@ public class Main {
         POJO2DbWriter pojoWriter = new POJO2DbWriter(endpoint, user, password, database);
         pojoWriter.resetTable();
         for (int i = 0; i < 10; i++) {
-            pojoWriter.submit(new ArticleViewEvent(11132929d, LocalDateTime.now(), UUID.randomUUID().toString()));
+            Address address = new Address("123 Main St", "San Francisco");
+            pojoWriter.submit(new ArticleViewEvent(11132929d, LocalDateTime.now(), UUID.randomUUID().toString(), address));
         }
 
         pojoWriter.printLastEvents();

--- a/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/data/Address.java
+++ b/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/data/Address.java
@@ -1,0 +1,16 @@
+package com.clickhouse.examples.client_v2.data;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * Nested POJO to test ClickHouse Tuple serialization with custom objects
+ */
+@AllArgsConstructor
+@Data
+@NoArgsConstructor
+public class Address {
+    private String street;
+    private String city;
+}

--- a/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/data/ArticleViewEvent.java
+++ b/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/data/ArticleViewEvent.java
@@ -17,5 +17,6 @@ public class ArticleViewEvent {
     private Double postId;
     private LocalDateTime viewTime;
     private String clientId;
+    private Address address;  // Nested custom object - demonstrates Tuple serialization issue
 
 }

--- a/examples/client-v2/src/main/resources/article_view_event_init.sql
+++ b/examples/client-v2/src/main/resources/article_view_event_init.sql
@@ -2,4 +2,5 @@ create table article_view_events (
 postId Nullable(Float64),
 viewTime DateTime DEFAULT now(),
 clientId String DEFAULT 'unknown',
+address Nested(street String, city String)
 ) engine = MergeTree order by ();


### PR DESCRIPTION
This example demonstrates an issue when using the POJO serializer with nested custom objects.

## Test Case

**Schema:**
```sql
address Nested(street String, city String)
```

**POJO:**
```java
public class ArticleViewEvent {
    private Address address;
}

public class Address {
    private String street;
    private String city;
}
```

**Usage:**
```java
Address address = new Address("123 Main St", "San Francisco");
pojoWriter.submit(new ArticleViewEvent(..., address));
```

## Error

```
WARN com.clickhouse.client.api.serde.POJOSerDe - No getter method found for column: addressstreet
Exception: No serializer found for column 'address.street'. Did you forget to register it?
```

The POJO serializer looks for `getAddressStreet()` and `getAddressCity()` methods (flattened column names) but the POJO only has `getAddress()` returning an `Address` object. The serializer doesn't traverse nested object graphs.

To run the example:
```bash
docker run -d -p 8123:8123 clickhouse/clickhouse-server
cd examples/client-v2
mvn exec:java -Dexec.mainClass="com.clickhouse.examples.client_v2.Main"
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a nested POJO example to exercise ClickHouse `Nested`/Tuple serialization.
> 
> - Adds `Address` class and embeds it in `ArticleViewEvent` as `address`
> - Updates table schema in `article_view_event_init.sql` to include `address Nested(street String, city String)`
> - Modifies `Main.java` to construct `Address` and submit it via `POJO2DbWriter`
> 
> This demonstrates the serializer behavior with nested custom objects (per PR description).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bf8d006d37241f9670b3f963eeef3d8c7ce2b3b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->