### PR TITLE
[repo] Fix slow init/teardown in cloud tests 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -278,6 +278,7 @@ jobs:
           CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT_PROD }}
           CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT_PROD }}
           CLIENT_JWT: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_JWT_DESERT_VM_43 }}
+          JWT_TEST_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
         run: |
           mvn --batch-mode --no-transfer-progress --projects ${{ matrix.project }} -DclickhouseVersion=${{ matrix.clickhouse }} -Dprotocol=http -Dmaven.javadoc.skip=true verify
       - name: Upload test results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -267,16 +267,16 @@ jobs:
 
       - name: Create Temporary Database
         env:
-          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
-          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
+          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT_PROD }}
+          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT_PROD }}
         run: |
           echo "::add-mask::$CLICKHOUSE_CLOUD_HOST"
           echo "Creating database: $TEST_DB_NAME"
           curl -s -u "default:$CLICKHOUSE_CLOUD_PASSWORD" "https://$CLICKHOUSE_CLOUD_HOST:8443" --data-binary "CREATE DATABASE IF NOT EXISTS $TEST_DB_NAME"
       - name: Test http client
         env:
-          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
-          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
+          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT_PROD }}
+          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT_PROD }}
           CLIENT_JWT: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_JWT_DESERT_VM_43 }}
         run: |
           mvn --batch-mode --no-transfer-progress --projects ${{ matrix.project }} -DclickhouseVersion=${{ matrix.clickhouse }} -Dprotocol=http -Dmaven.javadoc.skip=true verify
@@ -291,8 +291,8 @@ jobs:
       - name: Cleanup Database Unconditionally
         if: always() # CRITICAL: This ensures the step runs regardless of previous success/failure
         env:
-          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
-          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
+          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT_PROD }}
+          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT_PROD }}
         run: |
           echo "::add-mask::$CLICKHOUSE_CLOUD_HOST"
           # Verify we actually generated a DB name to avoid dropping something accidentally 
@@ -352,9 +352,6 @@ jobs:
       - name: Install Java client
         run: mvn --also-make --batch-mode --no-transfer-progress --projects clickhouse-http-client,client-v2 -DskipTests=true -Dmaven.javadoc.skip=true install
       - name: Test JDBC driver
-        env:
-          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
-          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
         run: |
           mvn --batch-mode --no-transfer-progress --projects clickhouse-jdbc,jdbc-v2 -DclickhouseVersion=${{ matrix.clickhouse }} -Dprotocol=${{ matrix.protocol }} -Dmaven.javadoc.skip=true verify
       - name: Upload test results

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -297,12 +297,12 @@ jobs:
           echo "::add-mask::$CLICKHOUSE_CLOUD_HOST"
           # Verify we actually generated a DB name to avoid dropping something accidentally 
           if [ -n "$TEST_DB_NAME" ]; then
-            echo "Cleaning up database: $TEST_DB_NAME"
-#            curl -s -u "default:$CLICKHOUSE_CLOUD_PASSWORD" "https://$CLICKHOUSE_CLOUD_HOST:8443" --data-binary "DROP DATABASE IF EXISTS $TEST_DB_NAME"
-            curl -s -u "default:$CLICKHOUSE_CLOUD_PASSWORD" "https://$CLICKHOUSE_CLOUD_HOST:8443" --data-binary "SELECT '$TEST_DB_NAME'"
+            echo "Cleaning up database: $TEST_DB_NAME";
+            curl -s -u "default:$CLICKHOUSE_CLOUD_PASSWORD" "https://$CLICKHOUSE_CLOUD_HOST:8443" --data-binary "SELECT '$TEST_DB_NAME'";
           else
-            echo "No database name was generated; skipping cleanup."
-          fi
+            echo "No database name was generated; skipping cleanup.";
+          fi;
+
   test-jdbc-driver:
     runs-on: ubuntu-latest
     needs: test-java-client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,6 +256,23 @@ jobs:
           EOF
       - name: Install Java client
         run: mvn --also-make --batch-mode --no-transfer-progress -DskipTests=true -Dmaven.javadoc.skip=true install
