### PR TITLE
[JDBC-V2] fixed the JDBC version in database metadata

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java
@@ -32,6 +32,9 @@ import java.util.function.Consumer;
 public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wrapper {
     private static final Logger log = LoggerFactory.getLogger(DatabaseMetaDataImpl.class);
 
+    private static final int JDBC_SPEC_MAJOR_VERSION = 4;
+    private static final int JDBC_SPEC_MINOR_VERSION = 2;
+
     public enum TableType {
         DICTIONARY("DICTIONARY"),
         LOG_TABLE("LOG TABLE"),
@@ -1410,12 +1413,12 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
 
     @Override
     public int getJDBCMajorVersion() throws SQLException {
-        return Driver.getDriverMajorVersion();
+        return JDBC_SPEC_MAJOR_VERSION;
     }
 
     @Override
     public int getJDBCMinorVersion() throws SQLException {
-        return Driver.getDriverMinorVersion();
+        return JDBC_SPEC_MINOR_VERSION;
     }
 
     @Override

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataTest.java
@@ -248,8 +248,8 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
             assertEquals(dbmd.supportsMultipleOpenResults(), false);
             assertEquals(dbmd.supportsGetGeneratedKeys(), false);
             assertEquals(dbmd.getResultSetHoldability(), 1);
-            assertEquals(dbmd.getJDBCMajorVersion(), 9);
-            assertEquals(dbmd.getJDBCMinorVersion(), 6);
+            assertEquals(dbmd.getJDBCMajorVersion(), 4); // Latest major version (since java 6).
+            assertEquals(dbmd.getJDBCMinorVersion(), 2); // Most supported minor version (since java 8).
             assertEquals(dbmd.getSQLStateType(), 2);
             assertEquals(dbmd.supportsStatementPooling(), false);
             assertEquals(dbmd.getRowIdLifetime(), ROWID_UNSUPPORTED);


### PR DESCRIPTION
## Summary
- Fixes JDBC version returned by `com.clickhouse.jdbc.metadata.DatabaseMetaDataImpl#getJDBCMajorVersion` and `com.clickhouse.jdbc.metadata.DatabaseMetaDataImpl#getJDBCMinorVersion`. Previously was returning driver's version what is wrong. It should return spec supported version. We support 4.2 (what is almost fresh, next is 4.3) 

## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized metadata change with corresponding test update; only affects clients that read JDBC version from `DatabaseMetaData`.
> 
> **Overview**
> Fixes JDBC version reporting in `DatabaseMetaDataImpl` so `getJDBCMajorVersion()`/`getJDBCMinorVersion()` return the supported JDBC *spec* version (`4.2`) instead of the ClickHouse driver’s own version.
> 
> Updates the integration test expectations in `DatabaseMetaDataTest` to assert the new `4`/`2` values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a4bb4a22c5093c4c366e20efa0400a758c68094e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->