### PR TITLE
Renamed NO_THROW_ON_UNKNOWN_CONFIG to IGNORE_UNKNOWN_CONFIG_KEY 

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/ClientConfigProperties.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/ClientConfigProperties.java
@@ -239,7 +239,7 @@ public enum ClientConfigProperties {
     // Key used to identify default value in configuration map
     public static final String DEFAULT_KEY = "_default_";
 
-    public static final String NO_THROW_ON_UNKNOWN_CONFIG = "no_throw_on_unknown_config";
+    public static final String IGNORE_UNKNOWN_CONFIG_KEY = "ignore_unknown_config_key";
 
     public static String serverSetting(String key) {
         return SERVER_SETTING_PREFIX + key;
@@ -363,10 +363,10 @@ public enum ClientConfigProperties {
             }
         }
 
-        tmpMap.remove(ClientConfigProperties.NO_THROW_ON_UNKNOWN_CONFIG);
+        tmpMap.remove(ClientConfigProperties.IGNORE_UNKNOWN_CONFIG_KEY);
         if (!tmpMap.isEmpty()) {
             String msg = "Unknown and unmapped config properties: " + tmpMap.keySet();
-            if (configMap.containsKey(NO_THROW_ON_UNKNOWN_CONFIG)) {
+            if (Boolean.parseBoolean(String.valueOf(configMap.get(IGNORE_UNKNOWN_CONFIG_KEY)))) {
                 LOG.warn(msg);
             } else {
                 throw new ClientMisconfigurationException(msg);

--- a/client-v2/src/test/java/com/clickhouse/client/ClientTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/ClientTests.java
@@ -502,7 +502,7 @@ public class ClientTests extends BaseIntegrationTest {
             Assert.assertTrue(ex.getMessage().contains("unknown_setting"));
         }
 
-        try (Client client = newClient().setOption(ClientConfigProperties.NO_THROW_ON_UNKNOWN_CONFIG, "what ever").setOption("unknown_setting", "value").build()) {
+        try (Client client = newClient().setOption(ClientConfigProperties.IGNORE_UNKNOWN_CONFIG_KEY, "true").setOption("unknown_setting", "value").build()) {
             Assert.assertTrue(client.ping());
         }
 

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/DriverTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/DriverTest.java
@@ -194,6 +194,6 @@ public class DriverTest extends JdbcIntegrationTest {
         }
 
         // next should not throw exception
-        driver.connect(getEndpointString() + "?unknown_setting=1&" + ClientConfigProperties.NO_THROW_ON_UNKNOWN_CONFIG + "=1", new Properties()).close();
+        driver.connect(getEndpointString() + "?unknown_setting=1&" + ClientConfigProperties.IGNORE_UNKNOWN_CONFIG_KEY + "=true", new Properties()).close();
     }
 }


### PR DESCRIPTION
## Summary

- Renames `NO_THROW_ON_UNKNOWN_CONFIG` to `IGNORE_UNKNOWN_CONFIG_KEY` to avoid reversed logic 
- Updates logic 
- Fixes issue with not checking value but only presence of the property


## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public config key used to ignore unknown properties and alters the check to depend on the property’s boolean value, which may break existing setups relying on the old key or truthy values like `1`. Scope is small but affects connection/config parsing behavior.
> 
> **Overview**
> Renames the opt-out flag for unknown/unmapped configuration from `NO_THROW_ON_UNKNOWN_CONFIG` to `IGNORE_UNKNOWN_CONFIG_KEY`.
> 
> Updates `ClientConfigProperties.parseConfigMap` so unknown config keys are ignored *only when* `IGNORE_UNKNOWN_CONFIG_KEY` is set to a boolean-true value; otherwise it still throws `ClientMisconfigurationException`. Integration tests in both `client-v2` and `jdbc-v2` are updated to use the new key/value.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4310a95708746294e2de62eddf7dda8cb3b1b099. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->