### PR TITLE
[client-v2,jdbc-v2] Support Geometry Type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 - **[jdbc-v2]** Added `cluster_name` configuration property to specify a target cluster for statements like `KILL QUERY` that require an `ON CLUSTER` clause to execute across all nodes. (https://github.com/ClickHouse/clickhouse-java/issues/2837)
 
+- **[client-v2, jdbc-v2]** Added support for ClickHouse `Geometry` type for ClickHouse `25.11+`, where `Geometry` changed from a `String` alias to `Variant(Point, Ring, LineString, MultiLineString, Polygon, MultiPolygon)` (client still compatible with older versions). Includes client read/write handling and JDBC type mapping for retrieving and inserting geometry values. Current writes infer the target geometry variant from array nesting depth, so `Ring` vs `LineString` and `Polygon` vs `MultiLineString` are not yet distinguishable through the generic `Geometry` write path. (https://github.com/ClickHouse/clickhouse-java/pull/2815)
+
 ### Bug Fixes
 
 - **[client-v2]** Fixed inconsistent use of `executionTimeout` parameter in `Client` component. The timeout was previously set in milliseconds but mistakenly retrieved and used in seconds in some places. Now it correctly uses milliseconds consistently. (https://github.com/ClickHouse/clickhouse-java/issues/2358)

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseColumn.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseColumn.java
@@ -106,6 +106,8 @@ public final class ClickHouseColumn implements Serializable {
 
     private Map<Class<?>, Integer> arrayToVariantOrdNumMap;
 
+    private Map<Integer, Integer> geometryTypeDimensionsToVariantOrdNumMap;
+
     private Map<Class<?>, Integer> mapKeyToVariantOrdNumMap;
     private Map<Class<?>, Integer> mapValueToVariantOrdNumMap;
 
@@ -312,6 +314,7 @@ public final class ClickHouseColumn implements Serializable {
                 column.nested = geometryVariantHelper.nested;
                 column.classToVariantOrdNumMap = geometryVariantHelper.classToVariantOrdNumMap;
                 column.arrayToVariantOrdNumMap = geometryVariantHelper.arrayToVariantOrdNumMap;
+                column.geometryTypeDimensionsToVariantOrdNumMap = geometryVariantHelper.geometryTypeDimensionsToVariantOrdNumMap;
                 column.mapKeyToVariantOrdNumMap = geometryVariantHelper.mapKeyToVariantOrdNumMap;
                 column.mapValueToVariantOrdNumMap = geometryVariantHelper.mapValueToVariantOrdNumMap;
                 break;
@@ -332,6 +335,28 @@ public final class ClickHouseColumn implements Serializable {
         }
 
         return column;
+    }
+
+    private static ClickHouseColumn createGeometryVariantColumn() {
+        ClickHouseColumn column = ClickHouseColumn.of("v",
+                "Variant(Point, Ring, LineString, MultiLineString, Polygon, MultiPolygon)");
+        Map<Integer, Integer> map = new HashMap<>();
+        map.put(1, getVariantOrdNum(column.nested, ClickHouseDataType.Point));
+        map.put(2, getVariantOrdNum(column.nested, ClickHouseDataType.Ring));
+        map.put(3, getVariantOrdNum(column.nested, ClickHouseDataType.Polygon));
+        map.put(4, getVariantOrdNum(column.nested, ClickHouseDataType.MultiPolygon));
+        column.geometryTypeDimensionsToVariantOrdNumMap = Collections.unmodifiableMap(map);
+        return column;
+    }
+
+    private static int getVariantOrdNum(List<ClickHouseColumn> nestedColumns, ClickHouseDataType dataType) {
+        for (int i = 0; i < nestedColumns.size(); i++) {
+            if (nestedColumns.get(i).getDataType() == dataType) {
+                return i;
+            }
+        }
+
+        throw new IllegalArgumentException("Missing nested geometry type: " + dataType);
     }
 
     protected static int readColumn(String args, int startIndex, int len, String name, List<ClickHouseColumn> list) {
@@ -837,6 +862,9 @@ public final class ClickHouseColumn implements Serializable {
 
     public int getVariantOrdNum(Object value) {
         if (value != null && value.getClass().isArray()) {
+            if (arrayToVariantOrdNumMap == null) {
+                return -1;
+            }
             // TODO: add cache by value class
             Class<?> c = value.getClass();
             while (c.isArray()) {
@@ -844,11 +872,14 @@ public final class ClickHouseColumn implements Serializable {
             }
             return arrayToVariantOrdNumMap.getOrDefault(c, -1);
         } else if (value != null && value instanceof List<?>) {
+            if (arrayToVariantOrdNumMap == null) {
+                return -1;
+            }
             // TODO: add cache by instance of the list
-            Object tmpV = ((List) value).get(0);
+            Object tmpV = ((List<?>) value).get(0);
             Class<?> valueClass = tmpV.getClass();
             while (tmpV instanceof List<?>) {
-                tmpV = ((List) tmpV).get(0);
+                tmpV = ((List<?>) tmpV).get(0);
                 valueClass = tmpV.getClass();
             }
             return arrayToVariantOrdNumMap.getOrDefault(valueClass, -1);
@@ -881,8 +912,28 @@ public final class ClickHouseColumn implements Serializable {
         }
     }
 
-    private static final ClickHouseColumn GEOMETRY_VARIANT_COLUMN = ClickHouseColumn.of("v",
-            "Variant(Point, Ring, LineString, MultiLineString, Polygon, MultiPolygon)");
+    public int getGeometryVariantOrdNum(Object value) {
+        if (value == null) {
+            return -1;
+        }
+
+        Integer ordNum = classToVariantOrdNumMap.get(value.getClass());
+        if (ordNum != null) {
+            return ordNum;
+        }
+
+        return -1;
+    }
+
+    public int getGeometryVariantOrdNum(int dimensions) {
+        if (dimensions < 1 || geometryTypeDimensionsToVariantOrdNumMap == null) {
+            return -1;
+        }
+
+        return geometryTypeDimensionsToVariantOrdNumMap.getOrDefault(dimensions, -1);
+    }
+
+    private static final ClickHouseColumn GEOMETRY_VARIANT_COLUMN = createGeometryVariantColumn();
 
     public boolean isArray() {
         return dataType == ClickHouseDataType.Array;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseColumn.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseColumn.java
@@ -54,6 +54,7 @@ import java.util.stream.Collectors;
 /**
  * This class represents a column defined in database.
  */
+@SuppressWarnings("deprecation")
 public final class ClickHouseColumn implements Serializable {
     public static final String TYPE_NAME = "Column";
     public static final ClickHouseColumn[] EMPTY_ARRAY = new ClickHouseColumn[0];
@@ -306,7 +307,7 @@ public final class ClickHouseColumn implements Serializable {
                 column.template = ClickHouseGeoMultiPolygonValue.ofEmpty();
                 break;
             case Geometry:
-                ClickHouseColumn geometryVariantHelper = getGeometryVariantHelper();
+                ClickHouseColumn geometryVariantHelper = GEOMETRY_VARIANT_COLUMN;
                 column.template = ClickHouseTupleValue.of();
                 column.nested = geometryVariantHelper.nested;
                 column.classToVariantOrdNumMap = geometryVariantHelper.classToVariantOrdNumMap;
@@ -625,6 +626,41 @@ public final class ClickHouseColumn implements Serializable {
         return i;
     }
 
+    private static void updateVariantMaps(ClickHouseColumn column) {
+        List<ClickHouseColumn> nestedColumns = column.getNestedColumns();
+        for (int ordNum = 0; ordNum < nestedColumns.size(); ordNum++) {
+            ClickHouseColumn nestedColumn = nestedColumns.get(ordNum);
+            if (nestedColumn.getDataType() == ClickHouseDataType.Array) {
+                Set<Class<?>> classSet = ClickHouseDataType.DATA_TYPE_TO_CLASS.get(nestedColumn.arrayBaseColumn.dataType);
+                if (classSet != null) {
+                    if (column.arrayToVariantOrdNumMap == null) {
+                        column.arrayToVariantOrdNumMap = new HashMap<>();
+                    }
+                    for (Class<?> c : classSet) {
+                        column.arrayToVariantOrdNumMap.put(c, ordNum);
+                    }
+                }
+            } else if (nestedColumn.getDataType() == ClickHouseDataType.Map) {
+                Set<Class<?>> keyClassSet = ClickHouseDataType.DATA_TYPE_TO_CLASS.get(nestedColumn.getKeyInfo().getDataType());
+                Set<Class<?>> valueClassSet = ClickHouseDataType.DATA_TYPE_TO_CLASS.get(nestedColumn.getValueInfo().getDataType());
+                if (keyClassSet != null && valueClassSet != null) {
+                    if (column.mapKeyToVariantOrdNumMap == null) {
+                        column.mapKeyToVariantOrdNumMap = new HashMap<>();
+                    }
+                    if (column.mapValueToVariantOrdNumMap == null) {
+                        column.mapValueToVariantOrdNumMap = new HashMap<>();
+                    }
+                    for (Class<?> c : keyClassSet) {
+                        column.mapKeyToVariantOrdNumMap.put(c, ordNum);
+                    }
+                    for (Class<?> c : valueClassSet) {
+                        column.mapValueToVariantOrdNumMap.put(c, ordNum);
+                    }
+                }
+            }
+        }
+    }
+
     public static ClickHouseColumn of(String columnName, ClickHouseDataType dataType, boolean nullable, int precision,
             int scale) {
         ClickHouseColumn column = new ClickHouseColumn(dataType, columnName, null, nullable, false, null, null);
@@ -841,35 +877,16 @@ public final class ClickHouseColumn implements Serializable {
             while (c.isArray()) {
                 c = c.getComponentType();
             }
-            int ordNum = arrayToVariantOrdNumMap == null ? -1 : arrayToVariantOrdNumMap.getOrDefault(c, -1);
-            if (ordNum != -1) {
-                return ordNum;
-            }
-            return classToVariantOrdNumMap == null ? -1 : classToVariantOrdNumMap.getOrDefault(value.getClass(), -1);
+            return arrayToVariantOrdNumMap.getOrDefault(c, -1);
         } else if (value != null && value instanceof List<?>) {
             // TODO: add cache by instance of the list
-            List<?> list = (List<?>) value;
-            if (list.isEmpty()) {
-                return -1;
-            }
-            Object tmpV = list.get(0);
-            if (tmpV == null) {
-                return -1;
-            }
+            Object tmpV = ((List) value).get(0);
             Class<?> valueClass = tmpV.getClass();
             while (tmpV instanceof List<?>) {
-                List<?> nestedList = (List<?>) tmpV;
-                if (nestedList.isEmpty() || nestedList.get(0) == null) {
-                    return findGeoVariantOrdNum(value);
-                }
-                tmpV = nestedList.get(0);
+                tmpV = ((List) tmpV).get(0);
                 valueClass = tmpV.getClass();
             }
-            int ordNum = arrayToVariantOrdNumMap == null ? -1 : arrayToVariantOrdNumMap.getOrDefault(valueClass, -1);
-            if (ordNum != -1) {
-                return ordNum;
-            }
-            return findGeoVariantOrdNum(value);
+            return arrayToVariantOrdNumMap.getOrDefault(valueClass, -1);
         } else if (value != null && value instanceof Map<?,?>) {
             // TODO: add cache by instance of map
             Map<?, ?> map = (Map<?, ?>) value;
@@ -899,74 +916,8 @@ public final class ClickHouseColumn implements Serializable {
         }
     }
 
-    private int findGeoVariantOrdNum(Object value) {
-        int depth = 0;
-        Object current = value;
-        while (current instanceof List<?>) {
-            List<?> list = (List<?>) current;
-            if (list.isEmpty()) {
-                return -1;
-            }
-            current = list.get(0);
-            depth++;
-        }
-
-        if (!(current instanceof Number)) {
-            return -1;
-        }
-
-        ClickHouseDataType preferredType;
-        switch (depth) {
-            case 1:
-                preferredType = ClickHouseDataType.Point;
-                break;
-            case 2:
-                preferredType = ClickHouseDataType.Ring;
-                break;
-            case 3:
-                preferredType = ClickHouseDataType.Polygon;
-                break;
-            case 4:
-                preferredType = ClickHouseDataType.MultiPolygon;
-                break;
-            default:
-                return -1;
-        }
-
-        return findGeoVariantOrdNum(preferredType);
-    }
-
-    private int findGeoVariantOrdNum(ClickHouseDataType preferredType) {
-        int fallback = -1;
-        int geometryOrdNum = -1;
-        for (int i = 0; i < nested.size(); i++) {
-            ClickHouseDataType nestedType = nested.get(i).getDataType();
-            if (nestedType == preferredType) {
-                return i;
-            }
-            if (preferredType == ClickHouseDataType.Ring && nestedType == ClickHouseDataType.LineString) {
-                fallback = i;
-            } else if (preferredType == ClickHouseDataType.Polygon && nestedType == ClickHouseDataType.MultiLineString) {
-                fallback = i;
-            } else if (nestedType == ClickHouseDataType.Geometry) {
-                geometryOrdNum = i;
-            }
-        }
-
-        return fallback != -1 ? fallback : geometryOrdNum;
-    }
-
-    private static ClickHouseColumn getGeometryVariantHelper() {
-        return GeometryVariantHolder.COLUMN;
-    }
-
-    private static final class GeometryVariantHolder {
-        private static final ClickHouseColumn COLUMN = ClickHouseColumn.of("v",
-                "Variant(Point, Ring, LineString, MultiLineString, Polygon, MultiPolygon)");
-
-        private GeometryVariantHolder() {
-        }
-    }
+    private static final ClickHouseColumn GEOMETRY_VARIANT_COLUMN = ClickHouseColumn.of("v",
+            "Variant(Point, Ring, LineString, MultiLineString, Polygon, MultiPolygon)");
 
     public boolean isArray() {
         return dataType == ClickHouseDataType.Array;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseColumn.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseColumn.java
@@ -626,41 +626,6 @@ public final class ClickHouseColumn implements Serializable {
         return i;
     }
 
-    private static void updateVariantMaps(ClickHouseColumn column) {
-        List<ClickHouseColumn> nestedColumns = column.getNestedColumns();
-        for (int ordNum = 0; ordNum < nestedColumns.size(); ordNum++) {
-            ClickHouseColumn nestedColumn = nestedColumns.get(ordNum);
-            if (nestedColumn.getDataType() == ClickHouseDataType.Array) {
-                Set<Class<?>> classSet = ClickHouseDataType.DATA_TYPE_TO_CLASS.get(nestedColumn.arrayBaseColumn.dataType);
-                if (classSet != null) {
-                    if (column.arrayToVariantOrdNumMap == null) {
-                        column.arrayToVariantOrdNumMap = new HashMap<>();
-                    }
-                    for (Class<?> c : classSet) {
-                        column.arrayToVariantOrdNumMap.put(c, ordNum);
-                    }
-                }
-            } else if (nestedColumn.getDataType() == ClickHouseDataType.Map) {
-                Set<Class<?>> keyClassSet = ClickHouseDataType.DATA_TYPE_TO_CLASS.get(nestedColumn.getKeyInfo().getDataType());
-                Set<Class<?>> valueClassSet = ClickHouseDataType.DATA_TYPE_TO_CLASS.get(nestedColumn.getValueInfo().getDataType());
-                if (keyClassSet != null && valueClassSet != null) {
-                    if (column.mapKeyToVariantOrdNumMap == null) {
-                        column.mapKeyToVariantOrdNumMap = new HashMap<>();
-                    }
-                    if (column.mapValueToVariantOrdNumMap == null) {
-                        column.mapValueToVariantOrdNumMap = new HashMap<>();
-                    }
-                    for (Class<?> c : keyClassSet) {
-                        column.mapKeyToVariantOrdNumMap.put(c, ordNum);
-                    }
-                    for (Class<?> c : valueClassSet) {
-                        column.mapValueToVariantOrdNumMap.put(c, ordNum);
-                    }
-                }
-            }
-        }
-    }
-
     public static ClickHouseColumn of(String columnName, ClickHouseDataType dataType, boolean nullable, int precision,
             int scale) {
         ClickHouseColumn column = new ClickHouseColumn(dataType, columnName, null, nullable, false, null, null);

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseColumn.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseColumn.java
@@ -908,12 +908,12 @@ public final class ClickHouseColumn implements Serializable {
             }
             return -1;
         } else {
-            return classToVariantOrdNumMap.getOrDefault(value.getClass(), -1);
+            return getGeometryVariantOrdNum(value);
         }
     }
 
     public int getGeometryVariantOrdNum(Object value) {
-        if (value == null) {
+        if (value == null || classToVariantOrdNumMap == null) {
             return -1;
         }
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseColumn.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseColumn.java
@@ -415,7 +415,7 @@ public final class ClickHouseColumn implements Serializable {
                     nestedColumns.add(ClickHouseColumn.of("", p));
                 }
             }
-            column = new ClickHouseColumn(ClickHouseDataType.valueOf(matchedKeyword), name,
+            column = new ClickHouseColumn(ClickHouseDataType.of(matchedKeyword), name,
                     args.substring(startIndex, i), nullable, lowCardinality, params, nestedColumns);
             column.aggFuncType = aggFunc;
             if (!nestedColumns.isEmpty()) {
@@ -509,7 +509,7 @@ public final class ClickHouseColumn implements Serializable {
                     variantDataTypes.add(c.dataType);
                 });
             }
-            column = new ClickHouseColumn(ClickHouseDataType.valueOf(matchedKeyword), name,
+            column = new ClickHouseColumn(ClickHouseDataType.of(matchedKeyword), name,
                     args.substring(startIndex, endIndex + 1), nullable, lowCardinality, null, nestedColumns);
             for (ClickHouseColumn n : nestedColumns) {
                 estimatedLength += n.estimatedByteLength;

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseColumn.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseColumn.java
@@ -293,11 +293,26 @@ public final class ClickHouseColumn implements Serializable {
             case Ring:
                 column.template = ClickHouseGeoRingValue.ofEmpty();
                 break;
+            case LineString:
+                column.template = ClickHouseGeoRingValue.ofEmpty();
+                break;
             case Polygon:
+                column.template = ClickHouseGeoPolygonValue.ofEmpty();
+                break;
+            case MultiLineString:
                 column.template = ClickHouseGeoPolygonValue.ofEmpty();
                 break;
             case MultiPolygon:
                 column.template = ClickHouseGeoMultiPolygonValue.ofEmpty();
+                break;
+            case Geometry:
+                ClickHouseColumn geometryVariantHelper = getGeometryVariantHelper();
+                column.template = ClickHouseTupleValue.of();
+                column.nested = geometryVariantHelper.nested;
+                column.classToVariantOrdNumMap = geometryVariantHelper.classToVariantOrdNumMap;
+                column.arrayToVariantOrdNumMap = geometryVariantHelper.arrayToVariantOrdNumMap;
+                column.mapKeyToVariantOrdNumMap = geometryVariantHelper.mapKeyToVariantOrdNumMap;
+                column.mapValueToVariantOrdNumMap = geometryVariantHelper.mapValueToVariantOrdNumMap;
                 break;
             case Nested:
                 column.template = ClickHouseNestedValue.ofEmpty(column.nested);
@@ -826,16 +841,35 @@ public final class ClickHouseColumn implements Serializable {
             while (c.isArray()) {
                 c = c.getComponentType();
             }
-            return arrayToVariantOrdNumMap.getOrDefault(c, -1);
+            int ordNum = arrayToVariantOrdNumMap == null ? -1 : arrayToVariantOrdNumMap.getOrDefault(c, -1);
+            if (ordNum != -1) {
+                return ordNum;
+            }
+            return classToVariantOrdNumMap == null ? -1 : classToVariantOrdNumMap.getOrDefault(value.getClass(), -1);
         } else if (value != null && value instanceof List<?>) {
             // TODO: add cache by instance of the list
-            Object tmpV = ((List) value).get(0);
+            List<?> list = (List<?>) value;
+            if (list.isEmpty()) {
+                return -1;
+            }
+            Object tmpV = list.get(0);
+            if (tmpV == null) {
+                return -1;
+            }
             Class<?> valueClass = tmpV.getClass();
             while (tmpV instanceof List<?>) {
-                tmpV = ((List) tmpV).get(0);
+                List<?> nestedList = (List<?>) tmpV;
+                if (nestedList.isEmpty() || nestedList.get(0) == null) {
+                    return findGeoVariantOrdNum(value);
+                }
+                tmpV = nestedList.get(0);
                 valueClass = tmpV.getClass();
             }
-            return arrayToVariantOrdNumMap.getOrDefault(valueClass, -1);
+            int ordNum = arrayToVariantOrdNumMap == null ? -1 : arrayToVariantOrdNumMap.getOrDefault(valueClass, -1);
+            if (ordNum != -1) {
+                return ordNum;
+            }
+            return findGeoVariantOrdNum(value);
         } else if (value != null && value instanceof Map<?,?>) {
             // TODO: add cache by instance of map
             Map<?, ?> map = (Map<?, ?>) value;
@@ -862,6 +896,75 @@ public final class ClickHouseColumn implements Serializable {
             return -1;
         } else {
             return classToVariantOrdNumMap.getOrDefault(value.getClass(), -1);
+        }
+    }
+
+    private int findGeoVariantOrdNum(Object value) {
+        int depth = 0;
+        Object current = value;
+        while (current instanceof List<?>) {
+            List<?> list = (List<?>) current;
+            if (list.isEmpty()) {
+                return -1;
+            }
+            current = list.get(0);
+            depth++;
+        }
+
+        if (!(current instanceof Number)) {
+            return -1;
+        }
+
+        ClickHouseDataType preferredType;
+        switch (depth) {
+            case 1:
+                preferredType = ClickHouseDataType.Point;
+                break;
+            case 2:
+                preferredType = ClickHouseDataType.Ring;
+                break;
+            case 3:
+                preferredType = ClickHouseDataType.Polygon;
+                break;
+            case 4:
+                preferredType = ClickHouseDataType.MultiPolygon;
+                break;
+            default:
+                return -1;
+        }
+
+        return findGeoVariantOrdNum(preferredType);
+    }
+
+    private int findGeoVariantOrdNum(ClickHouseDataType preferredType) {
+        int fallback = -1;
+        int geometryOrdNum = -1;
+        for (int i = 0; i < nested.size(); i++) {
+            ClickHouseDataType nestedType = nested.get(i).getDataType();
+            if (nestedType == preferredType) {
+                return i;
+            }
+            if (preferredType == ClickHouseDataType.Ring && nestedType == ClickHouseDataType.LineString) {
+                fallback = i;
+            } else if (preferredType == ClickHouseDataType.Polygon && nestedType == ClickHouseDataType.MultiLineString) {
+                fallback = i;
+            } else if (nestedType == ClickHouseDataType.Geometry) {
+                geometryOrdNum = i;
+            }
+        }
+
+        return fallback != -1 ? fallback : geometryOrdNum;
+    }
+
+    private static ClickHouseColumn getGeometryVariantHelper() {
+        return GeometryVariantHolder.COLUMN;
+    }
+
+    private static final class GeometryVariantHolder {
+        private static final ClickHouseColumn COLUMN = ClickHouseColumn.of("v",
+                "Variant(Point, Ring, LineString, MultiLineString, Polygon, MultiPolygon)");
+
+        private GeometryVariantHolder() {
         }
     }
 

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataType.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataType.java
@@ -106,6 +106,7 @@ public enum ClickHouseDataType implements SQLType {
     Ring(Object.class, false, true, true, 0, 0, 0, 0, 0, true), // same as Array(Point)
     LineString( Object.class, false, true, true, 0, 0, 0, 0, 0, true), // same as Array(Point)
     MultiLineString(Object.class, false, true, true, 0, 0, 0, 0, 0, true), // same as Array(Ring)
+    Geometry(Object.class, false, true, true, 0, 0, 0, 0, 0, true), // same as Variant(Point, ...)
     JSON(Object.class, false, false, false, 0, 0, 0, 0, 0, true, 0x30),
     @Deprecated // (since = "CH 25.11")
     Object(Object.class, true, true, false, 0, 0, 0, 0, 0, true),
@@ -130,7 +131,6 @@ public enum ClickHouseDataType implements SQLType {
     Time(LocalDateTime.class, true, false, false, 4, 9, 0, 0, 9, false, 0x32), // 0x33 for Time(Timezone)
     Time64(LocalDateTime.class, true, false, false, 8, 9, 0, 0, 0, false, 0x34), // 0x35 for Time64(P, Timezone)
     QBit(Double.class, true, true, false, 0, 0, 0, 0, 0, false, 0x36),
-    Geometry(Object.class, false, false, false, 0, 0, 0, 0, 0, true),
     ;
 
     public static final List<ClickHouseDataType> ORDERED_BY_RANGE_INT_TYPES =

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataType.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseDataType.java
@@ -214,8 +214,19 @@ public enum ClickHouseDataType implements SQLType {
 
         map.put(Point, setOf(double[].class, ClickHouseGeoPointValue.class));
         map.put(Ring, setOf(double[][].class, ClickHouseGeoRingValue.class));
+        map.put(LineString, setOf(double[][].class, ClickHouseGeoRingValue.class));
         map.put(Polygon, setOf(double[][][].class, ClickHouseGeoPolygonValue.class));
+        map.put(MultiLineString, setOf(double[][][].class, ClickHouseGeoPolygonValue.class));
         map.put(MultiPolygon, setOf(double[][][][].class, ClickHouseGeoMultiPolygonValue.class));
+        map.put(Geometry, setOf(
+                double[].class,
+                double[][].class,
+                double[][][].class,
+                double[][][][].class,
+                ClickHouseGeoPointValue.class,
+                ClickHouseGeoRingValue.class,
+                ClickHouseGeoPolygonValue.class,
+                ClickHouseGeoMultiPolygonValue.class));
 
         map.put(Date, setOf(LocalDateTime.class, LocalDate.class, ZonedDateTime.class));
         map.put(Date32, setOf(LocalDateTime.class, LocalDate.class, ZonedDateTime.class));

--- a/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseColumnTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseColumnTest.java
@@ -11,6 +11,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.clickhouse.data.value.ClickHouseArrayValue;
+import com.clickhouse.data.value.ClickHouseGeoMultiPolygonValue;
 import com.clickhouse.data.value.ClickHouseGeoPointValue;
 import com.clickhouse.data.value.ClickHouseGeoPolygonValue;
 import com.clickhouse.data.value.ClickHouseGeoRingValue;
@@ -420,7 +421,7 @@ public class ClickHouseColumnTest {
                 return true;
             };
         };
-        for (ClickHouseDataType type : ClickHouseDataType.values()) {
+        for (ClickHouseDataType type : java.util.EnumSet.allOf(ClickHouseDataType.class)) {
             // skip advanced types
             if (type.isNested() || type == ClickHouseDataType.AggregateFunction
                     || type == ClickHouseDataType.SimpleAggregateFunction || type == ClickHouseDataType.Enum
@@ -454,6 +455,13 @@ public class ClickHouseColumnTest {
                 getVariantOrdNum(geometry, ClickHouseDataType.Point));
         Assert.assertEquals(geometry.getGeometryVariantOrdNum(2),
                 getVariantOrdNum(geometry, ClickHouseDataType.Ring));
+        Assert.assertEquals(geometry.getGeometryVariantOrdNum(3),
+                getVariantOrdNum(geometry, ClickHouseDataType.Polygon));
+        Assert.assertEquals(geometry.getGeometryVariantOrdNum(4),
+                getVariantOrdNum(geometry, ClickHouseDataType.MultiPolygon));
+        Assert.assertEquals(geometry.getGeometryVariantOrdNum(0), -1);
+        Assert.assertEquals(geometry.getGeometryVariantOrdNum(5), -1);
+        Assert.assertEquals(geometry.getGeometryVariantOrdNum((Object) null), -1);
         Assert.assertEquals(geometry.getGeometryVariantOrdNum(
                         ClickHouseGeoPointValue.of(new double[] { 1D, 2D })),
                 getVariantOrdNum(geometry, ClickHouseDataType.Point));
@@ -463,6 +471,10 @@ public class ClickHouseColumnTest {
         Assert.assertEquals(geometry.getGeometryVariantOrdNum(
                         ClickHouseGeoPolygonValue.of(new double[][][] { { { 1D, 2D }, { 3D, 4D } } })),
                 getVariantOrdNum(geometry, ClickHouseDataType.Polygon));
+        Assert.assertEquals(geometry.getGeometryVariantOrdNum(
+                        ClickHouseGeoMultiPolygonValue.of(new double[][][][] { { { { 1D, 2D }, { 3D, 4D } } } })),
+                getVariantOrdNum(geometry, ClickHouseDataType.MultiPolygon));
+        Assert.assertEquals(geometry.getGeometryVariantOrdNum(new Object()), -1);
     }
 
     private static int getVariantOrdNum(ClickHouseColumn column, ClickHouseDataType dataType) {

--- a/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseColumnTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseColumnTest.java
@@ -5,13 +5,15 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import com.clickhouse.data.value.ClickHouseArrayValue;
+import com.clickhouse.data.value.ClickHouseGeoPointValue;
+import com.clickhouse.data.value.ClickHouseGeoPolygonValue;
+import com.clickhouse.data.value.ClickHouseGeoRingValue;
 import com.clickhouse.data.value.ClickHouseLongValue;
 import com.clickhouse.data.value.UnsignedLong;
 import com.clickhouse.data.value.array.ClickHouseLongArrayValue;
@@ -442,6 +444,35 @@ public class ClickHouseColumnTest {
                 Assert.assertNull(value.asObject());
             }
         }
+    }
+
+    @Test(groups = { "unit" })
+    public void testGeometryVariantOrdNumUsesArrayDimensions() {
+        ClickHouseColumn geometry = ClickHouseColumn.of("v", "Geometry");
+
+        Assert.assertEquals(geometry.getGeometryVariantOrdNum(1),
+                getVariantOrdNum(geometry, ClickHouseDataType.Point));
+        Assert.assertEquals(geometry.getGeometryVariantOrdNum(2),
+                getVariantOrdNum(geometry, ClickHouseDataType.Ring));
+        Assert.assertEquals(geometry.getGeometryVariantOrdNum(
+                        ClickHouseGeoPointValue.of(new double[] { 1D, 2D })),
+                getVariantOrdNum(geometry, ClickHouseDataType.Point));
+        Assert.assertEquals(geometry.getGeometryVariantOrdNum(
+                        ClickHouseGeoRingValue.of(new double[][] { { 1D, 2D }, { 3D, 4D } })),
+                getVariantOrdNum(geometry, ClickHouseDataType.Ring));
+        Assert.assertEquals(geometry.getGeometryVariantOrdNum(
+                        ClickHouseGeoPolygonValue.of(new double[][][] { { { 1D, 2D }, { 3D, 4D } } })),
+                getVariantOrdNum(geometry, ClickHouseDataType.Polygon));
+    }
+
+    private static int getVariantOrdNum(ClickHouseColumn column, ClickHouseDataType dataType) {
+        for (int i = 0; i < column.getNestedColumns().size(); i++) {
+            if (column.getNestedColumns().get(i).getDataType() == dataType) {
+                return i;
+            }
+        }
+
+        throw new IllegalArgumentException("No nested variant type found for " + dataType);
     }
 
     @Test(groups = {"unit"}, dataProvider = "testJSONBinaryFormat_dp")

--- a/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseDataTypeTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseDataTypeTest.java
@@ -45,4 +45,19 @@ public class ClickHouseDataTypeTest {
         Assert.assertEquals(matched.size(), 1);
         Assert.assertEquals(matched.get(0), "UInt32");
     }
+
+    @Test(groups = { "unit" })
+    public void testGeometryVariantMapping() {
+        ClickHouseColumn geometry = ClickHouseColumn.of("v", "Geometry");
+
+        Assert.assertNotEquals(geometry.getVariantOrdNum(new double[] { 1D, 2D }), -1);
+        Assert.assertNotEquals(geometry.getVariantOrdNum(new double[][] { new double[] { 1D, 2D } }), -1);
+        Assert.assertNotEquals(
+                geometry.getVariantOrdNum(new double[][][] { new double[][] { new double[] { 1D, 2D } } }),
+                -1);
+        Assert.assertNotEquals(
+                geometry.getVariantOrdNum(
+                        new double[][][][] { new double[][][] { new double[][] { new double[] { 1D, 2D } } } }),
+                -1);
+    }
 }

--- a/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseDataTypeTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseDataTypeTest.java
@@ -45,19 +45,4 @@ public class ClickHouseDataTypeTest {
         Assert.assertEquals(matched.size(), 1);
         Assert.assertEquals(matched.get(0), "UInt32");
     }
-
-    @Test(groups = { "unit" })
-    public void testGeometryVariantMapping() {
-        ClickHouseColumn geometry = ClickHouseColumn.of("v", "Geometry");
-
-        Assert.assertNotEquals(geometry.getVariantOrdNum(new double[] { 1D, 2D }), -1);
-        Assert.assertNotEquals(geometry.getVariantOrdNum(new double[][] { new double[] { 1D, 2D } }), -1);
-        Assert.assertNotEquals(
-                geometry.getVariantOrdNum(new double[][][] { new double[][] { new double[] { 1D, 2D } } }),
-                -1);
-        Assert.assertNotEquals(
-                geometry.getVariantOrdNum(
-                        new double[][][][] { new double[][][] { new double[][] { new double[] { 1D, 2D } } } }),
-                -1);
-    }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -246,7 +246,6 @@ public class BinaryStreamReader {
                 case AggregateFunction:
                     return (T) readBitmap( actualColumn);
                 case Variant:
-                    return (T) readVariant(actualColumn);
                 case Geometry:
                     return (T) readVariant(actualColumn);
                 case Dynamic:

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -247,6 +247,8 @@ public class BinaryStreamReader {
                     return (T) readBitmap( actualColumn);
                 case Variant:
                     return (T) readVariant(actualColumn);
+                case Geometry:
+                    return (T) readVariant(actualColumn);
                 case Dynamic:
                     return (T) readValue(actualColumn, typeHint);
                 case Nested:
@@ -624,7 +626,10 @@ public class BinaryStreamReader {
 
     public ArrayValue readArrayItem(ClickHouseColumn itemTypeColumn, int len) throws IOException {
         ArrayValue array;
-        if (itemTypeColumn.isNullable() || itemTypeColumn.getDataType() == ClickHouseDataType.Variant) {
+        if (itemTypeColumn.isNullable()
+                || itemTypeColumn.getDataType() == ClickHouseDataType.Variant
+                || itemTypeColumn.getDataType() == ClickHouseDataType.Dynamic
+                || itemTypeColumn.getDataType() == ClickHouseDataType.Geometry) {
             array = new ArrayValue(Object.class, len);
             for (int i = 0; i < len; i++) {
                 array.set(i, readValue(itemTypeColumn));

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/SerializerUtils.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/SerializerUtils.java
@@ -77,6 +77,9 @@ public class SerializerUtils {
             case Variant:
                 serializerVariant(stream, column, value);
                 break;
+            case Geometry:
+                serializerVariant(stream, column, value);
+                break;
             case Point:
                 value = value instanceof ClickHouseGeoPointValue ? ((ClickHouseGeoPointValue)value).getValue() : value;
                 serializeTupleData(stream, value, GEO_POINT_TUPLE);
@@ -305,9 +308,12 @@ public class SerializerUtils {
         if (binTag == -1) {
             switch (dt) {
                 case Point:
+                case LineString:
+                case MultiLineString:
                 case Polygon:
                 case Ring:
                 case MultiPolygon:
+                case Geometry:
                     stream.write(ClickHouseDataType.CUSTOM_TYPE_BIN_TAG);
                     BinaryStreamUtils.writeString(stream, dt.name());
                     return;

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/SerializerUtils.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/SerializerUtils.java
@@ -728,8 +728,11 @@ public class SerializerUtils {
 
     public static void serializerGeometry(OutputStream out, ClickHouseColumn column, Object value) throws IOException {
         int typeOrdNum = column.getGeometryVariantOrdNum(value);
-        if (typeOrdNum == -1 && value != null && value.getClass().isArray()) {
-            typeOrdNum = column.getGeometryVariantOrdNum(getArrayDimensions(value));
+        if (typeOrdNum == -1) {
+            int dimensions = getArrayDimensions(value);
+            if (isValidGeometryShape(value, dimensions)) {
+                typeOrdNum = column.getGeometryVariantOrdNum(dimensions);
+            }
         }
         if (typeOrdNum != -1) {
             BinaryStreamUtils.writeUnsignedInt8(out, typeOrdNum);
@@ -751,7 +754,19 @@ public class SerializerUtils {
             return 3;
         } else if (value instanceof double[][][][] || value instanceof Double[][][][]) {
             return 4;
-        } else if (value == null || !value.getClass().isArray()) {
+        } else if (value == null) {
+            return -1;
+        }
+
+        if (value instanceof List<?>) {
+            Object nestedValue = firstNonNullListElement((List<?>) value);
+            if (nestedValue == null) {
+                return 1;
+            }
+
+            int nestedDimensions = getArrayDimensions(nestedValue);
+            return nestedDimensions > 0 ? nestedDimensions + 1 : 1;
+        } else if (!value.getClass().isArray()) {
             return -1;
         }
 
@@ -773,6 +788,66 @@ public class SerializerUtils {
 
         int nestedDimensions = getArrayDimensions(nestedValue);
         return nestedDimensions > 0 ? dimensions + nestedDimensions : dimensions;
+    }
+
+    private static Object firstNonNullListElement(List<?> value) {
+        for (Object item : value) {
+            if (item != null) {
+                return item;
+            }
+        }
+
+        return null;
+    }
+
+    private static boolean isValidGeometryShape(Object value, int dimensions) {
+        if (value == null || dimensions < 1) {
+            return false;
+        }
+
+        if (dimensions == 1) {
+            return getGeometryLength(value) == 2
+                    && getGeometryElement(value, 0) instanceof Number
+                    && getGeometryElement(value, 1) instanceof Number;
+        }
+
+        int len = getGeometryLength(value);
+        if (len < 0) {
+            return false;
+        }
+
+        for (int i = 0; i < len; i++) {
+            Object element = getGeometryElement(value, i);
+            if (element == null || !isArrayOrList(element) || !isValidGeometryShape(element, dimensions - 1)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private static boolean isArrayOrList(Object value) {
+        return value instanceof List<?> || value.getClass().isArray();
+    }
+
+    private static int getGeometryLength(Object value) {
+        if (value instanceof List<?>) {
+            return ((List<?>) value).size();
+        } else if (value != null && value.getClass().isArray()) {
+            return Array.getLength(value);
+        }
+
+        return -1;
+    }
+
+    private static Object getGeometryElement(Object value, int index) {
+        if (value instanceof List<?>) {
+            return ((List<?>) value).get(index);
+        } else if (value != null && value.getClass().isArray()) {
+            return Array.get(value, index);
+        }
+
+        return null;
     }
 
     private static Object firstNonNullArrayElement(Object value) {

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/SerializerUtils.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/SerializerUtils.java
@@ -721,7 +721,8 @@ public class SerializerUtils {
             BinaryStreamUtils.writeUnsignedInt8(out, typeOrdNum);
             serializeData(out, value, column.getNestedColumns().get(typeOrdNum));
         } else {
-            throw new IllegalArgumentException("Cannot write value of class " + value.getClass() + " into column with variant type " + column.getOriginalTypeName());
+            throw new IllegalArgumentException("Cannot write value of class " + (value == null ? "<null value>" : value.getClass())
+                    + " into column with variant type " + column.getOriginalTypeName());
         }
     }
 
@@ -735,7 +736,8 @@ public class SerializerUtils {
             serializeData(out, value, column.getNestedColumns().get(typeOrdNum));
         } else {
             throw new IllegalArgumentException(
-                    "Cannot write value of class " + value.getClass() + " into column with geometry type "
+                    "Cannot write value of class " + (value == null ? "<null value>" : value.getClass())
+                            + " into column with geometry type "
                             + column.getOriginalTypeName());
         }
     }

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/SerializerUtils.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/SerializerUtils.java
@@ -78,7 +78,7 @@ public class SerializerUtils {
                 serializerVariant(stream, column, value);
                 break;
             case Geometry:
-                serializerVariant(stream, column, value);
+                serializerGeometry(stream, column, value);
                 break;
             case Point:
                 value = value instanceof ClickHouseGeoPointValue ? ((ClickHouseGeoPointValue)value).getValue() : value;
@@ -722,6 +722,65 @@ public class SerializerUtils {
         } else {
             throw new IllegalArgumentException("Cannot write value of class " + value.getClass() + " into column with variant type " + column.getOriginalTypeName());
         }
+    }
+
+    public static void serializerGeometry(OutputStream out, ClickHouseColumn column, Object value) throws IOException {
+        int typeOrdNum = column.getGeometryVariantOrdNum(value);
+        if (typeOrdNum == -1 && value != null && value.getClass().isArray()) {
+            typeOrdNum = column.getGeometryVariantOrdNum(getArrayDimensions(value));
+        }
+        if (typeOrdNum != -1) {
+            BinaryStreamUtils.writeUnsignedInt8(out, typeOrdNum);
+            serializeData(out, value, column.getNestedColumns().get(typeOrdNum));
+        } else {
+            throw new IllegalArgumentException(
+                    "Cannot write value of class " + value.getClass() + " into column with geometry type "
+                            + column.getOriginalTypeName());
+        }
+    }
+
+    static int getArrayDimensions(Object value) {
+        if (value instanceof double[] || value instanceof Double[]) {
+            return 1;
+        } else if (value instanceof double[][] || value instanceof Double[][]) {
+            return 2;
+        } else if (value instanceof double[][][] || value instanceof Double[][][]) {
+            return 3;
+        } else if (value instanceof double[][][][] || value instanceof Double[][][][]) {
+            return 4;
+        } else if (value == null || !value.getClass().isArray()) {
+            return -1;
+        }
+
+        Class<?> componentType = value.getClass();
+        int dimensions = 0;
+        while (componentType.isArray()) {
+            dimensions++;
+            componentType = componentType.getComponentType();
+        }
+
+        if (componentType != Object.class) {
+            return dimensions;
+        }
+
+        Object nestedValue = firstNonNullArrayElement(value);
+        if (nestedValue == null) {
+            return dimensions;
+        }
+
+        int nestedDimensions = getArrayDimensions(nestedValue);
+        return nestedDimensions > 0 ? dimensions + nestedDimensions : dimensions;
+    }
+
+    private static Object firstNonNullArrayElement(Object value) {
+        for (int i = 0, len = Array.getLength(value); i < len; i++) {
+            Object item = Array.get(value, i);
+            if (item != null) {
+                return item;
+            }
+        }
+
+        return null;
     }
 
     private static final ClickHouseColumn GEO_POINT_TUPLE = ClickHouseColumn.parse("geopoint Tuple(Float64, Float64)").get(0);

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/DataTypeConverter.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/DataTypeConverter.java
@@ -5,6 +5,10 @@ import com.clickhouse.client.api.DataTypeUtils;
 import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseDataType;
+import com.clickhouse.data.value.ClickHouseGeoMultiPolygonValue;
+import com.clickhouse.data.value.ClickHouseGeoPointValue;
+import com.clickhouse.data.value.ClickHouseGeoPolygonValue;
+import com.clickhouse.data.value.ClickHouseGeoRingValue;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -58,6 +62,14 @@ public class DataTypeConverter {
             case Enum16:
             case Enum:
                 return enumToString(value, column);
+            case Point:
+            case Ring:
+            case LineString:
+            case Polygon:
+            case MultiLineString:
+            case MultiPolygon:
+            case Geometry:
+                return geoToString(value);
             case IPv4:
             case IPv6:
                 return ipvToString(value, column);
@@ -221,8 +233,81 @@ public class DataTypeConverter {
     public String variantOrDynamicToString(Object value, ClickHouseColumn column) {
         if (value instanceof BinaryStreamReader.ArrayValue) {
             return arrayToString(value, column);
+        } else if (isGeoValue(value)) {
+            return geoToString(value);
+        } else if (value.getClass().isArray() || value instanceof List<?>) {
+            return rawArrayLikeToString(value);
         }
         return value.toString();
+    }
+
+    private String geoToString(Object value) {
+        if (value instanceof ClickHouseGeoPointValue
+                || value instanceof ClickHouseGeoRingValue
+                || value instanceof ClickHouseGeoPolygonValue
+                || value instanceof ClickHouseGeoMultiPolygonValue) {
+            return ((com.clickhouse.data.ClickHouseValue) value).asString();
+        } else if (value instanceof double[]) {
+            return ClickHouseGeoPointValue.of((double[]) value).asString();
+        } else if (value instanceof double[][]) {
+            return ClickHouseGeoRingValue.of((double[][]) value).asString();
+        } else if (value instanceof double[][][]) {
+            return ClickHouseGeoPolygonValue.of((double[][][]) value).asString();
+        } else if (value instanceof double[][][][]) {
+            return ClickHouseGeoMultiPolygonValue.of((double[][][][]) value).asString();
+        }
+        return rawArrayLikeToString(value);
+    }
+
+    private boolean isGeoValue(Object value) {
+        return value instanceof ClickHouseGeoPointValue
+                || value instanceof ClickHouseGeoRingValue
+                || value instanceof ClickHouseGeoPolygonValue
+                || value instanceof ClickHouseGeoMultiPolygonValue
+                || value instanceof double[]
+                || value instanceof double[][]
+                || value instanceof double[][][]
+                || value instanceof double[][][][];
+    }
+
+    private String rawArrayLikeToString(Object value) {
+        if (value instanceof List<?>) {
+            List<?> list = (List<?>) value;
+            StringBuilder builder = new StringBuilder("[");
+            for (Object item : list) {
+                builder.append(rawArrayLikeItemToString(item)).append(", ");
+            }
+            if (!list.isEmpty()) {
+                builder.setLength(builder.length() - 2);
+            }
+            return builder.append(']').toString();
+        } else if (value != null && value.getClass().isArray()) {
+            int len = java.lang.reflect.Array.getLength(value);
+            StringBuilder builder = new StringBuilder("[");
+            for (int i = 0; i < len; i++) {
+                builder.append(rawArrayLikeItemToString(java.lang.reflect.Array.get(value, i))).append(", ");
+            }
+            if (len > 0) {
+                builder.setLength(builder.length() - 2);
+            }
+            return builder.append(']').toString();
+        }
+        return String.valueOf(value);
+    }
+
+    private String rawArrayLikeItemToString(Object item) {
+        if (item == null) {
+            return NULL;
+        } else if (item instanceof String || item instanceof Character) {
+            return new StringBuilder().append(QUOTE).append(item).append(QUOTE).toString();
+        } else if (item instanceof BinaryStreamReader.EnumValue) {
+            return ((BinaryStreamReader.EnumValue) item).name;
+        } else if (isGeoValue(item)) {
+            return geoToString(item);
+        } else if (item instanceof List<?> || item.getClass().isArray()) {
+            return rawArrayLikeToString(item);
+        }
+        return String.valueOf(item);
     }
 
     private static void appendEnquotedArrayElement(String value, ClickHouseColumn elementColumn, Appendable appendable) {

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/DataTypeConverter.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/DataTypeConverter.java
@@ -5,10 +5,6 @@ import com.clickhouse.client.api.DataTypeUtils;
 import com.clickhouse.client.api.data_formats.internal.BinaryStreamReader;
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseDataType;
-import com.clickhouse.data.value.ClickHouseGeoMultiPolygonValue;
-import com.clickhouse.data.value.ClickHouseGeoPointValue;
-import com.clickhouse.data.value.ClickHouseGeoPolygonValue;
-import com.clickhouse.data.value.ClickHouseGeoRingValue;
 
 import java.io.IOException;
 import java.net.InetAddress;
@@ -62,14 +58,6 @@ public class DataTypeConverter {
             case Enum16:
             case Enum:
                 return enumToString(value, column);
-            case Point:
-            case Ring:
-            case LineString:
-            case Polygon:
-            case MultiLineString:
-            case MultiPolygon:
-            case Geometry:
-                return geoToString(value);
             case IPv4:
             case IPv6:
                 return ipvToString(value, column);
@@ -233,81 +221,8 @@ public class DataTypeConverter {
     public String variantOrDynamicToString(Object value, ClickHouseColumn column) {
         if (value instanceof BinaryStreamReader.ArrayValue) {
             return arrayToString(value, column);
-        } else if (isGeoValue(value)) {
-            return geoToString(value);
-        } else if (value.getClass().isArray() || value instanceof List<?>) {
-            return rawArrayLikeToString(value);
         }
         return value.toString();
-    }
-
-    private String geoToString(Object value) {
-        if (value instanceof ClickHouseGeoPointValue
-                || value instanceof ClickHouseGeoRingValue
-                || value instanceof ClickHouseGeoPolygonValue
-                || value instanceof ClickHouseGeoMultiPolygonValue) {
-            return ((com.clickhouse.data.ClickHouseValue) value).asString();
-        } else if (value instanceof double[]) {
-            return ClickHouseGeoPointValue.of((double[]) value).asString();
-        } else if (value instanceof double[][]) {
-            return ClickHouseGeoRingValue.of((double[][]) value).asString();
-        } else if (value instanceof double[][][]) {
-            return ClickHouseGeoPolygonValue.of((double[][][]) value).asString();
-        } else if (value instanceof double[][][][]) {
-            return ClickHouseGeoMultiPolygonValue.of((double[][][][]) value).asString();
-        }
-        return rawArrayLikeToString(value);
-    }
-
-    private boolean isGeoValue(Object value) {
-        return value instanceof ClickHouseGeoPointValue
-                || value instanceof ClickHouseGeoRingValue
-                || value instanceof ClickHouseGeoPolygonValue
-                || value instanceof ClickHouseGeoMultiPolygonValue
-                || value instanceof double[]
-                || value instanceof double[][]
-                || value instanceof double[][][]
-                || value instanceof double[][][][];
-    }
-
-    private String rawArrayLikeToString(Object value) {
-        if (value instanceof List<?>) {
-            List<?> list = (List<?>) value;
-            StringBuilder builder = new StringBuilder("[");
-            for (Object item : list) {
-                builder.append(rawArrayLikeItemToString(item)).append(", ");
-            }
-            if (!list.isEmpty()) {
-                builder.setLength(builder.length() - 2);
-            }
-            return builder.append(']').toString();
-        } else if (value != null && value.getClass().isArray()) {
-            int len = java.lang.reflect.Array.getLength(value);
-            StringBuilder builder = new StringBuilder("[");
-            for (int i = 0; i < len; i++) {
-                builder.append(rawArrayLikeItemToString(java.lang.reflect.Array.get(value, i))).append(", ");
-            }
-            if (len > 0) {
-                builder.setLength(builder.length() - 2);
-            }
-            return builder.append(']').toString();
-        }
-        return String.valueOf(value);
-    }
-
-    private String rawArrayLikeItemToString(Object item) {
-        if (item == null) {
-            return NULL;
-        } else if (item instanceof String || item instanceof Character) {
-            return new StringBuilder().append(QUOTE).append(item).append(QUOTE).toString();
-        } else if (item instanceof BinaryStreamReader.EnumValue) {
-            return ((BinaryStreamReader.EnumValue) item).name;
-        } else if (isGeoValue(item)) {
-            return geoToString(item);
-        } else if (item instanceof List<?> || item.getClass().isArray()) {
-            return rawArrayLikeToString(item);
-        }
-        return String.valueOf(item);
     }
 
     private static void appendEnquotedArrayElement(String value, ClickHouseColumn elementColumn, Appendable appendable) {

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/DataTypeConverter.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/DataTypeConverter.java
@@ -7,6 +7,7 @@ import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseDataType;
 
 import java.io.IOException;
+import java.lang.reflect.Array;
 import java.net.InetAddress;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -63,6 +64,14 @@ public class DataTypeConverter {
                 return ipvToString(value, column);
             case Array:
                 return  arrayToString(value, column);
+            case Point:
+            case Ring:
+            case LineString:
+            case Polygon:
+            case MultiLineString:
+            case MultiPolygon:
+            case Geometry:
+                return geoToString(value, column);
             case Variant:
             case Dynamic:
                 return variantOrDynamicToString(value, column);
@@ -212,6 +221,11 @@ public class DataTypeConverter {
         return arrayToString(value, column);
     }
 
+    public String geoToString(Object value, ClickHouseColumn column) {
+        String geoValue = tryGeoToString(value, column);
+        return geoValue != null ? geoValue : value.toString();
+    }
+
     /**
      *
      * @param value not null object value to convert
@@ -222,7 +236,127 @@ public class DataTypeConverter {
         if (value instanceof BinaryStreamReader.ArrayValue) {
             return arrayToString(value, column);
         }
+        String geoValue = tryGeoToString(value, column);
+        if (geoValue != null) {
+            return geoValue;
+        }
+        if (value.getClass().isArray()) {
+            return arrayToString(value, column);
+        }
         return value.toString();
+    }
+
+    private String tryGeoToString(Object value, ClickHouseColumn column) {
+        if (value == null || !value.getClass().isArray()) {
+            return null;
+        }
+
+        int dimensions = getArrayDimensions(value);
+        if (dimensions < 1 || dimensions > 4 || !isGeoShape(value, dimensions)) {
+            return null;
+        }
+
+        ClickHouseDataType dataType = column.getDataType();
+        if (isGeoType(dataType)) {
+            return geoArrayToString(value);
+        }
+
+        if (dataType == ClickHouseDataType.Variant && matchesGeoVariant(column, dimensions)) {
+            return geoArrayToString(value);
+        }
+
+        if (dataType == ClickHouseDataType.Dynamic) {
+            return geoArrayToString(value);
+        }
+
+        return null;
+    }
+
+    private boolean matchesGeoVariant(ClickHouseColumn column, int dimensions) {
+        for (ClickHouseColumn nestedColumn : column.getNestedColumns()) {
+            if (isGeoTypeForDimensions(nestedColumn.getDataType(), dimensions)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private boolean isGeoType(ClickHouseDataType dataType) {
+        switch (dataType) {
+            case Point:
+            case Ring:
+            case LineString:
+            case Polygon:
+            case MultiLineString:
+            case MultiPolygon:
+            case Geometry:
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private boolean isGeoTypeForDimensions(ClickHouseDataType dataType, int dimensions) {
+        switch (dimensions) {
+            case 1:
+                return dataType == ClickHouseDataType.Point;
+            case 2:
+                return dataType == ClickHouseDataType.Ring || dataType == ClickHouseDataType.LineString;
+            case 3:
+                return dataType == ClickHouseDataType.Polygon || dataType == ClickHouseDataType.MultiLineString;
+            case 4:
+                return dataType == ClickHouseDataType.MultiPolygon;
+            default:
+                return false;
+        }
+    }
+
+    private int getArrayDimensions(Object value) {
+        int dimensions = 0;
+        Class<?> arrayClass = value.getClass();
+        while (arrayClass.isArray()) {
+            dimensions++;
+            arrayClass = arrayClass.getComponentType();
+        }
+        return dimensions;
+    }
+
+    private boolean isGeoShape(Object value, int dimensions) {
+        if (dimensions == 1) {
+            return Array.getLength(value) == 2
+                    && Array.get(value, 0) instanceof Double
+                    && Array.get(value, 1) instanceof Double;
+        }
+
+        for (int i = 0, len = Array.getLength(value); i < len; i++) {
+            Object item = Array.get(value, i);
+            if (item == null || !item.getClass().isArray() || !isGeoShape(item, dimensions - 1)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private String geoArrayToString(Object value) {
+        int dimensions = getArrayDimensions(value);
+        if (dimensions == 1) {
+            return new StringBuilder()
+                    .append('(')
+                    .append(Array.get(value, 0))
+                    .append(',')
+                    .append(Array.get(value, 1))
+                    .append(')')
+                    .toString();
+        }
+
+        StringBuilder builder = new StringBuilder().append('[');
+        for (int i = 0, len = Array.getLength(value); i < len; i++) {
+            if (i > 0) {
+                builder.append(',');
+            }
+            builder.append(geoArrayToString(Array.get(value, i)));
+        }
+        return builder.append(']').toString();
     }
 
     private static void appendEnquotedArrayElement(String value, ClickHouseColumn elementColumn, Appendable appendable) {

--- a/client-v2/src/test/java/com/clickhouse/client/api/data_formats/internal/SerializerUtilsTest.java
+++ b/client-v2/src/test/java/com/clickhouse/client/api/data_formats/internal/SerializerUtilsTest.java
@@ -31,15 +31,23 @@ public class SerializerUtilsTest {
     }
 
     @Test
-    public void testVariantWithGeometryRoundTrip() throws Exception {
-        ClickHouseColumn variant = ClickHouseColumn.of("v", "Variant(String, Geometry)");
-        double[][] ring = new double[][] {{1D, 2D}, {3D, 4D}};
+    public void testGeometryRoundTripWithBoxedArray() throws Exception {
+        ClickHouseColumn geometry = ClickHouseColumn.of("v", "Geometry");
+        Double[][] ring = new Double[][] {{1D, 2D}, {3D, 4D}};
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();
-        SerializerUtils.serializeData(out, ring, variant);
+        SerializerUtils.serializeData(out, ring, geometry);
 
-        Object value = newReader(out.toByteArray()).readValue(variant);
-        Assert.assertTrue(Arrays.deepEquals((double[][]) value, ring));
+        Object value = newReader(out.toByteArray()).readValue(geometry);
+        Assert.assertTrue(Arrays.deepEquals((double[][]) value, new double[][] {{1D, 2D}, {3D, 4D}}));
+    }
+
+    @Test
+    public void testGeometryArrayDimensions() {
+        Assert.assertEquals(SerializerUtils.getArrayDimensions(new Double[] {1D, 2D}), 1);
+        Assert.assertEquals(SerializerUtils.getArrayDimensions(new Double[][] {{1D, 2D}}), 2);
+        Assert.assertEquals(SerializerUtils.getArrayDimensions(new Double[][][] {{{1D, 2D}}}), 3);
+        Assert.assertEquals(SerializerUtils.getArrayDimensions(new Object[] {new Double[] {1D, 2D}}), 2);
     }
 
     @Test

--- a/client-v2/src/test/java/com/clickhouse/client/api/data_formats/internal/SerializerUtilsTest.java
+++ b/client-v2/src/test/java/com/clickhouse/client/api/data_formats/internal/SerializerUtilsTest.java
@@ -9,6 +9,7 @@ import org.testng.annotations.Test;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.util.Arrays;
+import java.util.List;
 import java.util.TimeZone;
 
 @Test(groups = {"unit"})
@@ -43,6 +44,34 @@ public class SerializerUtilsTest {
     }
 
     @Test
+    public void testGeometryRoundTripWithPointList() throws Exception {
+        ClickHouseColumn geometry = ClickHouseColumn.of("v", "Geometry");
+        List<Double> point = Arrays.asList(1.5D, 2.5D);
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SerializerUtils.serializeData(out, point, geometry);
+
+        Object value = newReader(out.toByteArray()).readValue(geometry);
+        Assert.assertEquals((double[]) value, new double[] {1.5D, 2.5D});
+    }
+
+    @Test
+    public void testGeometryRoundTripWithPolygonList() throws Exception {
+        ClickHouseColumn geometry = ClickHouseColumn.of("v", "Geometry");
+        List<List<List<Double>>> polygon = Arrays.asList(
+                Arrays.asList(
+                        Arrays.asList(1D, 2D),
+                        Arrays.asList(3D, 4D),
+                        Arrays.asList(1D, 2D)));
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SerializerUtils.serializeData(out, polygon, geometry);
+
+        Object value = newReader(out.toByteArray()).readValue(geometry);
+        Assert.assertTrue(Arrays.deepEquals((double[][][]) value, new double[][][] {{{1D, 2D}, {3D, 4D}, {1D, 2D}}}));
+    }
+
+    @Test
     public void testGeometryRoundTripWithMultiPolygonArray() throws Exception {
         ClickHouseColumn geometry = ClickHouseColumn.of("v", "Geometry");
         double[][][][] multiPolygon = new double[][][][] {{{{1D, 2D}, {3D, 4D}}}};
@@ -63,6 +92,10 @@ public class SerializerUtilsTest {
         Assert.assertEquals(SerializerUtils.getArrayDimensions(new Object[] {new Double[] {1D, 2D}}), 2);
         Assert.assertEquals(SerializerUtils.getArrayDimensions(new Object[] {null, new Object[] {new Double[] {1D, 2D}}}), 3);
         Assert.assertEquals(SerializerUtils.getArrayDimensions(new Object[] {null, null}), 1);
+        Assert.assertEquals(SerializerUtils.getArrayDimensions(Arrays.asList(1D, 2D)), 1);
+        Assert.assertEquals(SerializerUtils.getArrayDimensions(Arrays.asList(Arrays.asList(1D, 2D))), 2);
+        Assert.assertEquals(SerializerUtils.getArrayDimensions(Arrays.asList(null, Arrays.asList(Arrays.asList(1D, 2D)))), 3);
+        Assert.assertEquals(SerializerUtils.getArrayDimensions(Arrays.asList()), 1);
         Assert.assertEquals(SerializerUtils.getArrayDimensions("not an array"), -1);
         Assert.assertEquals(SerializerUtils.getArrayDimensions(null), -1);
     }
@@ -90,6 +123,14 @@ public class SerializerUtilsTest {
     public void testGeometrySerializationRejectsUnsupportedValue() {
         Assert.assertThrows(IllegalArgumentException.class,
                 () -> SerializerUtils.serializeData(new ByteArrayOutputStream(), "not-geometry",
+                        ClickHouseColumn.of("v", "Geometry")));
+    }
+
+    @Test
+    public void testGeometrySerializationRejectsMalformedList() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> SerializerUtils.serializeData(new ByteArrayOutputStream(),
+                        Arrays.asList(Arrays.asList(1D, 2D, 3D)),
                         ClickHouseColumn.of("v", "Geometry")));
     }
 

--- a/client-v2/src/test/java/com/clickhouse/client/api/data_formats/internal/SerializerUtilsTest.java
+++ b/client-v2/src/test/java/com/clickhouse/client/api/data_formats/internal/SerializerUtilsTest.java
@@ -43,11 +43,28 @@ public class SerializerUtilsTest {
     }
 
     @Test
+    public void testGeometryRoundTripWithMultiPolygonArray() throws Exception {
+        ClickHouseColumn geometry = ClickHouseColumn.of("v", "Geometry");
+        double[][][][] multiPolygon = new double[][][][] {{{{1D, 2D}, {3D, 4D}}}};
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SerializerUtils.serializeData(out, multiPolygon, geometry);
+
+        Object value = newReader(out.toByteArray()).readValue(geometry);
+        Assert.assertTrue(Arrays.deepEquals((double[][][][]) value, multiPolygon));
+    }
+
+    @Test
     public void testGeometryArrayDimensions() {
         Assert.assertEquals(SerializerUtils.getArrayDimensions(new Double[] {1D, 2D}), 1);
         Assert.assertEquals(SerializerUtils.getArrayDimensions(new Double[][] {{1D, 2D}}), 2);
         Assert.assertEquals(SerializerUtils.getArrayDimensions(new Double[][][] {{{1D, 2D}}}), 3);
+        Assert.assertEquals(SerializerUtils.getArrayDimensions(new Double[][][][] {{{{1D, 2D}}}}), 4);
         Assert.assertEquals(SerializerUtils.getArrayDimensions(new Object[] {new Double[] {1D, 2D}}), 2);
+        Assert.assertEquals(SerializerUtils.getArrayDimensions(new Object[] {null, new Object[] {new Double[] {1D, 2D}}}), 3);
+        Assert.assertEquals(SerializerUtils.getArrayDimensions(new Object[] {null, null}), 1);
+        Assert.assertEquals(SerializerUtils.getArrayDimensions("not an array"), -1);
+        Assert.assertEquals(SerializerUtils.getArrayDimensions(null), -1);
     }
 
     @Test
@@ -67,6 +84,13 @@ public class SerializerUtilsTest {
         assertCustomGeoTypeTag("LineString");
         assertCustomGeoTypeTag("MultiLineString");
         assertCustomGeoTypeTag("Geometry");
+    }
+
+    @Test
+    public void testGeometrySerializationRejectsUnsupportedValue() {
+        Assert.assertThrows(IllegalArgumentException.class,
+                () -> SerializerUtils.serializeData(new ByteArrayOutputStream(), "not-geometry",
+                        ClickHouseColumn.of("v", "Geometry")));
     }
 
     private void assertCustomGeoTypeTag(String typeName) throws Exception {

--- a/client-v2/src/test/java/com/clickhouse/client/api/data_formats/internal/SerializerUtilsTest.java
+++ b/client-v2/src/test/java/com/clickhouse/client/api/data_formats/internal/SerializerUtilsTest.java
@@ -1,0 +1,72 @@
+package com.clickhouse.client.api.data_formats.internal;
+
+import com.clickhouse.data.ClickHouseColumn;
+import com.clickhouse.data.ClickHouseDataType;
+import com.clickhouse.data.value.ClickHouseGeoPolygonValue;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.util.Arrays;
+import java.util.TimeZone;
+
+@Test(groups = {"unit"})
+public class SerializerUtilsTest {
+    private BinaryStreamReader newReader(byte[] data) {
+        return new BinaryStreamReader(new ByteArrayInputStream(data), TimeZone.getTimeZone("UTC"), null,
+                new BinaryStreamReader.DefaultByteBufferAllocator(), false, null);
+    }
+
+    @Test
+    public void testGeometryRoundTrip() throws Exception {
+        ClickHouseColumn geometry = ClickHouseColumn.of("v", "Geometry");
+        double[] point = new double[] {1.5D, 2.5D};
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SerializerUtils.serializeData(out, point, geometry);
+
+        Object value = newReader(out.toByteArray()).readValue(geometry);
+        Assert.assertEquals((double[]) value, point);
+    }
+
+    @Test
+    public void testVariantWithGeometryRoundTrip() throws Exception {
+        ClickHouseColumn variant = ClickHouseColumn.of("v", "Variant(String, Geometry)");
+        double[][] ring = new double[][] {{1D, 2D}, {3D, 4D}};
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SerializerUtils.serializeData(out, ring, variant);
+
+        Object value = newReader(out.toByteArray()).readValue(variant);
+        Assert.assertTrue(Arrays.deepEquals((double[][]) value, ring));
+    }
+
+    @Test
+    public void testDynamicWithGeoCustomTypeRoundTrip() throws Exception {
+        ClickHouseColumn dynamic = ClickHouseColumn.of("v", "Dynamic");
+        double[][][] polygon = new double[][][] {{{1D, 2D}, {3D, 4D}}};
+
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SerializerUtils.serializeData(out, ClickHouseGeoPolygonValue.of(polygon), dynamic);
+
+        Object value = newReader(out.toByteArray()).readValue(dynamic);
+        Assert.assertTrue(Arrays.deepEquals((double[][][]) value, polygon));
+    }
+
+    @Test
+    public void testDynamicTypeTagUsesCustomEncodingForGeoTypes() throws Exception {
+        assertCustomGeoTypeTag("LineString");
+        assertCustomGeoTypeTag("MultiLineString");
+        assertCustomGeoTypeTag("Geometry");
+    }
+
+    private void assertCustomGeoTypeTag(String typeName) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        SerializerUtils.writeDynamicTypeTag(out, ClickHouseColumn.of("v", typeName));
+
+        ByteArrayInputStream in = new ByteArrayInputStream(out.toByteArray());
+        Assert.assertEquals(in.read(), ClickHouseDataType.CUSTOM_TYPE_BIN_TAG & 0xFF);
+        Assert.assertEquals(BinaryStreamReader.readString(in), typeName);
+    }
+}

--- a/client-v2/src/test/java/com/clickhouse/client/api/internal/DataTypeConverterTest.java
+++ b/client-v2/src/test/java/com/clickhouse/client/api/internal/DataTypeConverterTest.java
@@ -136,6 +136,9 @@ public class DataTypeConverterTest {
                 "[(1.0,2.0),(3.0,4.0)]");
         assertEquals(converter.convertToString(new double[][][] {{{1D, 2D}, {3D, 4D}}}, ClickHouseColumn.of("field", "Polygon")),
                 "[[(1.0,2.0),(3.0,4.0)]]");
+        assertEquals(
+                converter.convertToString(new double[][][][] {{{{1D, 2D}, {3D, 4D}}}}, ClickHouseColumn.of("field", "MultiPolygon")),
+                "[[[(1.0,2.0),(3.0,4.0)]]]");
         assertEquals(converter.convertToString(new double[] {1D, 2D}, ClickHouseColumn.of("field", "Geometry")), "(1.0,2.0)");
     }
 
@@ -148,5 +151,17 @@ public class DataTypeConverterTest {
         assertEquals(
                 converter.convertToString(new double[][] {{1D, 2D}, {3D, 4D}}, ClickHouseColumn.of("field", "Dynamic")),
                 "[(1.0,2.0),(3.0,4.0)]");
+        assertEquals(
+                converter.convertToString(new double[][][] {{{1D, 2D}, {3D, 4D}}}, ClickHouseColumn.of("field", "Variant(String, Polygon)")),
+                "[[(1.0,2.0),(3.0,4.0)]]");
+        assertEquals(
+                converter.convertToString(new double[][][][] {{{{1D, 2D}, {3D, 4D}}}}, ClickHouseColumn.of("field", "Dynamic")),
+                "[[[(1.0,2.0),(3.0,4.0)]]]");
+        assertEquals(
+                converter.convertToString(new int[] {1, 2, 3}, ClickHouseColumn.of("field", "Variant(String, Array(Int32))")),
+                "[1, 2, 3]");
+        assertEquals(
+                converter.convertToString(new double[][] {{1D, 2D, 3D}}, ClickHouseColumn.of("field", "Dynamic")),
+                "[[1.0, 2.0, 3.0]]");
     }
 }

--- a/client-v2/src/test/java/com/clickhouse/client/api/internal/DataTypeConverterTest.java
+++ b/client-v2/src/test/java/com/clickhouse/client/api/internal/DataTypeConverterTest.java
@@ -126,4 +126,27 @@ public class DataTypeConverterTest {
         assertEquals(converter.convertToString("1234567", column), "1234567");
         assertEquals(converter.convertToString(2, column), "2");
     }
+
+    @Test
+    public void testGeoToString() {
+        DataTypeConverter converter = new DataTypeConverter();
+
+        assertEquals(converter.convertToString(new double[] {1D, 2D}, ClickHouseColumn.of("field", "Point")), "(1.0,2.0)");
+        assertEquals(converter.convertToString(new double[][] {{1D, 2D}, {3D, 4D}}, ClickHouseColumn.of("field", "Ring")),
+                "[(1.0,2.0),(3.0,4.0)]");
+        assertEquals(converter.convertToString(new double[][][] {{{1D, 2D}, {3D, 4D}}}, ClickHouseColumn.of("field", "Polygon")),
+                "[[(1.0,2.0),(3.0,4.0)]]");
+        assertEquals(converter.convertToString(new double[] {1D, 2D}, ClickHouseColumn.of("field", "Geometry")), "(1.0,2.0)");
+    }
+
+    @Test
+    public void testVariantOrDynamicGeoToString() {
+        DataTypeConverter converter = new DataTypeConverter();
+
+        assertEquals(converter.convertToString(new double[] {1D, 2D}, ClickHouseColumn.of("field", "Variant(String, Point)")),
+                "(1.0,2.0)");
+        assertEquals(
+                converter.convertToString(new double[][] {{1D, 2D}, {3D, 4D}}, ClickHouseColumn.of("field", "Dynamic")),
+                "[(1.0,2.0),(3.0,4.0)]");
+    }
 }

--- a/client-v2/src/test/java/com/clickhouse/client/datatypes/DataTypeTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/datatypes/DataTypeTests.java
@@ -32,7 +32,6 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.sql.Connection;
 import java.time.Duration;
 import java.time.Instant;
 import java.time.LocalDate;
@@ -1062,6 +1061,55 @@ public class DataTypeTests extends BaseIntegrationTest {
     }
 
     @Test(groups = {"integration"})
+    public void testGeometryReadFromTable() throws Exception {
+        if (isVersionMatch("(,25.10]")) {
+            return;
+        }
+
+        final String table = "test_geometry_read";
+        final CommandSettings geometrySettings = (CommandSettings) new CommandSettings()
+                .serverSetting("allow_suspicious_variant_types", "1");
+        final Object[] expectedValues = new Object[] {
+                new double[] {1D, 2D},
+                new double[][] {{1D, 2D}, {3D, 4D}, {1D, 2D}},
+                new double[][][] {{{1D, 2D}, {3D, 4D}, {1D, 2D}}},
+                new double[][][][] {
+                        {{{1D, 2D}, {3D, 4D}, {1D, 2D}}},
+                        {{{5D, 6D}, {7D, 8D}, {5D, 6D}}}
+                }
+        };
+
+        client.execute("DROP TABLE IF EXISTS " + table).get().close();
+        client.execute(tableDefinition(table, "rowId Int32", "geom Geometry"), geometrySettings).get().close();
+        client.execute("INSERT INTO " + table + " VALUES "
+                + "(0, (1, 2)), "
+                + "(1, [(1, 2), (3, 4), (1, 2)]), "
+                + "(2, [[(1, 2), (3, 4), (1, 2)]]), "
+                + "(3, [[[(1, 2), (3, 4), (1, 2)]], [[(5, 6), (7, 8), (5, 6)]]])").get().close();
+
+        List<GenericRecord> records = client.queryAll("SELECT * FROM " + table + " ORDER BY rowId");
+        Assert.assertEquals(records.size(), expectedValues.length);
+        for (GenericRecord record : records) {
+            int rowId = record.getInteger("rowId");
+            Object actual = record.getObject("geom");
+            Assert.assertNotNull(record.getString("geom"));
+            assertGeometryValue(actual, expectedValues[rowId]);
+        }
+
+        try (QueryResponse response = client.query("SELECT * FROM " + table + " ORDER BY rowId").get()) {
+            ClickHouseBinaryFormatReader reader = client.newBinaryFormatReader(response);
+            int rowId = 0;
+            while (reader.next() != null) {
+                Object actual = reader.readValue("geom");
+                Assert.assertNotNull(reader.getString("geom"));
+                assertGeometryValue(actual, expectedValues[rowId]);
+                rowId++;
+            }
+            Assert.assertEquals(rowId, expectedValues.length);
+        }
+    }
+
+    @Test(groups = {"integration"})
     public void testDates() throws Exception {
         LocalDate date = LocalDate.of(2024, 1, 15);
 
@@ -1641,6 +1689,23 @@ public class DataTypeTests extends BaseIntegrationTest {
         sb.setLength(sb.length() - 2);
         sb.append(") Engine = MergeTree ORDER BY ()");
         return sb.toString();
+    }
+
+    private static void assertGeometryValue(Object actual, Object expected) {
+        Assert.assertNotNull(actual);
+        Assert.assertEquals(actual.getClass(), expected.getClass());
+
+        if (expected instanceof double[]) {
+            Assert.assertEquals((double[]) actual, (double[]) expected);
+        } else if (expected instanceof double[][]) {
+            Assert.assertTrue(Arrays.deepEquals((double[][]) actual, (double[][]) expected));
+        } else if (expected instanceof double[][][]) {
+            Assert.assertTrue(Arrays.deepEquals((double[][][]) actual, (double[][][]) expected));
+        } else if (expected instanceof double[][][][]) {
+            Assert.assertTrue(Arrays.deepEquals((double[][][][]) actual, (double[][][][]) expected));
+        } else {
+            Assert.fail("Unexpected geometry type: " + expected.getClass());
+        }
     }
 
     private boolean isVersionMatch(String versionExpression) {

--- a/client-v2/src/test/java/com/clickhouse/client/datatypes/DataTypeTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/datatypes/DataTypeTests.java
@@ -1109,6 +1109,60 @@ public class DataTypeTests extends BaseIntegrationTest {
         }
     }
 
+    @Data
+    @AllArgsConstructor
+    public static class DTOForGeometryTests {
+        private int rowId;
+        private Object geom;
+    }
+
+    @Test(groups = {"integration"})
+    public void testGeometryWriteToTable() throws Exception {
+        if (isVersionMatch("(,25.10]")) {
+            return;
+        }
+
+        final String table = "test_geometry_write";
+        final CommandSettings geometrySettings = (CommandSettings) new CommandSettings()
+                .serverSetting("allow_suspicious_variant_types", "1");
+        final Object[] valuesToInsert = new Object[] {
+                new Double[] {1D, 2D},
+                new Double[][] {{1D, 2D}, {3D, 4D}, {1D, 2D}},
+                new Double[][][] {{{1D, 2D}, {3D, 4D}, {1D, 2D}}},
+                new Double[][][][] {
+                        {{{1D, 2D}, {3D, 4D}, {1D, 2D}}},
+                        {{{5D, 6D}, {7D, 8D}, {5D, 6D}}}
+                }
+        };
+        final Object[] expectedValues = new Object[] {
+                new double[] {1D, 2D},
+                new double[][] {{1D, 2D}, {3D, 4D}, {1D, 2D}},
+                new double[][][] {{{1D, 2D}, {3D, 4D}, {1D, 2D}}},
+                new double[][][][] {
+                        {{{1D, 2D}, {3D, 4D}, {1D, 2D}}},
+                        {{{5D, 6D}, {7D, 8D}, {5D, 6D}}}
+                }
+        };
+
+        client.execute("DROP TABLE IF EXISTS " + table).get().close();
+        client.execute(tableDefinition(table, "rowId Int32", "geom Geometry"), geometrySettings).get().close();
+        client.register(DTOForGeometryTests.class, client.getTableSchema(table));
+
+        List<DTOForGeometryTests> data = new ArrayList<>();
+        for (int i = 0; i < valuesToInsert.length; i++) {
+            data.add(new DTOForGeometryTests(i, valuesToInsert[i]));
+        }
+        client.insert(table, data).get().close();
+
+        List<GenericRecord> records = client.queryAll("SELECT * FROM " + table + " ORDER BY rowId");
+        Assert.assertEquals(records.size(), expectedValues.length);
+        for (GenericRecord record : records) {
+            int rowId = record.getInteger("rowId");
+            Assert.assertNotNull(record.getString("geom"));
+            assertGeometryValue(record.getObject("geom"), expectedValues[rowId]);
+        }
+    }
+
     @Test(groups = {"integration"})
     public void testDates() throws Exception {
         LocalDate date = LocalDate.of(2024, 1, 15);

--- a/docs/features.md
+++ b/docs/features.md
@@ -15,6 +15,7 @@ This document lists stable, user-visible behavior in `client-v2` and `jdbc-v2` t
 - Result materialization helpers: Provides streaming `Records`, generic row access, and convenience APIs that materialize all rows into generic records or typed POJOs.
 - Binary format readers: Reads ClickHouse binary result formats including `Native`, `RowBinary`, `RowBinaryWithNames`, and `RowBinaryWithNamesAndTypes`.
 - Data type conversion: Maps ClickHouse types to Java values for binary reads, POJO binding, and SQL parameter formatting, including date/time handling.
+- Geometry type support: For ClickHouse `25.11+`, where `Geometry` changed from a string alias to `Variant(Point, Ring, LineString, MultiLineString, Polygon, MultiPolygon)`, the client reads and writes `Geometry` values through generic records, binary readers, POJO binding, and SQL parameter formatting, using Java array dimensionality to represent the geometry shape.
 - Insert APIs: Supports inserting registered POJOs, raw streams, and callback-driven writers, with optional column lists and format selection.
 - Insert controls: Supports insert-specific settings such as deduplication token, query id, compression behavior, and request headers.
 - Command execution: Executes DDL or other non-result commands and exposes response summaries and operation metrics.
@@ -35,6 +36,8 @@ Compatibility-sensitive traits:
 - Identifier quoting behavior is stable API for helper callers: identifiers are double-quoted, embedded double quotes are doubled, and optional quoting keeps simple identifiers unchanged.
 - Instant formatting is type-sensitive and should not drift: `Date` formatting depends on an explicit timezone, `DateTime` is serialized as epoch seconds, and higher-precision timestamps preserve up to 9 fractional digits.
 - Timezone conversion helpers preserve nanoseconds and can intentionally shift local date or time when interpreted in a different timezone; this behavior is covered by tests and should not be normalized away.
+- `Geometry` handling is shape-sensitive: supported values are 1D through 4D Java arrays representing the nested geometry variants, and unsupported shapes or non-array values are rejected during serialization.
+- `Geometry` write inference is dimension-based rather than fully type-specific: point, ring/line string, polygon/multi-line string, and multi-polygon are selected from array depth, so writing `Geometry` cannot currently distinguish `Ring` from `LineString` or `Polygon` from `MultiLineString`.
 - Session precedence is part of the contract: client session defaults apply to each request, operation settings may override them, and only the client `session_id` is mutable at runtime while other client session properties remain fixed for the lifetime of the client.
 
 
@@ -60,6 +63,7 @@ Compatibility-sensitive traits:
 - Parameter metadata: Reports prepared-statement parameter counts.
 - Type mapping and conversions: Maps ClickHouse types to JDBC types and Java classes, including date/time handling and `java.time` support.
 - Arrays and tuples: Supports JDBC arrays plus ClickHouse tuple values through custom `Array` and `Struct` implementations.
+- Geometry type mapping: For ClickHouse `25.11+`, where `Geometry` changed from a string alias to `Variant(Point, Ring, LineString, MultiLineString, Polygon, MultiPolygon)`, JDBC exposes `Geometry` as `ARRAY`, returns nested Java arrays from `getObject()`/`getArray()`, and accepts `Struct` or nested `Array` inputs for prepared-statement inserts depending on the geometry shape.
 - Client info propagation: Supports JDBC client info such as `ApplicationName` and forwards it to the underlying client name.
 - Wrapper support: Implements standard JDBC `Wrapper` and `unwrap` behavior on major JDBC objects.
 - Packaging and runtime compatibility: Ships as a JDBC 4.2 driver, depends on `client-v2`, and includes native-image metadata for GraalVM users.
@@ -71,6 +75,8 @@ Compatibility-sensitive traits:
 - String parameters are escaped with backslash-based escaping: backslashes are doubled and single quotes are backslash-escaped before values are wrapped in single quotes.
 - `?` placeholder detection is SQL-aware and should not treat question marks inside quoted strings, quoted identifiers, comments, casts, or similar syntax as bind parameters.
 - String-like ClickHouse values have stable JDBC expectations: `String`, `FixedString`, and `Enum` values are returned as strings, while `UUID` is available both as `getString()` and `getObject(..., UUID.class)`.
+- `Geometry` has a stable JDBC mapping: metadata reports SQL type `ARRAY` with type name `Geometry`, read paths return nested Java arrays rather than custom wrappers, and write paths depend on the caller preserving the intended point/array nesting shape.
+- JDBC `Geometry` writes share the same ambiguity as the client serializer: variant selection is inferred from nesting depth, so `Ring` versus `LineString` and `Polygon` versus `MultiLineString` are not currently distinguishable when writing through the generic `Geometry` path.
 - Binary parameters passed through `setBytes()` are encoded as ClickHouse `unhex(...)` expressions rather than text literals; empty byte arrays map to an empty string expression.
 - Stream and reader setters (`setAsciiStream`, `setUnicodeStream`, `setBinaryStream`, `setCharacterStream`, `setNCharacterStream`) are treated as text input encoded with the same string-escaping rules, including length-based truncation when a length is supplied.
 - `getString()` formatting for temporal values is stable output: `Date` uses `yyyy-MM-dd`, `DateTime` uses `yyyy-MM-dd HH:mm:ss`, and `DateTime64` preserves fractional precision, all interpreted in server timezone context where applicable.

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/ResultSetImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/ResultSetImpl.java
@@ -1504,6 +1504,7 @@ public class ResultSetImpl implements ResultSet, JdbcV2Wrapper {
                         case Polygon:
                         case MultiPolygon:
                         case MultiLineString:
+                        case Geometry:
                             break; // read as is
                         default:
                             if (typeMap == null || typeMap.isEmpty()) {

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/JdbcUtils.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/JdbcUtils.java
@@ -186,6 +186,9 @@ public class JdbcUtils {
                     case MultiPolygon:
                         map.put(e.getKey(), double[][][][].class);
                         break;
+                    case Geometry:
+                        map.put(e.getKey(), Object.class);
+                        break;
                     case UUID:
                         map.put(e.getKey(), UUID.class);
                         break;

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/JdbcUtils.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/JdbcUtils.java
@@ -186,14 +186,12 @@ public class JdbcUtils {
                     case MultiPolygon:
                         map.put(e.getKey(), double[][][][].class);
                         break;
-                    case Geometry:
-                        map.put(e.getKey(), Object.class);
-                        break;
                     case UUID:
                         map.put(e.getKey(), UUID.class);
                         break;
                     case IPv4:
                     case IPv6:
+                    case Geometry:
                         // should be mapped to Object because require conversion.
                     default:
                         map.put(e.getKey(), Object.class);

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/JdbcDataTypeTests.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/JdbcDataTypeTests.java
@@ -2577,6 +2577,91 @@ public class JdbcDataTypeTests extends JdbcIntegrationTest {
         }
     }
 
+    @Test(groups = { "integration" })
+    public void testGeoGeometryPreparedStatement() throws Exception {
+        if (earlierThan(25, 11)) {
+            return;
+        }
+
+        final Object[] expectedValues = new Object[] {
+                new double[] {1D, 2D},
+                new double[][] {{1D, 2D}, {3D, 4D}, {1D, 2D}},
+                new double[][][] {{{1D, 2D}, {3D, 4D}, {1D, 2D}}},
+                new double[][][][] {
+                        {{{1D, 2D}, {3D, 4D}, {1D, 2D}}},
+                        {{{5D, 6D}, {7D, 8D}, {5D, 6D}}}
+                }
+        };
+        final String table = "test_geo_geometry_ps";
+        Properties properties = new Properties();
+        properties.setProperty(ClientConfigProperties.serverSetting("allow_suspicious_variant_types"), "1");
+
+        try (Connection conn = getJdbcConnection(properties); Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("DROP TABLE IF EXISTS " + table);
+            stmt.executeUpdate("CREATE TABLE " + table + " (rowId Int32, geom Geometry) ENGINE = MergeTree ORDER BY ()");
+
+            try (PreparedStatement pstmt = conn.prepareStatement("INSERT INTO " + table + " VALUES (?, ?)")) {
+                for (int i = 0; i < expectedValues.length; i++) {
+                    pstmt.setInt(1, i);
+                    pstmt.setObject(2, createGeometryParameter(conn, expectedValues[i]));
+                    pstmt.addBatch();
+                }
+                assertEquals(pstmt.executeBatch().length, expectedValues.length);
+            }
+
+            try (ResultSet rs = stmt.executeQuery("SELECT * FROM " + table + " ORDER BY rowId")) {
+                int rowId = 0;
+                while (rs.next()) {
+                    assertEquals(rs.getInt("rowId"), rowId);
+                    assertFalse(rs.getString("geom").isEmpty());
+                    assertGeometryValue(rs.getObject("geom"), expectedValues[rowId]);
+                    assertGeometryValue(rs.getArray("geom").getArray(), expectedValues[rowId]);
+                    rowId++;
+                }
+
+                assertEquals(rowId, expectedValues.length);
+            }
+        }
+    }
+
+    private static Object createGeometryParameter(Connection conn, Object value) throws SQLException {
+        if (value instanceof double[]) {
+            return conn.createStruct("Tuple(Float32, Float32)", Arrays.stream((double[]) value).boxed().toArray(Double[]::new));
+        } else if (value instanceof double[][]) {
+            return conn.createArrayOf("Array(Point)", box2d((double[][]) value));
+        } else if (value instanceof double[][][]) {
+            return conn.createArrayOf("Array(Array(Point))", box3d((double[][][]) value));
+        } else if (value instanceof double[][][][]) {
+            return conn.createArrayOf("Array(Array(Array(Point)))", box4d((double[][][][]) value));
+        }
+
+        throw new SQLException("Unsupported geometry parameter type: " + value.getClass());
+    }
+
+    private static Double[][] box2d(double[][] value) {
+        Double[][] result = new Double[value.length][];
+        for (int i = 0; i < value.length; i++) {
+            result[i] = Arrays.stream(value[i]).boxed().toArray(Double[]::new);
+        }
+        return result;
+    }
+
+    private static Double[][][] box3d(double[][][] value) {
+        Double[][][] result = new Double[value.length][][];
+        for (int i = 0; i < value.length; i++) {
+            result[i] = box2d(value[i]);
+        }
+        return result;
+    }
+
+    private static Double[][][][] box4d(double[][][][] value) {
+        Double[][][][] result = new Double[value.length][][][];
+        for (int i = 0; i < value.length; i++) {
+            result[i] = box3d(value[i]);
+        }
+        return result;
+    }
+
     private static void assertGeometryValue(Object actual, Object expected) {
         Assert.assertNotNull(actual);
         Assert.assertTrue(actual.getClass().isArray(), "Geometry value should be returned as an array");

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/JdbcDataTypeTests.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/JdbcDataTypeTests.java
@@ -2523,6 +2523,86 @@ public class JdbcDataTypeTests extends JdbcIntegrationTest {
         }
     }
 
+    @Test(groups = { "integration" })
+    public void testGeoGeometry() throws Exception {
+        if (earlierThan(25, 11)) {
+            return;
+        }
+
+        final Object[] expectedValues = new Object[] {
+                new double[] {1D, 2D},
+                new double[][] {{1D, 2D}, {3D, 4D}, {1D, 2D}},
+                new double[][][] {{{1D, 2D}, {3D, 4D}, {1D, 2D}}},
+                new double[][][][] {
+                        {{{1D, 2D}, {3D, 4D}, {1D, 2D}}},
+                        {{{5D, 6D}, {7D, 8D}, {5D, 6D}}}
+                }
+        };
+        final String table = "test_geo_geometry";
+        Properties properties = new Properties();
+        properties.setProperty(ClientConfigProperties.serverSetting("allow_suspicious_variant_types"), "1");
+
+        try (Connection conn = getJdbcConnection(properties); Statement stmt = conn.createStatement()) {
+            stmt.executeUpdate("DROP TABLE IF EXISTS " + table);
+            stmt.executeUpdate("CREATE TABLE " + table + " (rowId Int32, geom Geometry) ENGINE = MergeTree ORDER BY ()");
+            stmt.executeUpdate("INSERT INTO " + table + " VALUES "
+                    + "(0, (1, 2)), "
+                    + "(1, [(1, 2), (3, 4), (1, 2)]), "
+                    + "(2, [[(1, 2), (3, 4), (1, 2)]]), "
+                    + "(3, [[[(1, 2), (3, 4), (1, 2)]], [[(5, 6), (7, 8), (5, 6)]]])");
+
+            try (ResultSet rs = stmt.executeQuery("SELECT * FROM " + table + " ORDER BY rowId")) {
+                final int geomColumn = 2;
+                ResultSetMetaData rsMd = rs.getMetaData();
+                assertEquals(rsMd.getColumnTypeName(geomColumn), ClickHouseDataType.Geometry.name());
+                assertEquals(rsMd.getColumnType(geomColumn), Types.ARRAY);
+
+                int rowId = 0;
+                while (rs.next()) {
+                    assertEquals(rs.getInt("rowId"), rowId);
+                    assertFalse(rs.getString("geom").isEmpty());
+
+                    Object asObject = rs.getObject(geomColumn);
+                    assertGeometryValue(asObject, expectedValues[rowId]);
+
+                    Array asArray = rs.getArray(geomColumn);
+                    assertGeometryValue(asArray.getArray(), expectedValues[rowId]);
+                    assertEquals(asArray.getBaseTypeName(), ClickHouseDataType.Geometry.name());
+                    assertEquals(asArray.getBaseType(), Types.ARRAY);
+                    rowId++;
+                }
+
+                assertEquals(rowId, expectedValues.length);
+            }
+        }
+    }
+
+    private static void assertGeometryValue(Object actual, Object expected) {
+        Assert.assertNotNull(actual);
+        Assert.assertTrue(actual.getClass().isArray(), "Geometry value should be returned as an array");
+        assertGeometryArrayEquals(actual, expected);
+    }
+
+    private static void assertGeometryArrayEquals(Object actual, Object expected) {
+        int actualLength = java.lang.reflect.Array.getLength(actual);
+        int expectedLength = java.lang.reflect.Array.getLength(expected);
+        assertEquals(actualLength, expectedLength);
+
+        for (int i = 0; i < expectedLength; i++) {
+            Object actualItem = java.lang.reflect.Array.get(actual, i);
+            Object expectedItem = java.lang.reflect.Array.get(expected, i);
+
+            if (expectedItem != null && expectedItem.getClass().isArray()) {
+                Assert.assertNotNull(actualItem);
+                Assert.assertTrue(actualItem.getClass().isArray(),
+                        "Expected nested array but found: " + actualItem.getClass());
+                assertGeometryArrayEquals(actualItem, expectedItem);
+            } else {
+                assertEquals(((Number) actualItem).doubleValue(), ((Number) expectedItem).doubleValue());
+            }
+        }
+    }
+
     private static final HashMap<String, Object> EMPTY_JSON = new HashMap<>();
 
     @Test(groups = { "integration" }, dataProvider = "testJSONReadDP")


### PR DESCRIPTION
### Description 

ClickHouse supports many geometry types like Point, Ring, Polygon and others (https://clickhouse.com/docs/sql-reference/data-types/geo). There was an alias type `Geometry` that pointed to a `String` type. When this type is used it was replaced by `String`. This very well works with WKT functions (https://clickhouse.com/blog/state-of-geospatial-march-2026#ingesting-geospatial-data-via-wkt) that can parse different geometry notations. 

When `Variant` type was introduced it made possible to have better type alias so in `25.11` `Geometry` type became a real type not an alias. This doesn't break backward compatibility because `String` when table was created. However today cast to Geometry means different thing. 

`Variant` type of `Geometry` has a predefined list of types. Because of this we can pre-define column of such type and use it in serialization logic (client code uses `ClickHouseColumn` object to define how value should be serialized and deserialized).  Reading `Geometry` type is easy task because we client matches type ordinary number to java type. Here we should note that `Ring` and `LineString` are `Array(Point)` making them effectively same from data structure standpoint. Similar with `MultiLineString` and `Polygon` are defined as `Array(LineString)` and `Array(Ring)` respectively. This make type inference on a write operation complicated because task is to match array with specific nesting level to a type and use correct ordinary number. 

There should be a dedicated method to determine java array depth. Similar should exist for `List`. These only type client support to be written to geometry types. Because  we deal with limited number of array types it is more safe to use `instanceof Double[]` like statement instead of traversing whole array that can be quite big. In the future we will introduce some type hinting mechanism with annotations to make interface for type-safe. 

This PR:
- Adds new type to `ClickHouseDataType` enum 
- Adds `Geometry` `Variant` defined column to `ClickHouseColumn` and implement reading `Geometry` columns definitions.
- Adds method to determine array dimensions to `SerializationUtils` 
- Adds method to determine ordinary number of type for array or list of specific depth. 
- Adds tests for write and read. 

Closes: https://github.com/ClickHouse/clickhouse-java/issues/2678

 