+      - name: Generate Database Name
+        run: |
+          # Combine the GitHub Run ID and a random number to guarantee uniqueness
+          RANDOM_DB="clickhouse_java_test_${GITHUB_RUN_ID}_${RANDOM}"
+          
+          # Write it to GITHUB_ENV so future steps can access it as $DB_NAME
+          echo "TEST_DB_NAME=$RANDOM_DB" >> $GITHUB_ENV
+          echo "Generated database name: $RANDOM_DB"
+
+      - name: Create Temporary Database
+        env:
+          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
+          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
+        run: |
+          echo "::add-mask::$CLICKHOUSE_CLOUD_HOST"
+          echo "Creating database: $TEST_DB_NAME"
+          curl -s -u "default:$CLICKHOUSE_CLOUD_PASSWORD" "https://$CLICKHOUSE_CLOUD_HOST:8443" --data-binary "CREATE DATABASE IF NOT EXISTS $TEST_DB_NAME"
       - name: Test http client
         env:
           CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
@@ -271,7 +288,21 @@ jobs:
           path: |
             **/target/failsafe-reports
             **/target/surefire-reports
-
+      - name: Cleanup Database Unconditionally
+        if: always() # CRITICAL: This ensures the step runs regardless of previous success/failure
+        env:
+          CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
+          CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
+        run: |
+          echo "::add-mask::$CLICKHOUSE_CLOUD_HOST"
+          # Verify we actually generated a DB name to avoid dropping something accidentally 
+          if [ -n "$TEST_DB_NAME" ]; then
+            echo "Cleaning up database: $TEST_DB_NAME"
+#            curl -s -u "default:$CLICKHOUSE_CLOUD_PASSWORD" "https://$CLICKHOUSE_CLOUD_HOST:8443" --data-binary "DROP DATABASE IF EXISTS $TEST_DB_NAME"
+            curl -s -u "default:$CLICKHOUSE_CLOUD_PASSWORD" "https://$CLICKHOUSE_CLOUD_HOST:8443" --data-binary "SELECT '$TEST_DB_NAME'"
+          else
+            echo "No database name was generated; skipping cleanup."
+          fi
   test-jdbc-driver:
     runs-on: ubuntu-latest
     needs: test-java-client

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -258,20 +258,16 @@ jobs:
         run: mvn --also-make --batch-mode --no-transfer-progress -DskipTests=true -Dmaven.javadoc.skip=true install
       - name: Generate Database Name
         run: |
-          # Combine the GitHub Run ID and a random number to guarantee uniqueness
           RANDOM_DB="clickhouse_java_test_${GITHUB_RUN_ID}_${RANDOM}"
-          
-          # Write it to GITHUB_ENV so future steps can access it as $DB_NAME
           echo "TEST_DB_NAME=$RANDOM_DB" >> $GITHUB_ENV
           echo "Generated database name: $RANDOM_DB"
-
       - name: Create Temporary Database
         env:
           CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT_PROD }}
           CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT_PROD }}
         run: |
           echo "Creating database: \`$TEST_DB_NAME\`"
-          curl -s -u "default:$CLICKHOUSE_CLOUD_PASSWORD" "https://$CLICKHOUSE_CLOUD_HOST:8443" --data-binary "CREATE DATABASE IF NOT EXISTS $TEST_DB_NAME"
+          curl --fail-with-body -s -u "default:$CLICKHOUSE_CLOUD_PASSWORD" "https://$CLICKHOUSE_CLOUD_HOST:8443" --data-binary "CREATE DATABASE IF NOT EXISTS $TEST_DB_NAME"
       - name: Test http client
         env:
           CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT_PROD }}
@@ -298,7 +294,7 @@ jobs:
           if [ -n "$TEST_DB_NAME" ]; then
             DROP_STMT="DROP DATABASE IF EXISTS \`$TEST_DB_NAME\`" 
             echo "Cleaning up database: \`$TEST_DB_NAME\` with statement '$DROP_STMT'";
-            curl -s -u "default:$CLICKHOUSE_CLOUD_PASSWORD" "https://$CLICKHOUSE_CLOUD_HOST:8443" --data-binary "$DROP_STMT";
+            curl --fail-with-body -s -u "default:$CLICKHOUSE_CLOUD_PASSWORD" "https://$CLICKHOUSE_CLOUD_HOST:8443" --data-binary "$DROP_STMT";
           else
             echo "No database name was generated; skipping cleanup.";
           fi;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -295,11 +295,10 @@ jobs:
           CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT_PROD }}
           CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT_PROD }}
         run: |
