### PR TITLE
pass errorCode to SQLException

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/ExceptionUtils.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/ExceptionUtils.java
@@ -63,8 +63,8 @@ public final class ExceptionUtils {
             return new SQLException(exceptionMessage, SQL_STATE_CLIENT_ERROR, cause);
         } else if (cause instanceof ConnectionInitiationException) {
             return new SQLException(exceptionMessage, SQL_STATE_CONNECTION_EXCEPTION, cause);
-        } else if (cause instanceof ServerException se) {
-            return new SQLException(exceptionMessage, SQL_STATE_DATA_EXCEPTION, se.getCode(), cause);
+        } else if (cause instanceof ServerException) {
+            return new SQLException(exceptionMessage, SQL_STATE_DATA_EXCEPTION, ((ServerException) cause).getCode(), cause);
         } else if (cause instanceof ClientException) {
             return new SQLException(exceptionMessage, SQL_STATE_CLIENT_ERROR, cause);
         } else if (cause instanceof MalformedURLException) {


### PR DESCRIPTION
## Summary
Added pass error vendor code from ServerException to SqlException for issue https://github.com/ClickHouse/clickhouse-java/issues/2717


## Checklist

Closes: https://github.com/ClickHouse/clickhouse-java/issues/2717
---

> [!NOTE]
> Ensures JDBC surfaces server error codes to callers.
> 
> - In `ExceptionUtils.toSqlState(...)`, the `ServerException` branch now constructs `SQLException(message, SQL_STATE_DATA_EXCEPTION, serverException.getCode(), cause)` to include the vendor error code.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0df409c14e3a858ad142a6232cc821b0340dc0fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->