### PR TITLE
add codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-@chernser
-@mzitnik
+* @chernser @mzitnik


### PR DESCRIPTION
## Summary
Tag @chernser  and @mzitnik   on a new PR open. see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#about-code-owners

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds repository-wide CODEOWNERS.
> 
> - Introduces `.github/CODEOWNERS` mapping `*` to `@chernser` and `@mzitnik` to auto-request reviews on all changes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c97f65f1e83cc199c6467c92a75f63d1b1547249. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->