### PR TITLE
fix off-by-one bug in ArrayResultSet.next()

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/types/ArrayResultSet.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/types/ArrayResultSet.java
@@ -76,7 +76,7 @@ public class ArrayResultSet implements ResultSet {
 
     @Override
     public boolean next() throws SQLException {
-        if (pos == length || length == 0) {
+        if (pos + 1 >= length || length == 0) {
             return false;
         }
         pos++;

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/types/ArrayResultSetTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/types/ArrayResultSetTest.java
@@ -544,6 +544,39 @@ public class ArrayResultSetTest {
     }
 
     @Test
+    void testNextIterationCount() throws SQLException {
+        Integer[] array = {10, 20, 30};
+        ArrayResultSet rs = new ArrayResultSet(array, ClickHouseColumn.parse("v Array(Int32)").get(0));
+
+        int count = 0;
+        while (rs.next()) {
+            assertEquals(rs.getInt(2), array[count]);
+            count++;
+        }
+        assertEquals(count, array.length, "next() should return true exactly array.length times");
+        assertFalse(rs.next(), "next() should keep returning false after exhaustion");
+    }
+
+    @Test
+    void testNextEmptyArray() throws SQLException {
+        Integer[] array = {};
+        ArrayResultSet rs = new ArrayResultSet(array, ClickHouseColumn.parse("v Array(Int32)").get(0));
+
+        assertFalse(rs.next(), "next() should return false immediately for an empty array");
+        assertFalse(rs.next(), "next() should keep returning false on subsequent calls");
+    }
+
+    @Test
+    void testNextSingleElement() throws SQLException {
+        Integer[] array = {42};
+        ArrayResultSet rs = new ArrayResultSet(array, ClickHouseColumn.parse("v Array(Int32)").get(0));
+
+        assertTrue(rs.next());
+        assertEquals(rs.getInt(2), 42);
+        assertFalse(rs.next(), "next() should return false after the only element");
+    }
+
+    @Test
     void testArrayOfObjects() throws Exception {
         Object[] array = {null, 2, 3};
         ArrayResultSet rs = new ArrayResultSet(array, ClickHouseColumn.parse("v Array(Nullable(UInt32))").get(0));


### PR DESCRIPTION
## Summary

- **Fix off-by-one bug in `ArrayResultSet.next()`** that caused it to return `true` one extra time past the end of the array, leading to a `"No current row"` `SQLException` on the phantom iteration.
- The guard condition `pos == length` was checked before incrementing `pos`, so when `pos` was at `length-1` (last valid index), it passed the guard, incremented to `length`, and returned `true`. Fix: change to `pos + 1 >= length`.
- Add regression tests (`testNextIterationCount`, `testNextEmptyArray`, `testNextSingleElement`) verifying the standard JDBC iteration pattern `while (rs.next()) { rs.getString(2); }` works correctly.

Discovered via Airbyte connector source-clickhouse (airbytehq/airbyte#61419).

## Checklist

- [X] Verify `testNextIterationCount` passes
- [X] Verify `testNextEmptyArray` passes
- [X] Verify `testNextSingleElement` passes
- [X] Verify existing `ArrayResultSetTest` tests still pass
- [X] Run full `jdbc-v2` test suite