-          echo "::add-mask::$CLICKHOUSE_CLOUD_HOST"
           # Verify we actually generated a DB name to avoid dropping something accidentally 
           if [ -n "$TEST_DB_NAME" ]; then
             echo "Cleaning up database: $TEST_DB_NAME";
-            curl -s -u "default:$CLICKHOUSE_CLOUD_PASSWORD" "https://$CLICKHOUSE_CLOUD_HOST:8443" --data-binary "SELECT '$TEST_DB_NAME'";
+            curl -s -u "default:$CLICKHOUSE_CLOUD_PASSWORD" "https://$CLICKHOUSE_CLOUD_HOST:8443" --data-binary "DROP DATABASE IF EXISTS '$TEST_DB_NAME'";
           else
             echo "No database name was generated; skipping cleanup.";
           fi;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -298,7 +298,7 @@ jobs:
           # Verify we actually generated a DB name to avoid dropping something accidentally 
           if [ -n "$TEST_DB_NAME" ]; then
             echo "Cleaning up database: $TEST_DB_NAME";
-            curl -s -u "default:$CLICKHOUSE_CLOUD_PASSWORD" "https://$CLICKHOUSE_CLOUD_HOST:8443" --data-binary "DROP DATABASE IF EXISTS '$TEST_DB_NAME'";
+            curl -s -u "default:$CLICKHOUSE_CLOUD_PASSWORD" "https://$CLICKHOUSE_CLOUD_HOST:8443" --data-binary "DROP DATABASE `$TEST_DB_NAME`";
           else
             echo "No database name was generated; skipping cleanup.";
           fi;

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,8 +270,7 @@ jobs:
           CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT_PROD }}
           CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT_PROD }}
         run: |
-          echo "::add-mask::$CLICKHOUSE_CLOUD_HOST"
-          echo "Creating database: $TEST_DB_NAME"
+          echo "Creating database: \`$TEST_DB_NAME\`"
           curl -s -u "default:$CLICKHOUSE_CLOUD_PASSWORD" "https://$CLICKHOUSE_CLOUD_HOST:8443" --data-binary "CREATE DATABASE IF NOT EXISTS $TEST_DB_NAME"
       - name: Test http client
         env:
@@ -297,8 +296,9 @@ jobs:
         run: |
           # Verify we actually generated a DB name to avoid dropping something accidentally 
           if [ -n "$TEST_DB_NAME" ]; then
