### PR TITLE
Add getSchema() to Records for schema access with empty results

### DIFF
--- a/client-v2/src/main/java/com/clickhouse/client/api/query/Records.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/Records.java
@@ -2,6 +2,7 @@ package com.clickhouse.client.api.query;
 
 import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatReader;
 import com.clickhouse.client.api.data_formats.internal.BinaryReaderBackedRecord;
+import com.clickhouse.client.api.metadata.TableSchema;
 import com.clickhouse.client.api.metrics.OperationMetrics;
 import com.clickhouse.client.api.metrics.ServerMetrics;
 
@@ -62,6 +63,15 @@ public class Records implements Iterable<GenericRecord>, AutoCloseable {
      */
     public boolean isEmpty() {
         return empty;
+    }
+
+    /**
+     * Returns the schema of the collection.
+     *
+     * @return table schema with column definitions
+     */
+    public TableSchema getSchema() {
+        return reader.getSchema();
     }
 
     Stream<GenericRecord> stream() {

--- a/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/query/QueryTests.java
@@ -678,6 +678,36 @@ public class QueryTests extends BaseIntegrationTest {
         }
     }
 
+    @Test(groups = {"integration"})
+    public void testGetSchemaWithEmptyResult() throws Exception {
+        try (Records records = client.queryRecords("SELECT 1 as id, 'test' as name LIMIT 0").get(3, TimeUnit.SECONDS)) {
+            Assert.assertTrue(records.isEmpty());
+
+            TableSchema schema = records.getSchema();
+            Assert.assertNotNull(schema);
+            Assert.assertEquals(schema.getColumns().size(), 2);
+            Assert.assertEquals(schema.getColumnByIndex(1).getColumnName(), "id");
+            Assert.assertEquals(schema.getColumnByIndex(2).getColumnName(), "name");
+        }
+    }
+
+    @Test(groups = {"integration"})
+    public void testGetSchemaWithResults() throws Exception {
+        try (Records records = client.queryRecords("SELECT 1 as id, 'test' as name").get(3, TimeUnit.SECONDS)) {
+            Assert.assertFalse(records.isEmpty());
+
+            TableSchema recordsSchema = records.getSchema();
+            Assert.assertNotNull(recordsSchema);
+            Assert.assertEquals(recordsSchema.getColumns().size(), 2);
+
+            for (GenericRecord record : records) {
+                Assert.assertEquals(record.getInteger("id"), Integer.valueOf(1));
+                Assert.assertEquals(record.getString("name"), "test");
+                Assert.assertEquals(record.getSchema(), recordsSchema);
+            }
+        }
+    }
+
     @Test(description = "Verifies that queryRecords reads all values from the response", groups = {"integration"})
     public void testQueryRecordsReadsAllValues() throws Exception {
         try (Records records = client.queryRecords("SELECT toInt32(number) FROM system.numbers LIMIT 3").get(3, TimeUnit.SECONDS)) {


### PR DESCRIPTION
## Summary

Add `getSchema()` method to `Records` class to enable access to table schema metadata even when query results are empty.

Following the pattern from PR #2004, this change exposes the `TableSchema` from the underlying `ClickHouseBinaryFormatReader`, making it consistent with `GenericRecord.getSchema()`.

**Use case:** When `queryRecords()` or `queryAll()` returns no rows, users can still inspect column metadata (names, types, etc.) without needing to iterate through records.

**Example:**
```java
Records records = client.queryRecords("SELECT * FROM table WHERE 1=0").get();
if (records.isEmpty()) {
    TableSchema schema = records.getSchema();
    schema.getColumns().forEach(col ->
        System.out.println(col.getColumnName() + ": " + col.getDataType())
    );
}
```

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG

---

**CHANGELOG entry:**
```
* Add `Records.getSchema()` method to access table schema from query results, including empty result sets
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk API addition that delegates to the existing binary reader schema with only new test coverage; minimal impact beyond adding a new method.
> 
> **Overview**
> Adds `Records.getSchema()` to return the underlying `TableSchema`, enabling schema inspection even when `Records.isEmpty()` is true.
> 
> Extends `QueryTests` with integration coverage for `getSchema()` on both empty and non-empty result sets, and asserts records’ per-row schema matches the collection schema.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab709af92d3ac4a380e9170796ef2e7bf65e67cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->