### PR TITLE
[jdbc-v2,client-v2] Fix queryTimeout() 

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/StatementImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/StatementImpl.java
@@ -174,7 +174,10 @@ public class StatementImpl implements Statement, JdbcV2Wrapper {
             if (queryTimeout == 0) {
                 response = connection.getClient().query(lastStatementSql, mergedSettings).get();
             } else {
-                response = connection.getClient().query(lastStatementSql, mergedSettings).get(queryTimeout, TimeUnit.SECONDS);
+                // we need to perform async operation to support timeout.
+                response = connection.getClient().query(lastStatementSql, mergedSettings
+                                .setOption(ClientConfigProperties.ASYNC_OPERATIONS.getKey(), true))
+                        .get(queryTimeout, TimeUnit.SECONDS);
             }
 
             if (response.getFormat().isText()) {

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/StatementImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/StatementImpl.java
@@ -249,7 +249,9 @@ public class StatementImpl implements Statement, JdbcV2Wrapper {
         LOG.trace("SQL Query: {}", lastStatementSql);
         int updateCount = 0;
         try (QueryResponse response = queryTimeout == 0 ? connection.getClient().query(lastStatementSql, mergedSettings).get()
-                : connection.getClient().query(lastStatementSql, mergedSettings).get(queryTimeout, TimeUnit.SECONDS)) {
+                : connection.getClient().query(lastStatementSql, mergedSettings
+                        .setOption(ClientConfigProperties.ASYNC_OPERATIONS.getKey(), true))
+                        .get(queryTimeout, TimeUnit.SECONDS)) {
             updateCount = Math.max(0, (int) response.getWrittenRows()); // when statement alters schema no result rows returned.
             lastQueryId = response.getQueryId();
         } catch (Exception e) {

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/PreparedStatementTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/PreparedStatementTest.java
@@ -570,9 +570,7 @@ public class PreparedStatementTest extends JdbcIntegrationTest {
     @Test(groups = {"integration"})
     void testExecuteQueryTimeout() throws Exception {
         final String sql = "SELECT sum(reinterpretAsUInt64(MD5(toString(number)))) FROM system.numbers LIMIT 1000000";
-        Properties config = new Properties();
-        config.setProperty(ClientConfigProperties.ASYNC_OPERATIONS.getKey(), "true");
-        try (Connection conn = getJdbcConnection(config);
+        try (Connection conn = getJdbcConnection();
              PreparedStatement stmt = conn.prepareStatement(sql)) {
             stmt.setQueryTimeout(1);
             assertThrows(SQLException.class, stmt::executeQuery);

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/PreparedStatementTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/PreparedStatementTest.java
@@ -1,5 +1,6 @@
 package com.clickhouse.jdbc;
 
+import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.client.api.DataTypeUtils;
 import com.clickhouse.data.ClickHouseColumn;
 import com.clickhouse.data.ClickHouseDataType;
@@ -563,6 +564,18 @@ public class PreparedStatementTest extends JdbcIntegrationTest {
                 count++;
             }
             assertEquals(10, count);
+        }
+    }
+
+    @Test(groups = {"integration"})
+    void testExecuteQueryTimeout() throws Exception {
+        final String sql = "SELECT sum(reinterpretAsUInt64(MD5(toString(number)))) FROM system.numbers LIMIT 1000000";
+        Properties config = new Properties();
+        config.setProperty(ClientConfigProperties.ASYNC_OPERATIONS.getKey(), "true");
+        try (Connection conn = getJdbcConnection(config);
+             PreparedStatement stmt = conn.prepareStatement(sql)) {
+            stmt.setQueryTimeout(1);
+            assertThrows(SQLException.class, stmt::executeQuery);
         }
     }
 

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/StatementTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/StatementTest.java
@@ -1034,7 +1034,7 @@ public class StatementTest extends JdbcIntegrationTest {
         props.setProperty(ClientConfigProperties.HTTP_MAX_OPEN_CONNECTIONS.getKey(), "1");
         props.setProperty(ClientConfigProperties.CONNECTION_REQUEST_TIMEOUT.getKey(), "500");
         try (Connection conn = getJdbcConnection(props); Statement stmt = conn.createStatement()) {
-            stmt.setQueryTimeout(1);
+            stmt.setQueryTimeout(10);
             ResultSet rs = stmt.executeQuery("SELECT 1");
             boolean failedOnTimeout = false;
             try {


### PR DESCRIPTION
## Summary
- Requests Async operation when query timeout is set
- Adds test to verify that timeout is working 

Closes https://github.com/ClickHouse/clickhouse-java/issues/2637
## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