-            echo "Cleaning up database: $TEST_DB_NAME";
-            curl -s -u "default:$CLICKHOUSE_CLOUD_PASSWORD" "https://$CLICKHOUSE_CLOUD_HOST:8443" --data-binary "DROP DATABASE `$TEST_DB_NAME`";
+            DROP_STMT="DROP DATABASE IF EXISTS \`$TEST_DB_NAME\`" 
+            echo "Cleaning up database: \`$TEST_DB_NAME\` with statement '$DROP_STMT'";
+            curl -s -u "default:$CLICKHOUSE_CLOUD_PASSWORD" "https://$CLICKHOUSE_CLOUD_HOST:8443" --data-binary "$DROP_STMT";
           else
             echo "No database name was generated; skipping cleanup.";
           fi;

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseServerForTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseServerForTest.java
@@ -406,7 +406,6 @@ public class ClickHouseServerForTest {
             try {
                 URL serverURL = new URL(uri);
                 LOGGER.info("sending request to {} (uri={})", serverURL, uri);
-                sql = "SELECT 1";
                 byte[] postData = sql.getBytes(StandardCharsets.UTF_8);
                 for (int attempts = 0; attempts < 10; attempts++) {
                     HttpURLConnection httpConn = (HttpURLConnection) serverURL.openConnection();

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseServerForTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseServerForTest.java
@@ -68,6 +68,9 @@ public class ClickHouseServerForTest {
         properties = new Properties(System.getProperties());
         String externalDatabase = System.getenv("TEST_DB_NAME"); // see build.yaml workflow
         if (externalDatabase != null && !externalDatabase.trim().isEmpty()) {
+            if (!externalDatabase.startsWith("clickhouse_java_test_")) {
+                throw new RuntimeException("external database for tests should start with 'clickhouse_java_test_'");
+            }
             localDatabase = false;
             database = externalDatabase;
         } else {

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseServerForTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseServerForTest.java
@@ -8,6 +8,7 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.shaded.org.checkerframework.checker.units.qual.A;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
 
@@ -22,6 +23,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
 
@@ -62,6 +64,8 @@ public class ClickHouseServerForTest {
     private static boolean isCloud = false;
 
     private static final String database;
+    private static final AtomicBoolean databaseCreatedCloud = new AtomicBoolean(false);
+    private static final AtomicBoolean databaseDroppedCloud = new AtomicBoolean(false);
 
     static {
         properties = new Properties(System.getProperties());
@@ -320,10 +324,15 @@ public class ClickHouseServerForTest {
     @BeforeSuite(groups = {"integration"})
     public static void beforeSuite() {
         if (isCloud) {
-            if (!runQuery("CREATE DATABASE IF NOT EXISTS " + database)) {
-                throw new RuntimeException("Failed to create database for testing.");
-            }
+            synchronized (databaseCreatedCloud) {
+                if (!databaseCreatedCloud.get()) {
+                    if (!runQuery("CREATE DATABASE IF NOT EXISTS " + database)) {
+                        throw new RuntimeException("Failed to create database for testing.");
+                    }
 
+                    databaseCreatedCloud.set(true);
+                }
+            }
             return;
         }
 
@@ -358,8 +367,14 @@ public class ClickHouseServerForTest {
         }
 
         if (isCloud) {
-            if (!runQuery("DROP DATABASE IF EXISTS `" + database + "`")) {
-                LOGGER.warn("Failed to drop database for testing.");
+            synchronized (databaseDroppedCloud) {
+                if (!databaseDroppedCloud.get()) {
+                    if (!runQuery("DROP DATABASE IF EXISTS `" + database + "`")) {
+                        LOGGER.warn("Failed to drop database for testing.");
+                    }
+
+                    databaseDroppedCloud.set(true);
+                }
             }
         }
     }
@@ -391,16 +406,18 @@ public class ClickHouseServerForTest {
             try {
                 URL serverURL = new URL(uri);
                 LOGGER.info("sending request to {} (uri={})", serverURL, uri);
-
+                sql = "SELECT 1";
+                byte[] postData = sql.getBytes(StandardCharsets.UTF_8);
                 for (int attempts = 0; attempts < 10; attempts++) {
                     HttpURLConnection httpConn = (HttpURLConnection) serverURL.openConnection();
                     try {
                         httpConn.setRequestMethod("POST");
                         httpConn.setDoOutput(true);
                         httpConn.setRequestProperty("Authorization", "Basic " + Base64.getEncoder().encodeToString(("default:" + getPassword()).getBytes()));
+                        httpConn.setFixedLengthStreamingMode(postData.length);
 
                         try (OutputStream out = httpConn.getOutputStream()) {
-                            out.write(sql.getBytes(StandardCharsets.UTF_8));
+                            out.write(postData, 0, postData.length);
                             out.flush();
                         }
 

--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseServerForTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClickHouseServerForTest.java
@@ -8,7 +8,6 @@ import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.images.builder.ImageFromDockerfile;
-import org.testcontainers.shaded.org.checkerframework.checker.units.qual.A;
 import org.testng.annotations.AfterSuite;
 import org.testng.annotations.BeforeSuite;
 
@@ -23,7 +22,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
-import java.util.concurrent.atomic.AtomicBoolean;
 
 import static java.time.temporal.ChronoUnit.SECONDS;
 
@@ -64,12 +62,20 @@ public class ClickHouseServerForTest {
     private static boolean isCloud = false;
 
     private static final String database;
-    private static final AtomicBoolean databaseCreatedCloud = new AtomicBoolean(false);
-    private static final AtomicBoolean databaseDroppedCloud = new AtomicBoolean(false);
+    private static final boolean localDatabase;
 
     static {
         properties = new Properties(System.getProperties());
-        database = "clickhouse_java_" + UUID.randomUUID().toString().substring(0, 8) + "_test_" + System.currentTimeMillis();
+        String externalDatabase = System.getenv("TEST_DB_NAME"); // see build.yaml workflow
+        if (externalDatabase != null && !externalDatabase.trim().isEmpty()) {
+            localDatabase = false;
+            database = externalDatabase;
+        } else {
+            localDatabase = true;
+            database = "clickhouse_java_" + UUID.randomUUID().toString().substring(0, 8) + "_test_" + System.currentTimeMillis();
+        }
+
+        LOGGER.info("Local database: {}", localDatabase);
 
         String proxy = properties.getProperty("proxyAddress");
         if (proxy != null && !proxy.isEmpty()) { // use external proxy
@@ -324,13 +330,9 @@ public class ClickHouseServerForTest {
     @BeforeSuite(groups = {"integration"})
     public static void beforeSuite() {
         if (isCloud) {
-            synchronized (databaseCreatedCloud) {
-                if (!databaseCreatedCloud.get()) {
-                    if (!runQuery("CREATE DATABASE IF NOT EXISTS " + database)) {
-                        throw new RuntimeException("Failed to create database for testing.");
-                    }
-
-                    databaseCreatedCloud.set(true);
+            if (localDatabase) {
+                if (!runQuery("CREATE DATABASE IF NOT EXISTS " + database)) {
+                    throw new RuntimeException("Failed to create database for testing.");
                 }
             }
             return;
@@ -367,13 +369,9 @@ public class ClickHouseServerForTest {
         }
 
         if (isCloud) {
-            synchronized (databaseDroppedCloud) {
-                if (!databaseDroppedCloud.get()) {
-                    if (!runQuery("DROP DATABASE IF EXISTS `" + database + "`")) {
-                        LOGGER.warn("Failed to drop database for testing.");
-                    }
-
-                    databaseDroppedCloud.set(true);
+            if (localDatabase) {
+                if (!runQuery("DROP DATABASE IF EXISTS `" + database + "`")) {
+                    LOGGER.warn("Failed to drop database for testing.");
                 }
             }
         }

--- a/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
@@ -1220,7 +1220,8 @@ public class HttpTransportTests extends BaseIntegrationTest {
         }
         final String jwt = System.getenv("CLIENT_JWT");
         final String host = System.getenv("JWT_TEST_HOST");
-        Assert.assertTrue(jwt != null && !jwt.trim().isEmpty(), "JWT is missing");
+        Assert.assertTrue(jwt != null && !jwt.trim().isEmpty(), "CLIENT_JWT is not set.");
+        Assert.assertTrue(host != null && !host.trim().isEmpty(), "JWT_TEST_HOST is not set");
         Assert.assertFalse(jwt.contains("\n") || jwt.contains("-----"), "JWT should be single string ready for HTTP header");
         try (Client client = new Client.Builder()
                 .addEndpoint(Protocol.HTTP, host, 8443, true)

--- a/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
@@ -1218,10 +1218,17 @@ public class HttpTransportTests extends BaseIntegrationTest {
         if (!isCloud()) {
             return; // only for cloud
         }
-        String jwt = System.getenv("CLIENT_JWT");
+        final String jwt = System.getenv("CLIENT_JWT");
+        final String host = System.getenv("JWT_TEST_HOST");
         Assert.assertTrue(jwt != null && !jwt.trim().isEmpty(), "JWT is missing");
         Assert.assertFalse(jwt.contains("\n") || jwt.contains("-----"), "JWT should be single string ready for HTTP header");
-        try (Client client = newClient().useBearerTokenAuth(jwt).build()) {
+        try (Client client = new Client.Builder()
+                .addEndpoint(Protocol.HTTP, host, 8443, true)
+                .setUsername("default")
+                .compressClientRequest(false)
+                .setDefaultDatabase("default")
+                .serverSetting(ServerSettings.WAIT_END_OF_QUERY, "1")
+                .useBearerTokenAuth(jwt).build()) {
             try {
                 List<GenericRecord> response = client.queryAll("SELECT user(), now()");
                 System.out.println("response: " + response.get(0).getString(1) + " time: " + response.get(0).getString(2));


### PR DESCRIPTION
## Summary

Each test suite tries to create a database. Database name is shared among all tests suites in the project. When run on the cloud it significantly slows down test execution. 
This PR adds two flags to avoid extra queries. 

Server output when creating database: 

```
Code: 159. DB::Exception: Distributed DDL task /clickhouse/task_queue/ddl/query-0000221183 is not finished on 2 of 11 hosts (0 of them are currently executing the task, 0 are inactive). They are going to execute the query in background. Was waiting for 180.544706546 seconds, which is longer than distributed_ddl_task_timeout. (TIMEOUT_EXCEEDED) (version 26.2.1.324 (official build))

```


## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
