### PR TITLE
ci: declare workflow-level `contents: read` on 3 workflows

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,6 +15,9 @@ env:
   # CHC_VERSION: "0.9.0"
   CH_VERSION: "25.3"
 
+permissions:
+  contents: read
+
 jobs:
   nightly:
     if: ${{ startsWith(github.repository, 'ClickHouse/') }}

--- a/.github/workflows/run_examples.yml
+++ b/.github/workflows/run_examples.yml
@@ -22,6 +22,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && github.event.number || github.sha }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
 
 jobs:
   run-examples-with-8-jdk-and-latest:

--- a/.github/workflows/test_head.yml
+++ b/.github/workflows/test_head.yml
@@ -19,6 +19,9 @@ concurrency:
 env:
   CH_VERSION: "head"
 
+permissions:
+  contents: read
+
 jobs:
   test-java-client:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on 3 workflows in `.github/workflows/` that don't call a GitHub API beyond the initial checkout.

The following files were left implicit because they reference `GITHUB_TOKEN` / use a write-scope action / trigger on `pull_request_target`. Those scopes are best declared by maintainers: `build.yml`.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs. Pinning per workflow caps runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.