### PR TITLE
Update lz4-java from 1.10.2 to 1.10.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <jctools.version>4.0.1</jctools.version>
         <opencensus.version>0.31.1</opencensus.version>
         <protobuf.version>3.23.4</protobuf.version>
-        <lz4.version>1.10.2</lz4.version>
+        <lz4.version>1.10.4</lz4.version>
         <msgpack.version>0.9.5</msgpack.version>
         <roaring-bitmap.version>1.0.6</roaring-bitmap.version>
         <slf4j.version>2.0.7</slf4j.version>


### PR DESCRIPTION
## Summary
<!-- A short description of the changes with a link to an open issue. -->

ClickHouse Java Client switched to `at.yawk.lz4:lz4-java` for security reasons, but it unintentionally introduced performance regression.

https://github.com/yawkat/lz4-java/releases/tag/v1.10.4

> These changes attempt to fix the native performance regression in 1.9+. They should have no functional or security impact.

See the benchmark reports in Apache Celeborn and Apache Spark projects

- CELEBORN-2218 / https://github.com/apache/celeborn/pull/3555
- SPARK-55803 / https://github.com/apache/spark/pull/54585

## Checklist

- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump, but it changes the underlying LZ4 implementation and could affect compression/decompression performance or behavior at runtime.
> 
> **Overview**
> Updates the Maven-managed `lz4-java` dependency version to `1.10.4` (from `1.10.2`) via the `lz4.version` property in `pom.xml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e6565064097aef478d672b300f227b4af54226c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->