### PR TITLE
fixes inconsistency in max_execution_time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.9.9
+
+### Bug Fixes
+
+- **[client-v2]** Fixed inconsistent use of `executionTimeout` parameter in `Client` component. The timeout was previously set in milliseconds but mistakenly retrieved and used in seconds in some places. Now it correctly uses milliseconds consistently. (https://github.com/ClickHouse/clickhouse-java/issues/2358)
+
 ## 0.9.8
 
 ### Improvements 

--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -667,10 +667,12 @@ public class Client implements AutoCloseable {
         }
 
         /**
-         * Sets the maximum time for operation to complete. By default, it is set to 3 hours.
-         * @param timeout
-         * @param timeUnit
-         * @return
+         * Sets the maximum time for operation to complete. By default, it is unlimited.
+         * Value is saved in milliseconds always.
+         *
+         * @param timeout value of the timeout
+         * @param timeUnit time unit of the timeout value
+         * @return this instance
          */
         public Builder setExecutionTimeout(long timeout, ChronoUnit timeUnit) {
             this.configuration.put(ClientConfigProperties.MAX_EXECUTION_TIME.getKey(), String.valueOf(Duration.of(timeout, timeUnit).toMillis()));
@@ -1958,10 +1960,10 @@ public class Client implements AutoCloseable {
         QuerySettings settings = new QuerySettings().setDatabase(database);
         try (QueryResponse response = operationTimeout == 0
                 ? query(describeQuery, queryParams, settings).get()
-                : query(describeQuery, queryParams, settings).get(getOperationTimeout(), TimeUnit.SECONDS)) {
+                : query(describeQuery, queryParams, settings).get(operationTimeout, TimeUnit.MILLISECONDS)) {
             return TableSchemaParser.readTSKV(response.getInputStream(), name, originalQuery, database);
         } catch (TimeoutException e) {
-            throw new ClientException("Operation has likely timed out after " + getOperationTimeout() + " seconds.", e);
+            throw new ClientException("Operation has likely timed out after " + getOperationTimeout() + " milliseconds.", e);
         } catch (ExecutionException e) {
             throw new ClientException("Failed to get table schema", e.getCause());
         } catch (ServerException e) {
@@ -2118,7 +2120,10 @@ public class Client implements AutoCloseable {
         return readOnlyConfig;
     }
 
-    /** Returns operation timeout in seconds */
+    /**
+     * Returns operation ({@link ClientConfigProperties#MAX_EXECUTION_TIME}) timeout value in milliseconds.
+     * @return timeout value in milliseconds.
+     */
     protected int getOperationTimeout() {
         return ClientConfigProperties.MAX_EXECUTION_TIME.getOrDefault(configuration);
     }


### PR DESCRIPTION
## Summary
This PR fixes an inconsistency in how the executionTimeout parameter is handled in the client-v2 component, addressing [Issue #2358](https://github.com/ClickHouse/clickhouse-java/issues/2358).

Previously, the timeout was correctly saved in milliseconds by the builder, but was mistakenly retrieved and applied as seconds in getOperationTimeout() and Client.java's future get(...) methods. This caused operations to time out prematurely (or wait significantly longer than expected).

Changes:

Updated getOperationTimeout() to document and return the value correctly in milliseconds.
Updated CompletableFuture.get(...) calls to consistently use TimeUnit.MILLISECONDS instead of TimeUnit.SECONDS.
Updated exception messages to state the timeout accurately in milliseconds.

Closes https://github.com/ClickHouse/clickhouse-java/issues/2358
## Checklist
Delete items not relevant to your PR:
- [x] Closes #<issue ref>
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
