### PR TITLE
fixed issue converting multidimensional lists and arrays

### DIFF
--- a/client-v2/src/test/java/com/clickhouse/client/datatypes/DataTypeTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/datatypes/DataTypeTests.java
@@ -6,11 +6,9 @@ import com.clickhouse.client.ClickHouseProtocol;
 import com.clickhouse.client.ClickHouseServerForTest;
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ClientException;
-import com.clickhouse.client.api.DataTypeUtils;
 import com.clickhouse.client.api.command.CommandSettings;
 import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatReader;
 import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
-import com.clickhouse.client.api.data_formats.internal.SerializerUtils;
 import com.clickhouse.client.api.enums.Protocol;
 import com.clickhouse.client.api.insert.InsertSettings;
 import com.clickhouse.client.api.metadata.TableSchema;
@@ -34,19 +32,13 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.sql.Connection;
 import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.time.Period;
 import java.time.ZoneId;
 import java.time.ZoneOffset;
-import java.time.ZonedDateTime;
-import java.time.temporal.ChronoField;
 import java.time.temporal.ChronoUnit;
-import java.time.temporal.TemporalAccessor;
-import java.time.temporal.TemporalField;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -1152,8 +1144,7 @@ public class DataTypeTests extends BaseIntegrationTest {
         client.execute("DROP TABLE IF EXISTS " + table).get();
         client.execute(tableDefinition(table, "rowId Int32", columnDef)).get();
 
-        String insertSQL = "INSERT INTO " + table + " VALUES " + insertValues;
-        try (QueryResponse response = client.query(insertSQL).get()) {}
+        client.execute("INSERT INTO " + table + " VALUES " + insertValues).get().close();
 
         List<GenericRecord> records = client.queryAll("SELECT * FROM " + table + " ORDER BY rowId");
         Assert.assertEquals(records.size(), expectedStrValues.length);

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/JdbcUtils.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/JdbcUtils.java
@@ -426,6 +426,9 @@ public class JdbcUtils {
                 } else  if (value instanceof List<?>) {
                     List<?> srcList = (List<?>) value;
                     int depth = cursor.depth - 1;
+                    if (depth <= 0) {
+                        throw new IllegalStateException("There is a child array at depth 0 where it is not expected");
+                    }
                     arrayDimensions = new int[depth];
                     arrayDimensions[0] = srcList.size();
                     T[] targetArray = (T[]) java.lang.reflect.Array.newInstance(type, arrayDimensions);
@@ -473,6 +476,9 @@ public class JdbcUtils {
                     continue; // no need to set null value
                 } else  if (value.getClass().isArray()) {
                     int depth = cursor.depth - 1;
+                    if (depth <= 0) {
+                        throw new IllegalStateException("There is a child array at depth 0 where it is not expected");
+                    }
                     arrayDimensions = new int[depth];
                     arrayDimensions[0] = java.lang.reflect.Array.getLength(value);
                     T[] targetArray = (T[]) java.lang.reflect.Array.newInstance(type, arrayDimensions);

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/JdbcDataTypeTests.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/JdbcDataTypeTests.java
@@ -1269,7 +1269,7 @@ public class JdbcDataTypeTests extends JdbcIntegrationTest {
                     String result = rs.getString("deep_nested");
                     assertEquals(result, "[[['a', 'b'], ['c']], [['d', 'e', 'f']]]");
                     Array arr = rs.getArray(1);
-                    assertEquals(arr.getArray(), new String[][][] {{{"a", "b"}, {"c"}}, {{ "d", "e", "f"}}});
+                    assertTrue(Arrays.deepEquals((String[][][])arr.getArray(), new String[][][] {{{"a", "b"}, {"c"}}, {{ "d", "e", "f"}}}));
                 }
             }
         }

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/JdbcUtilsTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/JdbcUtilsTest.java
@@ -4,7 +4,8 @@ import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseDataType;
 import org.testng.Assert;
-import org.testng.annotations.*;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 import java.math.BigDecimal;
 import java.sql.SQLException;
@@ -68,6 +69,7 @@ public class JdbcUtilsTest {
         assertNull(JdbcUtils.convertArray(null, Integer.class, 1));
 
         Assert.assertThrows(IllegalArgumentException.class, () -> JdbcUtils.convertArray(new Object[0], String.class, 0 ));
+        Assert.assertThrows(IllegalStateException.class, () -> JdbcUtils.convertArray(new Object[] { new Object[] { 1, 2, 3}}, String.class, 1 ));
     }
 
 
@@ -84,6 +86,7 @@ public class JdbcUtilsTest {
         assertNull(JdbcUtils.convertList(null, Integer.class, 1));
 
         Assert.assertThrows(IllegalArgumentException.class, () -> JdbcUtils.convertList(Collections.emptyList(), String.class, 0));
+        Assert.assertThrows(IllegalStateException.class, () -> JdbcUtils.convertList(Arrays.asList(Collections.singletonList(1)), String.class, 1));
     }
 
 


### PR DESCRIPTION
## Summary
- Fixes converting multi-dimensional List to an array 
- Changes how child array dimensions are calculated - now it depth level of parent is used. 

Closes https://github.com/ClickHouse/clickhouse-java/issues/2741
## Checklist
Delete items not relevant to your PR:
- [x] Closes #<issue ref>
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core JDBC array conversion logic; while well-covered by new unit/integration tests, regressions could affect result decoding for nested array columns.
> 
> **Overview**
> Fixes JDBC conversion of multi-dimensional `List`/array values into Java arrays by tracking *remaining depth* per cursor instead of inferring it from stack size, and by validating invalid dimension inputs and unexpected extra nesting (throwing `IllegalArgumentException`/`IllegalStateException`).
> 
> Adds broader coverage for nested arrays: new client-v2 integration tests verify `GenericRecord.getString`/`getObject`/`getList` behavior across 2D–4D arrays (including strings and nullable elements), and JDBC tests extend nested-array coverage (including `ResultSet.getArray()` on 3D string arrays) plus unit assertions for the new error cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6e22f098845cb40c3db15583869a8316052acdff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->