### PR TITLE
[client-v2] Implemented settings max execution time as server setting

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/ServerSettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/ServerSettings.java
@@ -37,6 +37,12 @@ public final class ServerSettings {
 
     public static final String RESULT_OVERFLOW_MODE_BREAK  = "break";
 
+    /**
+     * Maximum query execution time in seconds on server. 0 means no limit.
+     * If query is not finished in this time then server will send an exception.
+     */
+    public static final String MAX_EXECUTION_TIME = "max_execution_time";
+
     public static final String ASYNC_INSERT = "async_insert";
 
     public static final String WAIT_ASYNC_INSERT = "wait_for_async_insert";

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
@@ -117,12 +117,14 @@ public class QuerySettings {
      * If query is not finished in this time then server will send an exception.
      */
     public QuerySettings setMaxExecutionTime(Integer maxExecutionTime) {
-        settings.setOption("max_execution_time", maxExecutionTime);
+        serverSetting(ServerSettings.MAX_EXECUTION_TIME, String.valueOf(maxExecutionTime));
         return this;
     }
 
     public Integer getMaxExecutionTime() {
-        return (Integer) settings.getOption("max_execution_time");
+        String val = (String) settings.getOption(
+                ClientConfigProperties.serverSetting(ServerSettings.MAX_EXECUTION_TIME));
+        return val == null ? null : Integer.valueOf(val);
     }
 
     /**

--- a/client-v2/src/test/java/com/clickhouse/client/SettingsTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/SettingsTests.java
@@ -2,6 +2,7 @@ package com.clickhouse.client;
 
 import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.client.api.insert.InsertSettings;
+import com.clickhouse.client.api.internal.ServerSettings;
 import com.clickhouse.client.api.query.QuerySettings;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -81,8 +82,11 @@ public class SettingsTests {
 
         {
             final QuerySettings settings = new QuerySettings();
-            settings.setMaxExecutionTime(10000);
-            Assert.assertEquals(settings.getMaxExecutionTime(), 10000);
+            int val = 10000;
+            settings.setMaxExecutionTime(val);
+            Assert.assertEquals(settings.getMaxExecutionTime(), val);
+            Assert.assertEquals(settings.getAllSettings().get(
+                    ClientConfigProperties.serverSetting(ServerSettings.MAX_EXECUTION_TIME)), String.valueOf(val));
         }
 
         {


### PR DESCRIPTION
## Summary
Fixed sending max_execution_time in query settings as server setting. 


Closes https://github.com/ClickHouse/clickhouse-java/issues/2750
## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches request settings serialization for `max_execution_time`, which can change query timeout behavior and could impact callers relying on previous (incorrect) handling; scope is small and covered by unit+integration tests.
> 
> **Overview**
> Ensures `QuerySettings#setMaxExecutionTime` is encoded as a *server setting* (using `ClientConfigProperties.serverSetting(...)`) instead of a plain option, and updates `getMaxExecutionTime` to read/parse the prefixed value.
> 
> Adds `ServerSettings.MAX_EXECUTION_TIME` constant, updates unit tests to assert the stored prefixed setting, and introduces an integration test that verifies a long-running query is aborted with ClickHouse `TIMEOUT_EXCEEDED` (code `159`) when `max_execution_time` is set.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 867ed757f042f479340060084cb6b90b11b57e50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->