### PR TITLE
Expose X-ClickHouse-Server-Display-Name header via client-v2 API

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -1338,9 +1338,7 @@ public class Client implements AutoCloseable {
                     String queryId =  HttpAPIClientHelper.getHeaderVal(httpResponse.getFirstHeader(ClickHouseHttpProto.HEADER_QUERY_ID), requestSettings.getQueryId(), String::valueOf);
                     metrics.operationComplete();
                     metrics.setQueryId(queryId);
-                    metrics.setServerDisplayName(HttpAPIClientHelper.getHeaderVal(
-                            httpResponse.getFirstHeader(ClickHouseHttpProto.HEADER_SRV_DISPLAY_NAME), null));
-                    return new InsertResponse(metrics);
+                    return new InsertResponse(metrics, HttpAPIClientHelper.collectResponseHeaders(httpResponse));
                 } catch (Exception e) {
                     String msg = requestExMsg("Insert", (i + 1), durationSince(startTime).toMillis(), requestSettings.getQueryId());
                     lastException = httpClientHelper.wrapException(msg, e, requestSettings.getQueryId());
@@ -1547,9 +1545,7 @@ public class Client implements AutoCloseable {
                     String queryId =  HttpAPIClientHelper.getHeaderVal(httpResponse.getFirstHeader(ClickHouseHttpProto.HEADER_QUERY_ID), requestSettings.getQueryId(), String::valueOf);
                     metrics.operationComplete();
                     metrics.setQueryId(queryId);
-                    metrics.setServerDisplayName(HttpAPIClientHelper.getHeaderVal(
-                            httpResponse.getFirstHeader(ClickHouseHttpProto.HEADER_SRV_DISPLAY_NAME), null));
-                    return new InsertResponse(metrics);
+                    return new InsertResponse(metrics, HttpAPIClientHelper.collectResponseHeaders(httpResponse));
                 } catch (Exception e) {
                     String msg = requestExMsg("Insert", (i + 1), durationSince(startTime).toMillis(), requestSettings.getQueryId());
                     lastException = httpClientHelper.wrapException(msg, e, requestSettings.getQueryId());
@@ -1681,8 +1677,6 @@ public class Client implements AutoCloseable {
                         String queryId = HttpAPIClientHelper.getHeaderVal(httpResponse
                                 .getFirstHeader(ClickHouseHttpProto.HEADER_QUERY_ID), requestSettings.getQueryId());
                         metrics.setQueryId(queryId);
-                        metrics.setServerDisplayName(HttpAPIClientHelper.getHeaderVal(httpResponse
-                                .getFirstHeader(ClickHouseHttpProto.HEADER_SRV_DISPLAY_NAME), null));
                         metrics.operationComplete();
                         Header formatHeader = httpResponse.getFirstHeader(ClickHouseHttpProto.HEADER_FORMAT);
                         ClickHouseFormat responseFormat = requestSettings.getFormat();
@@ -1690,7 +1684,8 @@ public class Client implements AutoCloseable {
                             responseFormat = ClickHouseFormat.valueOf(formatHeader.getValue());
                         }
 
-                        return new QueryResponse(httpResponse, responseFormat, requestSettings, metrics);
+                        return new QueryResponse(httpResponse, responseFormat, requestSettings, metrics,
+                                HttpAPIClientHelper.collectResponseHeaders(httpResponse));
 
                     } catch (Exception e) {
                         HttpAPIClientHelper.closeQuietly(httpResponse);

--- a/client-v2/src/main/java/com/clickhouse/client/api/command/CommandResponse.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/command/CommandResponse.java
@@ -5,6 +5,8 @@ import com.clickhouse.client.api.metrics.OperationMetrics;
 import com.clickhouse.client.api.metrics.ServerMetrics;
 import com.clickhouse.client.api.query.QueryResponse;
 
+import java.util.Map;
+
 public class CommandResponse implements AutoCloseable {
 
     private final QueryResponse response;
@@ -73,11 +75,22 @@ public class CommandResponse implements AutoCloseable {
     }
 
     /**
-     * Alias for {@link OperationMetrics#getServerDisplayName()}
-     * @return server display name from the response header
+     * Returns the value of {@code X-ClickHouse-Server-Display-Name} response header.
+     *
+     * @return server display name or {@code null} if not present
      */
     public String getServerDisplayName() {
         return response.getServerDisplayName();
+    }
+
+    /**
+     * Returns all collected response headers as an unmodifiable map.
+     * Only whitelisted ClickHouse headers are included.
+     *
+     * @return map of header name to header value
+     */
+    public Map<String, String> getResponseHeaders() {
+        return response.getResponseHeaders();
     }
 
     @Override

--- a/client-v2/src/main/java/com/clickhouse/client/api/insert/InsertResponse.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/insert/InsertResponse.java
@@ -1,13 +1,23 @@
 package com.clickhouse.client.api.insert;
 
+import com.clickhouse.client.api.http.ClickHouseHttpProto;
 import com.clickhouse.client.api.metrics.OperationMetrics;
 import com.clickhouse.client.api.metrics.ServerMetrics;
 
+import java.util.Collections;
+import java.util.Map;
+
 public class InsertResponse implements AutoCloseable {
     private OperationMetrics operationMetrics;
+    private final Map<String, String> responseHeaders;
 
     public InsertResponse(OperationMetrics metrics) {
+        this(metrics, Collections.emptyMap());
+    }
+
+    public InsertResponse(OperationMetrics metrics, Map<String, String> responseHeaders) {
         this.operationMetrics = metrics;
+        this.responseHeaders = responseHeaders;
     }
 
     @Override
@@ -80,10 +90,21 @@ public class InsertResponse implements AutoCloseable {
     }
 
     /**
-     * Alias for {@link OperationMetrics#getServerDisplayName()}
-     * @return server display name from the response header
+     * Returns the value of {@code X-ClickHouse-Server-Display-Name} response header.
+     *
+     * @return server display name or {@code null} if not present
      */
     public String getServerDisplayName() {
-        return operationMetrics.getServerDisplayName();
+        return responseHeaders.get(ClickHouseHttpProto.HEADER_SRV_DISPLAY_NAME);
+    }
+
+    /**
+     * Returns all collected response headers as an unmodifiable map.
+     * Only whitelisted ClickHouse headers are included.
+     *
+     * @return map of header name to header value
+     */
+    public Map<String, String> getResponseHeaders() {
+        return responseHeaders;
     }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
@@ -95,6 +95,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Arrays;
+import java.util.HashMap;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
@@ -750,6 +752,31 @@ public class HttpAPIClientHelper {
 
     public static int getHeaderInt(Header header, int defaultValue) {
         return getHeaderVal(header, defaultValue, Integer::parseInt);
+    }
+
+    private static final Set<String> RESPONSE_HEADER_WHITELIST = new HashSet<>(Arrays.asList(
+            ClickHouseHttpProto.HEADER_QUERY_ID,
+            ClickHouseHttpProto.HEADER_SRV_SUMMARY,
+            ClickHouseHttpProto.HEADER_SRV_DISPLAY_NAME,
+            ClickHouseHttpProto.HEADER_DATABASE,
+            ClickHouseHttpProto.HEADER_DB_USER
+    ));
+
+    /**
+     * Collects whitelisted response headers from an HTTP response into a map.
+     *
+     * @param response the HTTP response
+     * @return unmodifiable map of header name to header value for whitelisted headers present in the response
+     */
+    public static Map<String, String> collectResponseHeaders(ClassicHttpResponse response) {
+        Map<String, String> headers = new HashMap<>();
+        for (String name : RESPONSE_HEADER_WHITELIST) {
+            Header header = response.getFirstHeader(name);
+            if (header != null) {
+                headers.put(name, header.getValue());
+            }
+        }
+        return Collections.unmodifiableMap(headers);
     }
 
     public static String getHeaderVal(Header header, String defaultValue) {

--- a/client-v2/src/main/java/com/clickhouse/client/api/metrics/OperationMetrics.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/metrics/OperationMetrics.java
@@ -16,7 +16,6 @@ public class OperationMetrics {
 
     public Map<String, Metric> metrics = new HashMap<>();
     private String queryId;
-    private String serverDisplayName;
 
     private final ClientStatisticsHolder clientStatistics;
 
@@ -56,19 +55,10 @@ public class OperationMetrics {
         this.queryId = queryId;
     }
 
-    public String getServerDisplayName() {
-        return serverDisplayName;
-    }
-
-    public void setServerDisplayName(String serverDisplayName) {
-        this.serverDisplayName = serverDisplayName;
-    }
-
     @Override
     public String toString() {
         return "OperationStatistics{" +
                 "\"queryId\"=\"" + queryId + "\", " +
-                "\"serverDisplayName\"=\"" + serverDisplayName + "\", " +
                 "\"metrics\"=" + metrics +
                 '}';
     }

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/QueryResponse.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/QueryResponse.java
@@ -10,6 +10,8 @@ import org.apache.hc.core5.http.ClassicHttpResponse;
 import org.apache.hc.core5.http.Header;
 
 import java.io.InputStream;
+import java.util.Collections;
+import java.util.Map;
 import java.util.TimeZone;
 
 /**
@@ -35,12 +37,20 @@ public class QueryResponse implements AutoCloseable {
 
     private ClassicHttpResponse httpResponse;
 
+    private final Map<String, String> responseHeaders;
+
     public QueryResponse(ClassicHttpResponse response, ClickHouseFormat format, QuerySettings settings,
                          OperationMetrics operationMetrics) {
+        this(response, format, settings, operationMetrics, Collections.emptyMap());
+    }
+
+    public QueryResponse(ClassicHttpResponse response, ClickHouseFormat format, QuerySettings settings,
+                         OperationMetrics operationMetrics, Map<String, String> responseHeaders) {
         this.httpResponse = response;
         this.format = format;
         this.operationMetrics = operationMetrics;
         this.settings = settings;
+        this.responseHeaders = responseHeaders;
 
         Header tzHeader = response.getFirstHeader(ClickHouseHttpProto.HEADER_TIMEZONE);
         if (tzHeader != null) {
@@ -151,11 +161,22 @@ public class QueryResponse implements AutoCloseable {
     }
 
     /**
-     * Alias for {@link OperationMetrics#getServerDisplayName()}
-     * @return server display name from the response header
+     * Returns the value of {@code X-ClickHouse-Server-Display-Name} response header.
+     *
+     * @return server display name or {@code null} if not present
      */
     public String getServerDisplayName() {
-        return operationMetrics.getServerDisplayName();
+        return responseHeaders.get(ClickHouseHttpProto.HEADER_SRV_DISPLAY_NAME);
+    }
+
+    /**
+     * Returns all collected response headers as an unmodifiable map.
+     * Only whitelisted ClickHouse headers are included.
+     *
+     * @return map of header name to header value
+     */
+    public Map<String, String> getResponseHeaders() {
+        return responseHeaders;
     }
 
     public TimeZone getTimeZone() {


### PR DESCRIPTION
Extract the server display name from HTTP response headers and surface it through OperationMetrics, QueryResponse, InsertResponse, and CommandResponse, following the existing queryId pattern.

Closes https://github.com/ClickHouse/clickhouse-java/issues/2347

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API surface that only reads and exposes a small, whitelisted set of response headers; minimal impact on request/response flow aside from extra header collection.
> 
> **Overview**
> Client-v2 now captures a **whitelisted set of ClickHouse HTTP response headers** and attaches them to operation results.
> 
> `Client` passes collected headers into `QueryResponse` and `InsertResponse`, while `QueryResponse`, `InsertResponse`, and `CommandResponse` expose `getServerDisplayName()` (from `X-ClickHouse-Server-Display-Name`) plus `getResponseHeaders()` for the full collected map. `HttpAPIClientHelper` adds `collectResponseHeaders()` with a fixed whitelist to avoid exposing arbitrary headers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89328758f6069cf09a94766876b9abb3aadea871. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->