### PR TITLE
✨[JDBC-v2] Fix DataTypeConverter for nested arrays

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/DataTypeConverter.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/DataTypeConverter.java
@@ -261,12 +261,16 @@ public class DataTypeConverter {
         }
 
         public String convertAndReset(Object list, Appendable acc, ClickHouseColumn column) {
+            // Save current state to handle re-entrancy (nested array conversion)
+            ClickHouseColumn prevColumn = this.column;
+            Appendable prevAppendable = this.appendable;
             try {
                 setColumn(column);
                 return super.convert(list, acc);
             } finally {
-                this.column = null;
-                setAccumulator(null);
+                // Restore previous state for re-entrant calls
+                this.column = prevColumn;
+                setAccumulator(prevAppendable);
             }
         }
     }
@@ -292,12 +296,16 @@ public class DataTypeConverter {
         }
 
         public String convertAndReset(List<?> list, Appendable acc, ClickHouseColumn column) {
+            // Save current state to handle re-entrancy (nested array conversion)
+            ClickHouseColumn prevColumn = this.column;
+            Appendable prevAppendable = this.appendable;
             try {
                 setColumn(column);
                 return super.convert(list, acc);
             } finally {
-                this.column = null;
-                setAccumulator(null);
+                // Restore previous state for re-entrant calls
+                this.column = prevColumn;
+                setAccumulator(prevAppendable);
             }
         }
     }


### PR DESCRIPTION
## Summary
- Fixes the problem with nested arrays to be converted to string. 

Closes https://github.com/ClickHouse/clickhouse-java/issues/2723
## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents NPE when converting nested arrays to strings by making `DataTypeConverter` re-entrancy-safe.
> 
> - In `DataTypeConverter`, `ArrayAsStringWriter.convertAndReset` and `ListAsStringWriter.convertAndReset` now save/restore `column` and `appendable` instead of nulling them, ensuring correct nested conversions
> - Adds integration test `testNestedArrayToString` in `DataTypeTests` covering simple, CASE/WHEN with `splitByChar`, and deeply nested arrays to validate `ResultSet#getString()` on array columns
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76943676e5cc69472f49b0d48373e3d2229e175f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->