### PR TITLE
[jdbc-v2] Fix `Statement.cancel()` for query run with `session_id` parameters 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.10.9
+## 0.10.0
 
 ### Breaking Changes
 
@@ -38,6 +38,8 @@
 - **[jdbc-v2]** `ResultSet#getObject(int|String, Map<String, Class<?>>)` now accepts ClickHouse type names as map keys in addition to the JDBC `SQLType` names it has always accepted. Only unwrapped type names are used for the lookup — `Nullable(...)` and `LowCardinality(...)` wrappers are stripped and do not affect resolution, so a key like `"Int32"` matches both `Int32` and `Nullable(Int32)` columns; keys like `"Nullable(Int32)"` are not recognized. Lookup order is the `ClickHouseDataType` enum name (e.g. `"Int32"`, `"String"`, `"DateTime"`) then the JDBC `SQLType` name (e.g. `"INTEGER"`, `"VARCHAR"`, `"TIMESTAMP"`); a missing entry leaves the value uncoerced. The feature is supported for primitive ClickHouse types only — `Array`, `Tuple`, `Map`, `Nested`, and geometry types are not supported and continue to be returned in their native form regardless of the user-supplied map. Existing maps keyed only by JDBC `SQLType` names continue to work unchanged.
 
 ### Bug Fixes
