### PR TITLE
Fix hasValue to handle missing columns gracefully

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/AbstractBinaryFormatReader.java
@@ -569,12 +569,19 @@ public abstract class AbstractBinaryFormatReader implements ClickHouseBinaryForm
 
     @Override
     public boolean hasValue(int colIndex) {
+        if (colIndex < 1 || colIndex > currentRecord.length) {
+            return false;
+        }
         return currentRecord[colIndex - 1] != null;
     }
 
     @Override
     public boolean hasValue(String colName) {
-        return hasValue(schema.nameToColumnIndex(colName));
+        try {
+            return hasValue(schema.nameToColumnIndex(colName));
+        } catch (NoSuchColumnException e) {
+            return false;
+        }
     }
 
     @Override

--- a/client-v2/src/test/java/com/clickhouse/client/api/data_formats/ClickHouseBinaryFormatReaderTest.java
+++ b/client-v2/src/test/java/com/clickhouse/client/api/data_formats/ClickHouseBinaryFormatReaderTest.java
@@ -846,4 +846,35 @@ public class ClickHouseBinaryFormatReaderTest {
         Assert.assertEquals(reader.getList(2).size(), 0);
         Assert.assertEquals(reader.getList(3).size(), 0);
     }
+
+    @Test
+    public void testHasValueWithMissingColumns() throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        String[] names = new String[]{"a", "b"};
+        String[] types = new String[]{"UInt32", "UInt32"};
+
+        BinaryStreamUtils.writeVarInt(out, names.length);
+        for (String name : names) {
+            BinaryStreamUtils.writeString(out, name);
+        }
+        for (String type : types) {
+            BinaryStreamUtils.writeString(out, type);
+        }
+
+        BinaryStreamUtils.writeUnsignedInt32(out, 1L);
+        BinaryStreamUtils.writeUnsignedInt32(out, 2L);
+
+        InputStream in = new ByteArrayInputStream(out.toByteArray());
+        QuerySettings querySettings = new QuerySettings().setUseTimeZone("UTC");
+        RowBinaryWithNamesAndTypesFormatReader reader =
+                new RowBinaryWithNamesAndTypesFormatReader(in, querySettings, new BinaryStreamReader.CachingByteBufferAllocator());
+        reader.next();
+
+        Assert.assertTrue(reader.hasValue("a"), "Expected hasValue(\"a\") to be true");
+        Assert.assertTrue(reader.hasValue(1), "Expected hasValue(1) to be true");
+        Assert.assertFalse(reader.hasValue("missing"), "Expected hasValue(\"missing\") to return false, not throw");
+        Assert.assertFalse(reader.hasValue(100), "Expected hasValue(100) to return false, not throw");
+        Assert.assertFalse(reader.hasValue(0), "Expected hasValue(0) to return false, not throw");
+    }
 }


### PR DESCRIPTION
## Issue
The `hasValue()` method on GenericRecord would throw exceptions when checking for non-existent columns:
- `hasValue(int colIndex)` threw `ArrayIndexOutOfBoundsException` for out-of-range indices
- `hasValue(String colName)` threw `NoSuchColumnException` for unknown column names

## Solution
Add defensive checks to return `false` instead of throwing:
- Add bounds validation in the int-based method to check column index is within valid range (1-based, between 1 and record length)
- Wrap the name-to-index lookup in try-catch to handle `NoSuchColumnException`

This makes the API more intuitive and allows callers to safely check for column existence without exception handling.

Fixes #2755