### PR TITLE
added test to verify that session_timeout is working using temp tables

### DIFF
--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/ConnectionTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/ConnectionTest.java
@@ -1163,4 +1163,45 @@ public class ConnectionTest extends JdbcIntegrationTest {
             }
         }
     }
+
+    @Test(groups = {"integration"})
+    public void testSessionTimeout() throws Exception {
+        if (isCloud()) {
+            return; // HTTP sessions require server affinity
+        }
+
+        for (int timeout : new int[]{5, 10}) {
+            String sessionId = "test_session_" + UUID.randomUUID().toString();
+            Properties properties = new Properties();
+            properties.put(ClientConfigProperties.serverSetting("session_id"), sessionId);
+            properties.put(ClientConfigProperties.serverSetting("session_timeout"), String.valueOf(timeout));
+
+            // Create session and temp table
+            try (Connection conn = getJdbcConnection(properties)) {
+                try (Statement stmt = conn.createStatement()) {
+                    stmt.execute("CREATE TEMPORARY TABLE test_session_table_" + timeout + " (id Int32)");
+                    stmt.execute("INSERT INTO test_session_table_" + timeout + " VALUES (1)");
+
+                    try (ResultSet rs = stmt.executeQuery("SELECT * FROM test_session_table_" + timeout)) {
+                        Assert.assertTrue(rs.next());
+                        Assert.assertEquals(rs.getInt(1), 1);
+                    }
+                }
+            }
+
+            // Wait for session timeout
+            Thread.sleep((timeout + 2) * 1000L);
+
+            // Reconnect with same session_id and verify table is gone
+            try (Connection conn = getJdbcConnection(properties)) {
+                try (Statement stmt = conn.createStatement()) {
+                    try (ResultSet rs = stmt.executeQuery("SELECT * FROM test_session_table_" + timeout)) {
+                        fail("Table should not be accessible as session has timed out");
+                    } catch (SQLException e) {
+                        Assert.assertTrue(e.getMessage().contains("Unknown table") || e.getMessage().contains("does not exist"));
+                    }
+                }
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary
Added testSessionTimeout integration test to ConnectionTest.java in jdbc-v2 to verify the functionality of the Session API.
Validates session_timeout behavior by ensuring that temporary tables created within a session are properly cleared and no longer accessible once the specified session timeout period (e.g. 5 and 10 seconds) expires.
Addresses [Issue #1822](https://github.com/ClickHouse/clickhouse-java/issues/1822) by ensuring and testing that the session timeout parameters (session_id and session_timeout) function as expected with the new v2 client.

Closes https://github.com/ClickHouse/clickhouse-java/issues/1822
## Checklist
Delete items not relevant to your PR:
- [x] Closes #<issue ref>
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
