### PR TITLE
jdbc-v2: update keywords and engines in JDBC

### DIFF
--- a/.cursor/skills/update-keyword-engine-lists/SKILL.md
+++ b/.cursor/skills/update-keyword-engine-lists/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: update-keyword-engine-lists
+description: Update ALLOWED_KEYWORD_ALIASES in ClickHouseSqlUtils.java and ENGINE_TO_TABLE_TYPE in DatabaseMetaDataImpl.java from failing test output. Use when StatementSQLTest.testAllowedKeywordAliasesMatchSystemKeywords or DatabaseMetaDataTest.testAllTableEnginesFromSystemTableEnginesAreMapped fails.
+---
+
+# Update keyword and engine lists from test failures
+
+## Files
+
+**Keywords:**
+`jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/parser/javacc/ClickHouseSqlUtils.java`
+— `initAllowedKeywordAliases()`, append after the last `// Appended` comment block.
+
+**Engines:**
+`jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java`
+— `ENGINE_TO_TABLE_TYPE` static block, insert a new group before `// Special`.
+
+## Steps
+
+1. Parse the failing test message to extract the list of missing items.
+
+2. **For keywords** (`StatementSQLTest` failure — e.g. `["CURSOR", "DETERMINISTIC", ...]`):
+   Append a new dated comment + entries at the end of `buildKeywordSet(...)`, after the last existing `// Appended` block:
+   ```java
+   // Appended MM/DD/YYYY
+   "KEYWORD1", "KEYWORD2", ...
+   ```
+   The previous entry must have a trailing comma. Keep alphabetical order within the new block.
+
+3. **For engines** (`DatabaseMetaDataTest` failure — e.g. `[Paimon, PaimonAzure, ...]`):
+   Add a new named group before `// Special` in the static block:
+   ```java
+   // <GroupName> (appended MM/DD/YYYY)
+   map.put("Engine1", TableType.REMOTE_TABLE.getTypeName());
+   ```
+   Choose `TableType` by analogy:
+   - External storage (S3/Azure/HDFS variants, lake formats) → `REMOTE_TABLE`
+   - MergeTree family or local engines → `TABLE`
+
+## Output
+
+After editing, output this git commit command:
+
+```
+git commit -m "jdbc-v2: update <keywords|engines|keywords and engines> in JDBC"
+```

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/parser/javacc/ClickHouseSqlUtils.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/parser/javacc/ClickHouseSqlUtils.java
@@ -65,7 +65,9 @@ public final class ClickHouseSqlUtils {
                 "CENTURY", "DECADE", "DOW", "DOY", "EPOCH", "ISODOW", "ISOYEAR", "MILLENNIUM", "NATURAL", "SOME",
                 "ZONE",
                 // Appended 04/10/2026
-                "PATH", "PLACING"
+                "PATH", "PLACING",
+                // Appended 05/27/2026
+                "CURSOR", "DETERMINISTIC", "ESCAPE", "SAMPLES", "STREAM", "UNKNOWN"
             );
     }
 

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java
@@ -865,6 +865,13 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
         map.put("SharedSummingMergeTree", TableType.TABLE.getTypeName());
         map.put("SharedVersionedCollapsingMergeTree", TableType.TABLE.getTypeName());
 
+        // Paimon (appended 05/27/2026)
+        map.put("Paimon", TableType.REMOTE_TABLE.getTypeName());
+        map.put("PaimonAzure", TableType.REMOTE_TABLE.getTypeName());
+        map.put("PaimonHDFS", TableType.REMOTE_TABLE.getTypeName());
+        map.put("PaimonLocal", TableType.REMOTE_TABLE.getTypeName());
+        map.put("PaimonS3", TableType.REMOTE_TABLE.getTypeName());
+
         // Special
         map.put("TimeSeries", TableType.TABLE.getTypeName());
         map.put("Null", TableType.TABLE.getTypeName());


### PR DESCRIPTION
## Summary

- Updates keywords list
- Updates engine list 

Fixes tests against HEAD version of ClickHouse 

## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Static allowlists and metadata mappings only; no runtime behavior beyond parser keyword recognition and JDBC table type reporting.
> 
> **Overview**
> Keeps **jdbc-v2** in sync with newer ClickHouse server metadata by extending the SQL parser’s **allowed keyword aliases** and JDBC **engine → table type** map, plus a small Cursor skill for repeating the same maintenance when integration tests fail.
> 
> **`ClickHouseSqlUtils`** gains six aliases (`CURSOR`, `DETERMINISTIC`, `ESCAPE`, `SAMPLES`, `STREAM`, `UNKNOWN`) so `StatementSQLTest.testAllowedKeywordAliasesMatchSystemKeywords` matches `system.keywords`. **`DatabaseMetaDataImpl`** maps the Paimon engine family (`Paimon`, `PaimonAzure`, `PaimonHDFS`, `PaimonLocal`, `PaimonS3`) to **`REMOTE TABLE`**, aligning with other lake/external engines for `DatabaseMetaDataTest.testAllTableEnginesFromSystemTableEnginesAreMapped`. A new **`.cursor/skills/update-keyword-engine-lists`** skill documents how to append entries from failing test output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5eec56fc5b091fa3eb61b26d1aa2ca9379539998. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->