+
+- **[jdbc-v2]** Fixed `Statement.cancel()` throwing `SESSION_IS_LOCKED` when the statement was running inside a ClickHouse session (e.g. via `clickhouse_setting_session_id`). The `KILL QUERY` request issued by `cancel()` now runs outside the session, so it no longer contends with the running query for the session lock. (https://github.com/ClickHouse/clickhouse-java/issues/2690)
 
 - **[client-v2]** Fixed inconsistent use of `executionTimeout` parameter in `Client` component. The timeout was previously set in milliseconds but mistakenly retrieved and used in seconds in some places. Now it correctly uses milliseconds consistently. (https://github.com/ClickHouse/clickhouse-java/issues/2358)
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/command/CommandSettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/command/CommandSettings.java
@@ -34,6 +34,7 @@ public class CommandSettings extends QuerySettings {
         return this;
     }
 
+    @Override
     public CommandSettings clearSession() {
         super.clearSession();
         return this;

--- a/client-v2/src/main/java/com/clickhouse/client/api/command/CommandSettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/command/CommandSettings.java
@@ -33,4 +33,9 @@ public class CommandSettings extends QuerySettings {
         super.use(session);
         return this;
     }
+
+    public CommandSettings clearSession() {
+        super.clearSession();
+        return this;
+    }
 }

--- a/client-v2/src/main/java/com/clickhouse/client/api/insert/InsertSettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/insert/InsertSettings.java
@@ -4,7 +4,6 @@ import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.client.api.Session;
 import com.clickhouse.client.api.internal.CommonSettings;
-import com.clickhouse.client.api.query.QuerySettings;
 import org.apache.hc.core5.http.HttpHeaders;
 
 import java.time.temporal.ChronoUnit;

--- a/client-v2/src/main/java/com/clickhouse/client/api/insert/InsertSettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/insert/InsertSettings.java
@@ -4,6 +4,7 @@ import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.client.api.Session;
 import com.clickhouse.client.api.internal.CommonSettings;
+import com.clickhouse.client.api.query.QuerySettings;
 import org.apache.hc.core5.http.HttpHeaders;
 
 import java.time.temporal.ChronoUnit;
@@ -142,6 +143,11 @@ public class InsertSettings {
 
     public InsertSettings use(Session session) {
         settings.use(session);
+        return this;
+    }
+
+    public InsertSettings clearSession() {
+        settings.clearSession();
         return this;
     }
 

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/CommonSettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/CommonSettings.java
@@ -143,7 +143,8 @@ public class CommonSettings {
         resetOption(ClientConfigProperties.serverSetting(ClickHouseHttpProto.QPARAM_SESSION_ID));
         resetOption(ClientConfigProperties.serverSetting(ClickHouseHttpProto.QPARAM_SESSION_CHECK));
         resetOption(ClientConfigProperties.serverSetting(ClickHouseHttpProto.QPARAM_SESSION_TIMEOUT));
-        resetOption(ClientConfigProperties.serverSetting(ClickHouseHttpProto.QPARAM_SESSION_TIMEZONE));
+        // Do not clean `session_timezone` setting because it is not related to session management and used to
+        // set timezone for consequent queries in some multi-user applications.
     }
 
     /**

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/CommonSettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/CommonSettings.java
@@ -143,6 +143,7 @@ public class CommonSettings {
         resetOption(ClientConfigProperties.serverSetting(ClickHouseHttpProto.QPARAM_SESSION_ID));
         resetOption(ClientConfigProperties.serverSetting(ClickHouseHttpProto.QPARAM_SESSION_CHECK));
         resetOption(ClientConfigProperties.serverSetting(ClickHouseHttpProto.QPARAM_SESSION_TIMEOUT));
+        resetOption(ClientConfigProperties.serverSetting(ClickHouseHttpProto.QPARAM_SESSION_TIMEZONE));
     }
 
     /**

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/CommonSettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/CommonSettings.java
@@ -139,6 +139,12 @@ public class CommonSettings {
         return this;
     }
 
+    public void clearSession() {
+        resetOption(ClientConfigProperties.serverSetting(ClickHouseHttpProto.QPARAM_SESSION_ID));
+        resetOption(ClientConfigProperties.serverSetting(ClickHouseHttpProto.QPARAM_SESSION_CHECK));
+        resetOption(ClientConfigProperties.serverSetting(ClickHouseHttpProto.QPARAM_SESSION_TIMEOUT));
+    }
+
     /**
      * Operation id. Used internally to register new operation.
      * Should not be called directly.

--- a/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/query/QuerySettings.java
@@ -139,6 +139,11 @@ public class QuerySettings {
         return this;
     }
 
+    public QuerySettings clearSession() {
+        settings.clearSession();
+        return this;
+    }
+
     /**
      * Read buffer is used for reading data from a server. Size is in bytes.
      * Minimal value is {@value MINIMAL_READ_BUFFER_SIZE} bytes.

--- a/client-v2/src/test/java/com/clickhouse/client/SettingsTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/SettingsTests.java
@@ -143,6 +143,30 @@ public class SettingsTests {
             Assert.assertEquals(settings.getSessionTimeout().intValue(), 45);
             Assert.assertEquals(settings.getSessionTimezone(), "Europe/Berlin");
         }
+
+        {
+            final QuerySettings settings = new QuerySettings();
+            settings.setSessionId("session-clear-1");
+            settings.setSessionCheck(true);
+            settings.setSessionTimeout(60);
+            settings.setSessionTimezone("America/New_York");
+            Assert.assertNotNull(settings.getSessionId());
+            Assert.assertNotNull(settings.getSessionCheck());
+            Assert.assertNotNull(settings.getSessionTimeout());
+            Assert.assertNotNull(settings.getSessionTimezone());
+
+            settings.clearSession();
+
+            Assert.assertNull(settings.getSessionId(), "clearSession() must remove session_id");
+            Assert.assertNull(settings.getSessionCheck(), "clearSession() must remove session_check");
+            Assert.assertNull(settings.getSessionTimeout(), "clearSession() must remove session_timeout");
+            Assert.assertNull(settings.getSessionTimezone(), "clearSession() must remove session_timezone");
+
+            // Non-session settings are unaffected.
+            settings.setDatabase("db1");
+            settings.clearSession();
+            Assert.assertEquals(settings.getDatabase(), "db1");
+        }
     }
 
     @Test
@@ -231,6 +255,30 @@ public class SettingsTests {
             Assert.assertFalse(settings.getSessionCheck());
             Assert.assertEquals(settings.getSessionTimeout().intValue(), 50);
             Assert.assertEquals(settings.getSessionTimezone(), "Europe/Paris");
+        }
+
+        {
+            final InsertSettings settings = new InsertSettings();
+            settings.setSessionId("session-clear-2");
+            settings.setSessionCheck(true);
+            settings.setSessionTimeout(90);
+            settings.setSessionTimezone("Asia/Tokyo");
+            Assert.assertNotNull(settings.getSessionId());
+            Assert.assertNotNull(settings.getSessionCheck());
+            Assert.assertNotNull(settings.getSessionTimeout());
+            Assert.assertNotNull(settings.getSessionTimezone());
+
+            settings.clearSession();
+
+            Assert.assertNull(settings.getSessionId(), "clearSession() must remove session_id");
+            Assert.assertNull(settings.getSessionCheck(), "clearSession() must remove session_check");
+            Assert.assertNull(settings.getSessionTimeout(), "clearSession() must remove session_timeout");
+            Assert.assertNull(settings.getSessionTimezone(), "clearSession() must remove session_timezone");
+
+            // Non-session settings are unaffected.
+            settings.setDatabase("db2");
+            settings.clearSession();
+            Assert.assertEquals(settings.getDatabase(), "db2");
         }
     }
 }

--- a/client-v2/src/test/java/com/clickhouse/client/SettingsTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/SettingsTests.java
@@ -160,7 +160,9 @@ public class SettingsTests {
             Assert.assertNull(settings.getSessionId(), "clearSession() must remove session_id");
             Assert.assertNull(settings.getSessionCheck(), "clearSession() must remove session_check");
             Assert.assertNull(settings.getSessionTimeout(), "clearSession() must remove session_timeout");
-            Assert.assertNull(settings.getSessionTimezone(), "clearSession() must remove session_timezone");
+            // session_timezone is not session-management state; it is preserved across clearSession().
+            Assert.assertEquals(settings.getSessionTimezone(), "America/New_York",
+                    "clearSession() must not remove session_timezone");
 
             // Non-session settings are unaffected.
             settings.setDatabase("db1");
@@ -273,7 +275,9 @@ public class SettingsTests {
             Assert.assertNull(settings.getSessionId(), "clearSession() must remove session_id");
             Assert.assertNull(settings.getSessionCheck(), "clearSession() must remove session_check");
             Assert.assertNull(settings.getSessionTimeout(), "clearSession() must remove session_timeout");
-            Assert.assertNull(settings.getSessionTimezone(), "clearSession() must remove session_timezone");
+            // session_timezone is not session-management state; it is preserved across clearSession().
+            Assert.assertEquals(settings.getSessionTimezone(), "Asia/Tokyo",
+                    "clearSession() must not remove session_timezone");
 
             // Non-session settings are unaffected.
             settings.setDatabase("db2");

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/StatementImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/StatementImpl.java
@@ -334,7 +334,7 @@ public class StatementImpl implements Statement, JdbcV2Wrapper {
             return;
         }
 
-        // KILL QUERY must not run inside the same session as the query being cancelled otherwise it wil
+        // KILL QUERY must not run inside the same session as the query being canceled otherwise it will
         // cause "Session is locked by a concurrent client" (SESSION_IS_LOCKED) error.
         QuerySettings cancelSettings = QuerySettings.merge(getLocalSettings(), new QuerySettings()).clearSession();
         try (QueryResponse response = connection.getClient().query(String.format("KILL QUERY%sWHERE query_id = '%s'",

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/StatementImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/StatementImpl.java
@@ -2,6 +2,7 @@ package com.clickhouse.jdbc;
 
 import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatReader;
+import com.clickhouse.client.api.http.ClickHouseHttpProto;
 import com.clickhouse.client.api.internal.ServerSettings;
 import com.clickhouse.client.api.query.QueryResponse;
 import com.clickhouse.client.api.query.QuerySettings;
@@ -333,9 +334,12 @@ public class StatementImpl implements Statement, JdbcV2Wrapper {
             return;
         }
 
+        // KILL QUERY must not run inside the same session as the query being cancelled otherwise it wil
+        // cause "Session is locked by a concurrent client" (SESSION_IS_LOCKED) error.
+        QuerySettings cancelSettings = QuerySettings.merge(getLocalSettings(), new QuerySettings()).clearSession();
         try (QueryResponse response = connection.getClient().query(String.format("KILL QUERY%sWHERE query_id = '%s'",
                 connection.onCluster ? " ON CLUSTER " + SQLUtils.enquoteIdentifier(connection.cluster, true) + ' ' : ' ',
-                lastQueryId), connection.getDefaultQuerySettings()).get()){
+                lastQueryId), cancelSettings).get()){
             LOG.debug("Query {} was killed by {}", lastQueryId, response.getQueryId());
         } catch (Exception e) {
             throw new SQLException(e);

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/StatementImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/StatementImpl.java
@@ -2,7 +2,6 @@ package com.clickhouse.jdbc;
 
 import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatReader;
-import com.clickhouse.client.api.http.ClickHouseHttpProto;
 import com.clickhouse.client.api.internal.ServerSettings;
 import com.clickhouse.client.api.query.QueryResponse;
 import com.clickhouse.client.api.query.QuerySettings;

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/StatementTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/StatementTest.java
@@ -9,7 +9,6 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -29,6 +28,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -706,6 +707,126 @@ public class StatementTest extends JdbcIntegrationTest {
 
                     latch.await();
                     stmt.cancel();
+                }
+            }
+        }
+    }
+
+    /**
+     * Waits until the given query id appears in {@code system.processes}, so we know the operation has actually
+     * started on the server before attempting to cancel it. Uses a dedicated connection (no session) to observe.
+     */
+    private boolean waitForQueryToStart(String queryId, int timeoutSeconds) throws Exception {
+        if (queryId == null) {
+            return false;
+        }
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(timeoutSeconds);
+        while (System.currentTimeMillis() < deadline) {
+            try (Connection conn = getJdbcConnection();
+                 Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT count() FROM system.processes WHERE query_id = '" + queryId + "'")) {
+
+                if (rs.next() && rs.getLong(1) > 0) {
+                    return true;
+                }
+            }
+            Thread.sleep(200);
+        }
+        return false;
+    }
+
+    private String waitForQueryId(StatementImpl stmt, int timeoutSeconds) throws Exception {
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(timeoutSeconds);
+        while (System.currentTimeMillis() < deadline) {
+            String queryId = stmt.getLastQueryId();
+            if (queryId != null && !queryId.isEmpty()) {
+                return queryId;
+            }
+            Thread.sleep(50);
+        }
+        return null;
+    }
+
+    @Test(groups = {"integration"})
+    public void testCancelQueryWithSession() throws Exception {
+        // Regression test for #2690: cancelling a query that runs inside a session must not fail with
+        // "Session is locked by a concurrent client" (SESSION_IS_LOCKED). The KILL QUERY request issued by
+        // cancel() must not carry the session id of the query being cancelled.
+        String sessionId = "test-session-" + UUID.randomUUID();
+        try (Connection conn = getJdbcConnection()) {
+            try (StatementImpl stmt = (StatementImpl) conn.createStatement()) {
+                stmt.getLocalSettings().setSessionId(sessionId);
+                stmt.setQueryTimeout(30); // safety net so a failed cancel cannot hang the test
+
+                final AtomicReference<Throwable> threadError = new AtomicReference<>();
+                final CountDownLatch started = new CountDownLatch(1);
+                Thread worker = new Thread(() -> {
+                    started.countDown();
+                    // Long-running query that only completes when killed.
+                    try (ResultSet rs = stmt.executeQuery("SELECT count() FROM system.numbers_mt")) {
+                        rs.next();
+                    } catch (Throwable t) {
+                        System.out.println("Error: " + t.getMessage());
+                        threadError.set(t);
+                    }
+                });
+                worker.start();
+                started.await();
+
+                String queryId = waitForQueryId(stmt, 15);
+                assertNotNull(queryId, "Query id was not assigned in time");
+                assertTrue(waitForQueryToStart(queryId, 15), "Query did not start on the server in time");
+
+                // Cancel from the main thread - must not throw SESSION_IS_LOCKED.
+                stmt.cancel();
+
+                worker.join(TimeUnit.SECONDS.toMillis(20));
+                assertFalse(worker.isAlive(), "Query was not cancelled and is still running");
+            }
+        }
+    }
+
+    @Test(groups = {"integration"})
+    public void testCancelInsertWithSession() throws Exception {
+        // Regression test for #2690 covering a long-running INSERT executed inside a session.
+        String tableName = getDatabase() + ".cancel_insert_with_session";
+        String sessionId = "test-session-" + UUID.randomUUID();
+        try (Connection conn = getJdbcConnection(Map.of(ASYNC_INSERT_SETTING_KEY, ServerSettings.OFF))) {
+            try (Statement setup = conn.createStatement()) {
+                setup.execute("DROP TABLE IF EXISTS " + tableName);
+                setup.execute("CREATE TABLE " + tableName + " (num UInt64) ENGINE = MergeTree ORDER BY ()");
+            }
+
+            try (StatementImpl stmt = (StatementImpl) conn.createStatement()) {
+                stmt.getLocalSettings().setSessionId(sessionId);
+                stmt.setQueryTimeout(30); // safety net so a failed cancel cannot hang the test
+
+                final AtomicReference<Throwable> threadError = new AtomicReference<>();
+                final CountDownLatch started = new CountDownLatch(1);
+                Thread worker = new Thread(() -> {
+                    started.countDown();
+                    // Long-running insert that only completes when killed.
+                    try {
+                        stmt.executeUpdate("INSERT INTO " + tableName + " SELECT number FROM system.numbers_mt");
+                    } catch (Throwable t) {
+                        threadError.set(t);
+                    }
+                });
+                worker.start();
+                started.await();
+
+                String queryId = waitForQueryId(stmt, 15);
+                assertNotNull(queryId, "Query id was not assigned in time");
+                assertTrue(waitForQueryToStart(queryId, 15), "Insert did not start on the server in time");
+
+                // Cancel from the main thread - must not throw SESSION_IS_LOCKED.
+                stmt.cancel();
+
+                worker.join(TimeUnit.SECONDS.toMillis(20));
+                assertFalse(worker.isAlive(), "Insert was not cancelled and is still running");
+            } finally {
+                try (Statement cleanup = conn.createStatement()) {
+                    cleanup.execute("DROP TABLE IF EXISTS " + tableName);
                 }
             }
         }

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/StatementTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/StatementTest.java
@@ -9,6 +9,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -749,6 +750,10 @@ public class StatementTest extends JdbcIntegrationTest {
 
     @Test(groups = {"integration"})
     public void testCancelQueryWithSession() throws Exception {
+        if (isCloud()) {
+            throw new SkipException("Cloud + HTTP doesn't work well. Enough to test locally");
+        }
+
         // Regression test for #2690: cancelling a query that runs inside a session must not fail with
         // "Session is locked by a concurrent client" (SESSION_IS_LOCKED). The KILL QUERY request issued by
         // cancel() must not carry the session id of the query being cancelled.
@@ -788,6 +793,9 @@ public class StatementTest extends JdbcIntegrationTest {
 
     @Test(groups = {"integration"})
     public void testCancelInsertWithSession() throws Exception {
+        if (isCloud()) {
+            throw new SkipException("Cloud + HTTP doesn't work well. Enough to test locally");
+        }
         // Regression test for #2690 covering a long-running INSERT executed inside a session.
         String tableName = getDatabase() + ".cancel_insert_with_session";
         String sessionId = "test-session-" + UUID.randomUUID();


### PR DESCRIPTION
## Summary

Initial problem is that JDBC driver uses `session_id` for all queries even control ones like in `cancel()` method. If session is set then `cancel()` causes server error `SESSION_IS_LOCKED` error. Correct way is to remove session settings from `KILL` query. 

Main changes in this PR are:
- new method `clearSession()` in QuerySettings and other operations. This method holds all session reset logic and removes session related settings like id, check, timeout. Timezone session is not removed because it can be used without session ID and used to set particular timezone for request.  
- fix in `StatementImpl.cancel()` that clones local settings and clear session. Then settings are used for `KILL` query. 

Closes https://github.com/ClickHouse/clickhouse-java/issues/2690
## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Targeted cancel-path change with new session-clear API and regression tests; no auth or data-path changes beyond control queries.
> 
> **Overview**
> Fixes **jdbc-v2** `Statement.cancel()` when the statement uses a ClickHouse session (`session_id` / `clickhouse_setting_session_id`): the internal `KILL QUERY` no longer inherits session settings, avoiding server error **SESSION_IS_LOCKED** (“Session is locked by a concurrent client”).
> 
> **client-v2** adds **`clearSession()`** on `CommonSettings` and fluent wrappers on `QuerySettings`, `InsertSettings`, and `CommandSettings`. It clears `session_id`, `session_check`, and `session_timeout` only; **`session_timezone` is left intact** so timezone can still apply without a session.
> 
> `StatementImpl.cancel()` merges statement-local settings into a copy and calls **`clearSession()`** before issuing `KILL QUERY` (including `ON CLUSTER` when configured).
> 
> Unit tests cover `clearSession()` behavior; integration tests cancel long-running **SELECT** and **INSERT** inside a session. **CHANGELOG** documents the fix under 0.10.0.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df1a53012ddf231f827a3d8971344b3e8494236e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->