### PR TITLE
Added verification test for error in OK response

### DIFF
--- a/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
@@ -14,6 +14,7 @@ import com.clickhouse.client.api.command.CommandSettings;
 import com.clickhouse.client.api.data_formats.ClickHouseBinaryFormatReader;
 import com.clickhouse.client.api.enums.Protocol;
 import com.clickhouse.client.api.enums.ProxyType;
+import com.clickhouse.client.api.http.ClickHouseHttpProto;
 import com.clickhouse.client.api.insert.InsertResponse;
 import com.clickhouse.client.api.insert.InsertSettings;
 import com.clickhouse.client.api.internal.DataTypeConverter;
@@ -2082,6 +2083,55 @@ public class HttpTransportTests extends BaseIntegrationTest {
         } finally {
             mockServer.stop();
         }
+    }
+
+    @Test(groups = {"integration"}, dataProvider = "testErrorWhenResponseIsOk_Dp")
+    public void testErrorWhenResponseIsOk(boolean hasMsg) throws Exception {
+        WireMockServer mockServer = new WireMockServer(WireMockConfiguration
+                .options().port(9090).notifier(new ConsoleNotifier(false)));
+        mockServer.start();
+
+        try (Client client = new Client.Builder().addEndpoint(Protocol.HTTP, "localhost", mockServer.port(), false)
+                .setUsername("default")
+                .setPassword(ClickHouseServerForTest.getPassword())
+                .build()) {
+
+            final String errorMsg = hasMsg ? "Code: 60. DB::Exception: Unknown table expression identifier" : "";
+            mockServer.addStubMapping(WireMock.post(WireMock.anyUrl())
+                    .willReturn(WireMock.aResponse()
+                            .withStatus(HttpStatus.SC_OK)
+                            .withHeader(ClickHouseHttpProto.HEADER_EXCEPTION_CODE, "60")
+                            .withBody(errorMsg))
+                    .build());
+
+
+            try (QueryResponse response = client.query("SELECT * FROM not_existing_table").get(1, TimeUnit.SECONDS)) {
+                Assert.fail("Expected exception");
+            } catch (Exception e) {
+                ServerException se = null;
+                if (e instanceof ServerException) {
+                    se = (ServerException) e;
+                } else if (e.getCause() instanceof ServerException) {
+                    se = (ServerException) e.getCause();
+                } else {
+                    Assert.fail("Unexpected exception type", e);
+                }
+
+                Assert.assertEquals(se.getCode(), 60);
+                if (hasMsg) {
+                    Assert.assertEquals(se.getMessage().substring(0, errorMsg.length()), errorMsg);
+                } else {
+                    Assert.assertTrue(se.getMessage().contains("<Unreadable error message>"), "Error message was " + se.getMessage());
+                }
+            }
+        } finally {
+            mockServer.stop();
+        }
+    }
+
+    @DataProvider
+    public static Object[][] testErrorWhenResponseIsOk_Dp() {
+        return new Object[][]{{true}, {false}};
     }
 
     protected Client.Builder newClient() {


### PR DESCRIPTION
## Summary

The problem in the issue points to the scenario when error can be in response with status 200 (SUCCESS). 
This PR adds verification tests that error still parsed and exception thrown.  

Closes: https://github.com/ClickHouse/clickhouse-java/issues/2867 
## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change in HttpTransportTests; no runtime behavior modified.
> 
> **Overview**
> Adds **integration coverage** for ClickHouse HTTP responses that return **200 OK** while still signaling a server error via `X-ClickHouse-Exception-Code`.
> 
> The new `testErrorWhenResponseIsOk` WireMock test stubs HTTP 200 with exception code `60` and asserts the v2 client throws `ServerException` with code 60. A data provider runs two cases: a normal error body is surfaced in the message, and an **empty body** yields the `<Unreadable error message>` placeholder. The test imports `ClickHouseHttpProto.HEADER_EXCEPTION_CODE` for the stub header name.
> 
> **No production/client logic changes**—tests only, tied to issue #2867.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90ce7ddd098b8191b7407b758d14914736b54ffc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->