### PR TITLE
jdbc-v2: update keywords in JDBC

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/parser/javacc/ClickHouseSqlUtils.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/parser/javacc/ClickHouseSqlUtils.java
@@ -67,7 +67,9 @@ public final class ClickHouseSqlUtils {
                 // Appended 04/10/2026
                 "PATH", "PLACING",
                 // Appended 05/27/2026
-                "CURSOR", "DETERMINISTIC", "ESCAPE", "SAMPLES", "STREAM", "UNKNOWN"
+                "CURSOR", "DETERMINISTIC", "ESCAPE", "SAMPLES", "STREAM", "UNKNOWN",
+                // Appended 06/10/2026
+                "IPV4_PREFIX_BITS", "IPV6_PREFIX_BITS", "TIMEZONE_HOUR", "TIMEZONE_MINUTE"
             );
     }
 


### PR DESCRIPTION
## Summary
- Updates list of keywords because tests on HEAD failed

## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single static keyword list update with no logic changes; low impact on parsing behavior beyond recognizing these tokens as valid aliases.
> 
> **Overview**
> Extends the JDBC SQL parser’s **allowed keyword alias** list in `ClickHouseSqlUtils` with four ClickHouse keywords: `IPV4_PREFIX_BITS`, `IPV6_PREFIX_BITS`, `TIMEZONE_HOUR`, and `TIMEZONE_MINUTE` (dated comment 06/10/2026).
> 
> This keeps the static set aligned with non-reserved entries from `system.keywords`, so alias parsing and the keyword-sync test on HEAD pass again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af000a6dd4d80aca2f3a3d174015a70eae8006dd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->