### PR TITLE
SSL Root Certificate Examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,8 @@ performance/jmh-simple-results.json
 *.csv
 *.sql
 *.json
+
+*.crt 
+*.key
+*.srl
+*.csr

--- a/client-v2/pom.xml
+++ b/client-v2/pom.xml
@@ -147,6 +147,18 @@
             <version>1.5.7-6</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.84</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>1.84</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/HttpAPIClientHelper.java
@@ -1,6 +1,5 @@
 package com.clickhouse.client.api.internal;
 
-import com.clickhouse.client.ClickHouseSslContextProvider;
 import com.clickhouse.client.api.ClickHouseException;
 import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.ClientConfigProperties;
@@ -14,6 +13,7 @@ import com.clickhouse.client.api.ServerException;
 import com.clickhouse.client.api.enums.ProxyType;
 import com.clickhouse.client.api.http.ClickHouseHttpProto;
 import com.clickhouse.client.api.transport.Endpoint;
+import com.clickhouse.client.config.ClickHouseDefaultSslContextProvider;
 import com.clickhouse.data.ClickHouseFormat;
 import net.jpountz.lz4.LZ4Factory;
 import org.apache.commons.compress.compressors.CompressorStreamFactory;
@@ -131,6 +131,8 @@ public class HttpAPIClientHelper {
 
     LZ4Factory lz4Factory;
 
+    private final ClickHouseDefaultSslContextProvider sslContextProvider = new ClickHouseDefaultSslContextProvider();
+
     public HttpAPIClientHelper(Map<String, Object> configuration, Object metricsRegistry, boolean initSslContext, LZ4Factory lz4Factory) {
         this.metricsRegistry = metricsRegistry;
         this.httpClient = createHttpClient(initSslContext, configuration);
@@ -163,8 +165,10 @@ public class HttpAPIClientHelper {
         } catch (NoSuchAlgorithmException e) {
             throw new ClientException("Failed to create default SSL context", e);
         }
-        ClickHouseSslContextProvider sslContextProvider = ClickHouseSslContextProvider.getProvider();
-        String trustStorePath = (String) configuration.get(ClientConfigProperties.SSL_TRUST_STORE.getKey());
+        final String trustStorePath = (String) configuration.get(ClientConfigProperties.SSL_TRUST_STORE.getKey());
+        final String caCertificate = (String) configuration.get(ClientConfigProperties.CA_CERTIFICATE.getKey());
+        final String sslCertificate = (String) configuration.get(ClientConfigProperties.SSL_CERTIFICATE.getKey());
+        final String sslKey = (String) configuration.get(ClientConfigProperties.SSL_KEY.getKey());
         if (trustStorePath != null) {
             try {
                 sslContext = sslContextProvider.getSslContextFromKeyStore(
@@ -175,16 +179,9 @@ public class HttpAPIClientHelper {
             } catch (SSLException e) {
                 throw new ClientMisconfigurationException("Failed to create SSL context from a keystore", e);
             }
-        } else if (configuration.get(ClientConfigProperties.CA_CERTIFICATE.getKey()) != null ||
-                configuration.get(ClientConfigProperties.SSL_CERTIFICATE.getKey()) != null ||
-                configuration.get(ClientConfigProperties.SSL_KEY.getKey()) != null) {
-
+        } else if (caCertificate != null || sslCertificate != null|| sslKey != null) {
             try {
-                sslContext = sslContextProvider.getSslContextFromCerts(
-                        (String) configuration.get(ClientConfigProperties.SSL_CERTIFICATE.getKey()),
-                        (String) configuration.get(ClientConfigProperties.SSL_KEY.getKey()),
-                        (String) configuration.get(ClientConfigProperties.CA_CERTIFICATE.getKey())
-                );
+                sslContext = sslContextProvider.getSslContextFromCerts(sslCertificate, sslKey, caCertificate);
             } catch (SSLException e) {
                 throw new ClientMisconfigurationException("Failed to create SSL context from certificates", e);
             }

--- a/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
@@ -38,6 +38,20 @@ import org.apache.hc.core5.http.ConnectionRequestTimeoutException;
 import org.apache.hc.core5.http.HttpHeaders;
 import org.apache.hc.core5.http.HttpStatus;
 import org.apache.hc.core5.net.URIBuilder;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
 import org.testcontainers.utility.ThrowingFunction;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -45,14 +59,29 @@ import org.testng.annotations.Test;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.StringWriter;
+import java.math.BigInteger;
 import java.net.InetAddress;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.cert.Certificate;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Date;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -2144,5 +2173,184 @@ public class HttpTransportTests extends BaseIntegrationTest {
                 .compressClientRequest(false)
                 .setDefaultDatabase(ClickHouseServerForTest.getDatabase())
                 .serverSetting(ServerSettings.WAIT_END_OF_QUERY, "1");
+    }
+
+    private static final String BC_PROVIDER = BouncyCastleProvider.PROVIDER_NAME;
+
+    static {
+        if (Security.getProvider(BC_PROVIDER) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    @DataProvider(name = "testCustomCaCertificateProvider")
+    public static Object[][] testCustomCaCertificateProvider() {
+        return new Object[][]{
+                // TODO: decide if we need to support certificates via string {true},
+                {false}};
+    }
+
+    /**
+     * End-to-end verification that a client configured with only a custom root CA certificate
+     * ({@link Client.Builder#setRootCertificate(String)}, no trust store involved) can establish a validated TLS
+     * connection to a server whose certificate is signed by that CA, and successfully perform operations over it.
+     * The certificate is passed either as a file or as a string with PEM content. As a control, a client without
+     * the root CA must fail to validate the same server, proving the provided CA is what makes the trusted
+     * connection possible.
+     */
+    @Test(groups = {"integration"}, dataProvider = "testCustomCaCertificateProvider")
+    public void testCustomCaCertificate(boolean certAsString) throws Exception {
+        if (isCloud()) {
+            return; // test uses a local WireMock HTTPS server instead of a ClickHouse instance
+        }
+
+        // Generate a private CA and a server certificate (CN/SAN=localhost) signed by it.
+        KeyPair caKeyPair = generateRsaKeyPair();
+        X500Name caSubject = new X500Name("CN=ClickHouse Java Test CA");
+        X509Certificate caCertificate = generateCertificate(caSubject, caSubject, caKeyPair.getPublic(),
+                caKeyPair.getPrivate(), caKeyPair.getPublic(), true, null);
+
+        KeyPair serverKeyPair = generateRsaKeyPair();
+        X500Name serverSubject = new X500Name("CN=localhost");
+        GeneralNames serverSans = new GeneralNames(new GeneralName[]{
+                new GeneralName(GeneralName.dNSName, "localhost"),
+                new GeneralName(GeneralName.iPAddress, "127.0.0.1")
+        });
+        X509Certificate serverCertificate = generateCertificate(serverSubject, caSubject, serverKeyPair.getPublic(),
+                caKeyPair.getPrivate(), caKeyPair.getPublic(), false, serverSans);
+
+        // Server side: PKCS12 keystore with the server key and its certificate chain for WireMock HTTPS.
+        char[] keystorePassword = "changeit".toCharArray();
+        KeyStore serverKeyStore = KeyStore.getInstance("PKCS12");
+        serverKeyStore.load(null, null);
+        serverKeyStore.setKeyEntry("server", serverKeyPair.getPrivate(), keystorePassword,
+                new Certificate[]{serverCertificate, caCertificate});
+        Path keyStoreFile = Files.createTempFile("ch-test-server-keystore-", ".p12");
+        try (java.io.OutputStream out = Files.newOutputStream(keyStoreFile)) {
+            serverKeyStore.store(out, keystorePassword);
+        }
+
+        // Client side: only the root CA certificate, either as PEM content or as a file.
+        String caCertificatePem = toPem(caCertificate);
+        Path caCertFile = Files.createTempFile("ch-test-ca-", ".crt");
+        Files.write(caCertFile, caCertificatePem.getBytes(StandardCharsets.US_ASCII));
+        String rootCertificateValue = certAsString ? caCertificatePem : caCertFile.toAbsolutePath().toString();
+
+        WireMockServer httpsServer = new WireMockServer(WireMockConfiguration.options()
+                .dynamicPort()
+                .dynamicHttpsPort()
+                .keystorePath(keyStoreFile.toAbsolutePath().toString())
+                .keystorePassword(new String(keystorePassword))
+                .keyManagerPassword(new String(keystorePassword))
+                .keystoreType("PKCS12")
+                .notifier(new ConsoleNotifier(false)));
+        httpsServer.start();
+
+        try {
+            // ClickHouse-style success response for any query/command.
+            httpsServer.addStubMapping(WireMock.post(WireMock.anyUrl())
+                    .willReturn(WireMock.aResponse()
+                            .withStatus(HttpStatus.SC_OK)
+                            .withHeader(ClickHouseHttpProto.HEADER_QUERY_ID, UUID.randomUUID().toString())
+                            .withBody("1\n"))
+                    .build());
+
+            int httpsPort = httpsServer.httpsPort();
+            String endpoint = "https://localhost:" + httpsPort;
+
+            // Trusting client: configured with the root CA certificate only.
+            try (Client client = new Client.Builder()
+                    .addEndpoint(endpoint)
+                    .setUsername("default")
+                    .setPassword("")
+                    .setRootCertificate(rootCertificateValue)
+                    .compressClientRequest(false)
+                    .compressServerResponse(false)
+                    .build()) {
+
+                // Ping executes "SELECT 1" - succeeds only if the TLS handshake validated the server certificate.
+                Assert.assertTrue(client.ping(),
+                        "Client should validate the server certificate using the root CA passed as "
+                                + (certAsString ? "a string" : "a file"));
+
+                // A real operation over the validated connection: read the result back.
+                try (QueryResponse response =
+                             client.query("SELECT 1 FORMAT TabSeparated").get(10, TimeUnit.SECONDS)) {
+                    Assert.assertNotNull(response.getQueryId());
+                    ByteArrayOutputStream content = new ByteArrayOutputStream();
+                    byte[] buffer = new byte[128];
+                    int read;
+                    while ((read = response.getInputStream().read(buffer)) != -1) {
+                        content.write(buffer, 0, read);
+                    }
+                    Assert.assertEquals(content.toString("UTF-8"), "1\n");
+                }
+            }
+
+            // The operations actually reached the HTTPS mock server.
+            httpsServer.verify(WireMock.moreThanOrExactly(1), WireMock.postRequestedFor(WireMock.anyUrl()));
+
+            // Control client: without the root CA the default trust store rejects the private chain.
+            try (Client client = new Client.Builder()
+                    .addEndpoint(endpoint)
+                    .setUsername("default")
+                    .setPassword("")
+                    .compressClientRequest(false)
+                    .compressServerResponse(false)
+                    .build()) {
+                Assert.assertFalse(client.ping(),
+                        "Client should not trust the server when the root CA is not provided");
+            }
+        } finally {
+            httpsServer.stop();
+            Files.deleteIfExists(keyStoreFile);
+            Files.deleteIfExists(caCertFile);
+        }
+    }
+
+    private static KeyPair generateRsaKeyPair() throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048, new SecureRandom());
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    private static X509Certificate generateCertificate(X500Name subject, X500Name issuer, PublicKey subjectPublicKey,
+                                                       PrivateKey issuerPrivateKey, PublicKey issuerPublicKey,
+                                                       boolean isCa, GeneralNames subjectAlternativeNames)
+            throws Exception {
+        Date notBefore = new Date(System.currentTimeMillis() - 60_000L);
+        Date notAfter = new Date(System.currentTimeMillis() + Duration.ofDays(1).toMillis());
+        BigInteger serial = new BigInteger(160, new SecureRandom()).abs().add(BigInteger.ONE);
+
+        X509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(
+                issuer, serial, notBefore, notAfter, subject, subjectPublicKey);
+        certBuilder.addExtension(Extension.basicConstraints, true, new BasicConstraints(isCa));
+        certBuilder.addExtension(Extension.keyUsage, true, new KeyUsage(isCa
+                ? KeyUsage.keyCertSign | KeyUsage.cRLSign
+                : KeyUsage.digitalSignature | KeyUsage.keyEncipherment));
+
+        JcaX509ExtensionUtils extensionUtils = new JcaX509ExtensionUtils();
+        certBuilder.addExtension(Extension.subjectKeyIdentifier, false,
+                extensionUtils.createSubjectKeyIdentifier(subjectPublicKey));
+        certBuilder.addExtension(Extension.authorityKeyIdentifier, false,
+                extensionUtils.createAuthorityKeyIdentifier(issuerPublicKey));
+        if (subjectAlternativeNames != null) {
+            certBuilder.addExtension(Extension.subjectAlternativeName, false, subjectAlternativeNames);
+        }
+
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
+                .setProvider(BC_PROVIDER)
+                .build(issuerPrivateKey);
+        return new JcaX509CertificateConverter()
+                .setProvider(BC_PROVIDER)
+                .getCertificate(certBuilder.build(signer));
+    }
+
+    private static String toPem(X509Certificate certificate) throws Exception {
+        StringWriter stringWriter = new StringWriter();
+        try (JcaPEMWriter pemWriter = new JcaPEMWriter(stringWriter)) {
+            pemWriter.writeObject(certificate);
+        }
+        return stringWriter.toString();
     }
 }

--- a/examples/client-v2/README.md
+++ b/examples/client-v2/README.md
@@ -75,3 +75,97 @@ Notes:
 - First argument is server location (endpoint).
 - Example uses admin credentials to `CREATE USER` and `DROP USER`.
 - Optional database can be overridden with `-DchDatabase=<db>`.
+
+## SSL Examples
+
+`com.clickhouse.examples.client_v2.SSLExamples` shows how to connect securely to a server whose
+certificate is signed by a custom (private) CA. Only the CA certificate is passed to the client
+with `Client.Builder.setRootCertificate()` - no trust store configuration is required, and the JVM
+default trust store stays untouched.
+
+The example runs in one of two modes.
+
+### Local mode (dockerized server, default)
+
+Verifies the whole scenario end to end: the example generates a private CA and a server
+certificate, starts a local ClickHouse server in Docker configured with them, and connects using
+only the generated CA certificate. Requires a running Docker daemon.
+
+```shell
+mvn exec:java -Dexec.mainClass="com.clickhouse.examples.client_v2.SSLExamples"
+```
+
+Optional:
+- `-DchImage` - Docker image to use (default: `clickhouse/clickhouse-server:latest`)
+
+### Standalone mode (your own server)
+
+Once the local scenario works, verify your own instance by passing its address and the CA
+certificate that signed its server certificate:
+
+```shell
+mvn exec:java -Dexec.mainClass="com.clickhouse.examples.client_v2.SSLExamples" \
+  -DchHost="clickhouse.example.com" \
+  -DchPort="8443" \
+  -DchUser="default" \
+  -DchPassword="secret" \
+  -DchDatabase="default" \
+  -DchRootCert="/path/to/ca.crt"
+```
+
+`-DchRootCert` is required in this mode and must point to the CA certificate in PEM format.
+
+### Setting up a Docker dev instance with a self-signed certificate manually
+
+The local mode does all of this automatically, but the same setup can be created by hand.
+
+1. Generate a private CA and a server certificate signed by it (`CN`/SAN must match the hostname
+you will connect to, `localhost` in this example):
+
+```shell
+# Private CA
+openssl req -x509 -newkey rsa:2048 -days 365 -nodes \
+  -keyout ca.key -out ca.crt -subj "/CN=ExamplePrivateCA"
+
+# Server key and certificate signing request
+openssl req -newkey rsa:2048 -nodes \
+  -keyout server.key -out server.csr -subj "/CN=localhost"
+
+# Server certificate signed by the CA, with SANs for localhost
+openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
+  -days 365 -out server.crt \
+  -extfile <(printf "subjectAltName=DNS:localhost,IP:127.0.0.1")
+```
+
+2. Create a `config.d` overlay enabling the HTTPS interface, e.g. `zzz_ssl.xml`:
+
+```xml
+<clickhouse>
+    <https_port>8443</https_port>
+    <openSSL>
+        <server>
+            <certificateFile>/etc/clickhouse-server/certs/server.crt</certificateFile>
+            <privateKeyFile>/etc/clickhouse-server/certs/server.key</privateKeyFile>
+            <verificationMode>none</verificationMode>
+            <loadDefaultCAFile>true</loadDefaultCAFile>
+            <disableProtocols>sslv2,sslv3</disableProtocols>
+            <preferServerCiphers>true</preferServerCiphers>
+        </server>
+    </openSSL>
+</clickhouse>
+```
+
+3. Start the server with the certificates and the configuration mounted:
+
+```shell
+docker run -d --name clickhouse-ssl -p 8443:8443 \
+  -v "$PWD/server.crt:/etc/clickhouse-server/certs/server.crt:ro" \
+  -v "$PWD/server.key:/etc/clickhouse-server/certs/server.key:ro" \
+  -v "$PWD/zzz_ssl.xml:/etc/clickhouse-server/config.d/zzz_ssl.xml:ro" \
+  clickhouse/clickhouse-server:latest
+```
+
+4. Run the example in standalone mode with `-DchHost=localhost -DchRootCert="$PWD/ca.crt"`.
+
+The full description of the server-side TLS configuration is in the official documentation:
+[Configuring SSL-TLS](https://clickhouse.com/docs/en/guides/sre/configuring-ssl).

--- a/examples/client-v2/README.md
+++ b/examples/client-v2/README.md
@@ -135,9 +135,12 @@ openssl req -newkey rsa:2048 -nodes \
 openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
   -days 365 -out server.crt \
   -extfile <(printf "subjectAltName=DNS:localhost,IP:127.0.0.1")
+  
+# Only for demo purpose we make key readable by all. On production should be readable only by owner, not even by group.
+chmod a+r server.key
 ```
 
-2. Create a `config.d` overlay enabling the HTTPS interface, e.g. `zzz_ssl.xml`:
+2. Create a `config.d` overlay enabling the HTTPS interface, e.g. `my_ssl.xml`:
 
 ```xml
 <clickhouse>
@@ -161,11 +164,22 @@ openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
 docker run -d --name clickhouse-ssl -p 8443:8443 \
   -v "$PWD/server.crt:/etc/clickhouse-server/certs/server.crt:ro" \
   -v "$PWD/server.key:/etc/clickhouse-server/certs/server.key:ro" \
-  -v "$PWD/zzz_ssl.xml:/etc/clickhouse-server/config.d/zzz_ssl.xml:ro" \
+  -v "$PWD/my_ssl.xml:/etc/clickhouse-server/config.d/my_ssl.xml:ro" \
+  -e CLICKHOUSE_PASSWORD="secret" \
   clickhouse/clickhouse-server:latest
 ```
 
 4. Run the example in standalone mode with `-DchHost=localhost -DchRootCert="$PWD/ca.crt"`.
+
+```shell
+mvn exec:java -Dexec.mainClass="com.clickhouse.examples.client_v2.SSLExamples" \
+  -DchHost="localhost" \
+  -DchPort="8443" \
+  -DchUser="default" \
+  -DchPassword="secret" \
+  -DchDatabase="default" \
+  -DchRootCert="$PWD/ca.crt"
+```
 
 The full description of the server-side TLS configuration is in the official documentation:
 [Configuring SSL-TLS](https://clickhouse.com/docs/en/guides/sre/configuring-ssl).

--- a/examples/client-v2/pom.xml
+++ b/examples/client-v2/pom.xml
@@ -128,6 +128,23 @@
             <scope>compile</scope>
         </dependency>
 
+        <!-- For the SSL examples: local ClickHouse server in Docker with a self-signed certificate -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>2.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.84</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>1.84</version>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/SSLExamples.java
+++ b/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/SSLExamples.java
@@ -1,0 +1,114 @@
+package com.clickhouse.examples.client_v2;
+
+import com.clickhouse.client.api.Client;
+import com.clickhouse.client.api.query.GenericRecord;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.List;
+
+/**
+ * Examples showing how to configure secure (TLS/HTTPS) connections with Client-v2.
+ *
+ * <p>Currently covered:</p>
+ * <ul>
+ *     <li>Connecting to a server whose certificate is signed by a custom (private) CA -
+ *     the CA certificate is passed with {@link Client.Builder#setRootCertificate(String)}.
+ *     No trust store configuration is needed: the certificate is added to a trust store
+ *     used only by this client, so the JVM default trust store stays untouched.</li>
+ * </ul>
+ *
+ * <p>More SSL examples (mTLS, trust stores, SNI) will be added to this class later.</p>
+ *
+ * <p>The example runs in one of two modes:</p>
+ * <ul>
+ *     <li><b>Local mode</b> (default, when {@code chHost} is not set) - starts a local ClickHouse
+ *     server in Docker with a freshly generated self-signed certificate and verifies the whole
+ *     scenario end to end. Requires a running Docker daemon.</li>
+ *     <li><b>Standalone mode</b> (when {@code chHost} is set) - connects to your own server using
+ *     the provided CA certificate. Use it to verify your own instance once the local scenario works.</li>
+ * </ul>
+ *
+ * <p>Supported startup properties:</p>
+ * <ul>
+ *     <li>{@code chHost} - ClickHouse host. When set, standalone mode is used</li>
+ *     <li>{@code chPort} - ClickHouse HTTPS port, default {@code 8443}</li>
+ *     <li>{@code chDatabase} - database name, default {@code default}</li>
+ *     <li>{@code chUser} and {@code chPassword} - credentials (standalone mode)</li>
+ *     <li>{@code chRootCert} - path to the root CA certificate in PEM format (required in standalone mode)</li>
+ *     <li>{@code chImage} - Docker image for local mode, default {@code clickhouse/clickhouse-server:latest}</li>
+ * </ul>
+ */
+@Slf4j
+public class SSLExamples {
+
+    public static void main(String[] args) {
+        final String host = trimToNull(System.getProperty("chHost"));
+        final String database = System.getProperty("chDatabase", "default");
+
+        if (host != null) {
+            // Standalone mode: verify a user-provided instance.
+            final String port = System.getProperty("chPort", "8443");
+            final String user = System.getProperty("chUser", "default");
+            final String password = System.getProperty("chPassword", "");
+            final String rootCert = trimToNull(System.getProperty("chRootCert"));
+            if (rootCert == null) {
+                log.error("chRootCert is required when chHost is set. "
+                        + "Pass the path to the CA certificate (PEM) that signed the server certificate.");
+                return;
+            }
+
+            log.info("Running in standalone mode against {}:{}", host, port);
+            connectWithCustomRootCertificate("https://" + host + ":" + port, database, user, password, rootCert);
+            return;
+        }
+
+        // Local mode: start a dockerized ClickHouse with a self-signed certificate and
+        // verify the whole scenario end to end.
+        final String image = System.getProperty("chImage", "clickhouse/clickhouse-server:latest");
+        log.info("Running in local mode (set -DchHost to verify your own server)");
+        try (SecureServerSupport server = SecureServerSupport.start(image)) {
+            connectWithCustomRootCertificate(server.getEndpoint(), database,
+                    SecureServerSupport.USER, SecureServerSupport.PASSWORD, server.getCaCertPath());
+        } catch (Exception e) {
+            log.error("Failed to run the SSL example against a local Docker server", e);
+            Runtime.getRuntime().exit(-1);
+        }
+        // Explicit exit: testcontainers keeps non-daemon threads alive after the scenario is done.
+        Runtime.getRuntime().exit(0);
+    }
+
+    /**
+     * Connects to a ClickHouse server using a custom root CA certificate.
+     * Use this when the server certificate is signed by a private CA (corporate CA,
+     * self-managed Kubernetes CA, etc.) that is not present in the JVM default trust store.
+     */
+    static void connectWithCustomRootCertificate(String endpoint, String database, String user, String password,
+                                                 String rootCert) {
+        log.info("Connecting to {} using root CA certificate from {}", endpoint, rootCert);
+        try (Client client = new Client.Builder()
+                .addEndpoint(endpoint)
+                .setUsername(user)
+                .setPassword(password)
+                .setDefaultDatabase(database)
+                // Only the CA certificate is required. The server certificate chain will be
+                // validated against it, and hostname verification stays enabled.
+                .setRootCertificate(rootCert)
+                .build()) {
+
+            List<GenericRecord> rows = client.queryAll("SELECT currentUser() AS user, version() AS version");
+            log.info("Connected securely as '{}' to ClickHouse {}", rows.get(0).getString("user"),
+                    rows.get(0).getString("version"));
+        } catch (Exception e) {
+            log.error("Secure connection with a custom root CA certificate failed", e);
+        }
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/SSLExamples.java
+++ b/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/SSLExamples.java
@@ -71,10 +71,7 @@ public class SSLExamples {
                     SecureServerSupport.USER, SecureServerSupport.PASSWORD, server.getCaCertPath());
         } catch (Exception e) {
             log.error("Failed to run the SSL example against a local Docker server", e);
-            Runtime.getRuntime().exit(-1);
         }
-        // Explicit exit: testcontainers keeps non-daemon threads alive after the scenario is done.
-        Runtime.getRuntime().exit(0);
     }
 
     /**

--- a/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/SecureServerSupport.java
+++ b/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/SecureServerSupport.java
@@ -1,0 +1,271 @@
+package com.clickhouse.examples.client_v2;
+
+import lombok.extern.slf4j.Slf4j;
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.util.Date;
+import java.util.stream.Stream;
+
+/**
+ * Support class for SSL examples: starts a local ClickHouse server in Docker configured with a
+ * freshly generated self-signed certificate (a private CA signs the server certificate).
+ *
+ * <p>All TLS material is generated at runtime and removed when the server is closed, so the
+ * examples are fully self-contained. The same setup can be reproduced manually with
+ * {@code openssl} - see the project README. The server-side TLS configuration is described in the
+ * official documentation: <a href="https://clickhouse.com/docs/en/guides/sre/configuring-ssl">Configuring SSL-TLS</a>.</p>
+ */
+@Slf4j
+public class SecureServerSupport implements AutoCloseable {
+
+    /** Credentials of the user created in the local container. */
+    public static final String USER = "ssl_demo";
+    public static final String PASSWORD = "ssl_demo_password";
+
+    private static final int HTTP_PORT = 8123;
+    private static final int HTTPS_PORT = 8443;
+    private static final long CERTIFICATE_DAYS_VALID = 365;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final String BC_PROVIDER = BouncyCastleProvider.PROVIDER_NAME;
+
+    static {
+        if (Security.getProvider(BC_PROVIDER) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    private final GenericContainer<?> container;
+    private final Path certDir;
+    private final Path confDir;
+
+    private SecureServerSupport(GenericContainer<?> container, Path certDir, Path confDir) {
+        this.container = container;
+        this.certDir = certDir;
+        this.confDir = confDir;
+    }
+
+    /**
+     * Generates a private CA and a server certificate, writes the ClickHouse SSL configuration and
+     * starts a ClickHouse container with HTTPS enabled.
+     */
+    public static SecureServerSupport start(String image) throws Exception {
+        Path certDir = Files.createTempDirectory("ch-ssl-example-certs-");
+        Path confDir = Files.createTempDirectory("ch-ssl-example-config-");
+        Path sslConfig = confDir.resolve("zzz_ssl.xml");
+
+        log.info("Generating an ephemeral private CA and a server certificate in {}", certDir);
+        generatePrivateCaAndServerCertificate(certDir);
+        writeClickHouseSslConfig(sslConfig);
+        // The TLS material must be readable by the 'clickhouse' user inside the container,
+        // while temp directories are created accessible to the current user only.
+        makeReadableByContainer(certDir);
+        makeReadableByContainer(confDir);
+
+        log.info("Starting ClickHouse container from image: {}", image);
+        GenericContainer<?> container = new GenericContainer<>(image)
+                .withExposedPorts(HTTP_PORT, HTTPS_PORT)
+                .withEnv("CLICKHOUSE_USER", USER)
+                .withEnv("CLICKHOUSE_PASSWORD", PASSWORD)
+                .withFileSystemBind(certDir.toAbsolutePath().toString(),
+                        "/etc/clickhouse-server/certs", BindMode.READ_ONLY)
+                .withFileSystemBind(sslConfig.toAbsolutePath().toString(),
+                        "/etc/clickhouse-server/config.d/zzz_ssl.xml", BindMode.READ_ONLY)
+                .waitingFor(Wait.forHttp("/ping")
+                        .forPort(HTTP_PORT)
+                        .forStatusCode(200)
+                        .withStartupTimeout(Duration.ofMinutes(3)));
+        try {
+            container.start();
+        } catch (Exception e) {
+            log.error("ClickHouse container failed to start. Container logs:\n{}", safeGetLogs(container));
+            deleteRecursively(certDir);
+            deleteRecursively(confDir);
+            throw e;
+        }
+        log.info("ClickHouse container is ready on https://localhost:{}", container.getMappedPort(HTTPS_PORT));
+        return new SecureServerSupport(container, certDir, confDir);
+    }
+
+    /** HTTPS endpoint of the started container. */
+    public String getEndpoint() {
+        return "https://localhost:" + container.getMappedPort(HTTPS_PORT);
+    }
+
+    /** Path to the CA certificate (PEM) that signed the server certificate. */
+    public String getCaCertPath() {
+        return certDir.resolve("ca.crt").toAbsolutePath().toString();
+    }
+
+    @Override
+    public void close() {
+        log.info("Stopping ClickHouse container and deleting temporary TLS artifacts");
+        container.stop();
+        deleteRecursively(certDir);
+        deleteRecursively(confDir);
+    }
+
+    private static void generatePrivateCaAndServerCertificate(Path outputDir) throws Exception {
+        KeyPair caKeys = generateRsaKeyPair();
+        X500Name caSubject = new X500Name("CN=ExamplePrivateCA");
+        X509Certificate caCertificate = generateCertificate(caSubject, caSubject,
+                caKeys.getPublic(), caKeys.getPrivate(), caKeys.getPublic(), true, null);
+
+        KeyPair serverKeys = generateRsaKeyPair();
+        X500Name serverSubject = new X500Name("CN=localhost");
+        GeneralNames serverSans = new GeneralNames(new GeneralName[]{
+                new GeneralName(GeneralName.dNSName, "localhost"),
+                new GeneralName(GeneralName.iPAddress, "127.0.0.1")
+        });
+        X509Certificate serverCertificate = generateCertificate(serverSubject, caSubject,
+                serverKeys.getPublic(), caKeys.getPrivate(), caKeys.getPublic(), false, serverSans);
+
+        writePemObject(outputDir.resolve("ca.crt"), caCertificate);
+        writePemObject(outputDir.resolve("server.crt"), serverCertificate);
+        writePemObject(outputDir.resolve("server.key"), serverKeys.getPrivate());
+    }
+
+    private static KeyPair generateRsaKeyPair() throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048, SECURE_RANDOM);
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    private static X509Certificate generateCertificate(
+            X500Name subject,
+            X500Name issuer,
+            PublicKey subjectPublicKey,
+            PrivateKey issuerPrivateKey,
+            PublicKey issuerPublicKey,
+            boolean isCa,
+            GeneralNames subjectAlternativeNames) throws Exception {
+        Date notBefore = new Date(System.currentTimeMillis() - 60_000L);
+        Date notAfter = new Date(System.currentTimeMillis() + Duration.ofDays(CERTIFICATE_DAYS_VALID).toMillis());
+        BigInteger serial = new BigInteger(160, SECURE_RANDOM).abs().add(BigInteger.ONE);
+
+        X509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(
+                issuer, serial, notBefore, notAfter, subject, subjectPublicKey);
+        certBuilder.addExtension(Extension.basicConstraints, true, new BasicConstraints(isCa));
+        certBuilder.addExtension(Extension.keyUsage, true, new KeyUsage(isCa
+                ? KeyUsage.keyCertSign | KeyUsage.cRLSign
+                : KeyUsage.digitalSignature | KeyUsage.keyEncipherment));
+
+        JcaX509ExtensionUtils extensionUtils = new JcaX509ExtensionUtils();
+        certBuilder.addExtension(Extension.subjectKeyIdentifier, false,
+                extensionUtils.createSubjectKeyIdentifier(subjectPublicKey));
+        certBuilder.addExtension(Extension.authorityKeyIdentifier, false,
+                extensionUtils.createAuthorityKeyIdentifier(issuerPublicKey));
+        if (subjectAlternativeNames != null) {
+            certBuilder.addExtension(Extension.subjectAlternativeName, false, subjectAlternativeNames);
+        }
+
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
+                .setProvider(BC_PROVIDER)
+                .build(issuerPrivateKey);
+        X509Certificate certificate = new JcaX509CertificateConverter()
+                .setProvider(BC_PROVIDER)
+                .getCertificate(certBuilder.build(signer));
+        certificate.checkValidity(new Date());
+        certificate.verify(issuerPublicKey);
+        return certificate;
+    }
+
+    private static void writePemObject(Path targetPath, Object value) throws IOException {
+        try (Writer fileWriter = Files.newBufferedWriter(targetPath, StandardCharsets.US_ASCII);
+             JcaPEMWriter pemWriter = new JcaPEMWriter(fileWriter)) {
+            pemWriter.writeObject(value);
+        }
+    }
+
+    /**
+     * Writes a config.d overlay enabling the HTTPS interface. The full description of the
+     * server-side options is in the official documentation:
+     * https://clickhouse.com/docs/en/guides/sre/configuring-ssl
+     */
+    private static void writeClickHouseSslConfig(Path configPath) throws IOException {
+        String config = "<clickhouse>\n"
+                + "    <https_port>" + HTTPS_PORT + "</https_port>\n"
+                + "    <openSSL>\n"
+                + "        <server>\n"
+                + "            <certificateFile>/etc/clickhouse-server/certs/server.crt</certificateFile>\n"
+                + "            <privateKeyFile>/etc/clickhouse-server/certs/server.key</privateKeyFile>\n"
+                + "            <verificationMode>none</verificationMode>\n"
+                + "            <loadDefaultCAFile>true</loadDefaultCAFile>\n"
+                + "            <disableProtocols>sslv2,sslv3</disableProtocols>\n"
+                + "            <preferServerCiphers>true</preferServerCiphers>\n"
+                + "        </server>\n"
+                + "    </openSSL>\n"
+                + "</clickhouse>\n";
+        Files.write(configPath, config.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static void makeReadableByContainer(Path dir) throws IOException {
+        try (Stream<Path> targets = Files.walk(dir)) {
+            for (Path target : targets.toArray(Path[]::new)) {
+                File file = target.toFile();
+                if (!file.setReadable(true, false)) {
+                    log.warn("Failed to make {} world-readable", target);
+                }
+                if (Files.isDirectory(target) && !file.setExecutable(true, false)) {
+                    log.warn("Failed to make {} world-executable", target);
+                }
+            }
+        }
+    }
+
+    private static String safeGetLogs(GenericContainer<?> container) {
+        try {
+            return container.getLogs();
+        } catch (Exception e) {
+            return "<not available: " + e.getMessage() + ">";
+        }
+    }
+
+    private static void deleteRecursively(Path path) {
+        if (path == null || !Files.exists(path)) {
+            return;
+        }
+        try (Stream<Path> targets = Files.walk(path)) {
+            targets.sorted((left, right) -> right.getNameCount() - left.getNameCount())
+                    .forEach(target -> {
+                        try {
+                            Files.deleteIfExists(target);
+                        } catch (IOException ignored) {
+                            // Best effort cleanup for temporary example files.
+                        }
+                    });
+        } catch (IOException ignored) {
+            // Best effort cleanup for temporary example files.
+        }
+    }
+}

--- a/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/SecureServerSupport.java
+++ b/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/SecureServerSupport.java
@@ -82,7 +82,7 @@ public class SecureServerSupport implements AutoCloseable {
     public static SecureServerSupport start(String image) throws Exception {
         Path certDir = Files.createTempDirectory("ch-ssl-example-certs-");
         Path confDir = Files.createTempDirectory("ch-ssl-example-config-");
-        Path sslConfig = confDir.resolve("zzz_ssl.xml");
+        Path sslConfig = confDir.resolve("custom_ca_ssl.xml");
 
         log.info("Generating an ephemeral private CA and a server certificate in {}", certDir);
         generatePrivateCaAndServerCertificate(certDir);
@@ -100,7 +100,7 @@ public class SecureServerSupport implements AutoCloseable {
                 .withFileSystemBind(certDir.toAbsolutePath().toString(),
                         "/etc/clickhouse-server/certs", BindMode.READ_ONLY)
                 .withFileSystemBind(sslConfig.toAbsolutePath().toString(),
-                        "/etc/clickhouse-server/config.d/zzz_ssl.xml", BindMode.READ_ONLY)
+                        "/etc/clickhouse-server/config.d/custom_ca_ssl.xml", BindMode.READ_ONLY)
                 .waitingFor(Wait.forHttp("/ping")
                         .forPort(HTTP_PORT)
                         .forStatusCode(200)

--- a/examples/jdbc/README.md
+++ b/examples/jdbc/README.md
@@ -21,3 +21,96 @@ To run simplified example:
 Addition options can be passed to the application:
 - `-DchUrl` - ClickHouse JDBC URL. Default is `jdbc:clickhouse://localhost:8123/default`
 - `-Dclickhouse.jdbc.v2=true` - Use JDBC V2 implementation
+
+## SSL Examples
+
+`com.clickhouse.examples.jdbc.SSLExamples` shows how to connect securely to a server whose
+certificate is signed by a custom (private) CA. Only the CA certificate is passed with the
+`sslrootcert` connection property - no trust store configuration is required, and the JVM default
+trust store stays untouched.
+
+The example runs in one of two modes.
+
+### Local mode (dockerized server, default)
+
+Verifies the whole scenario end to end: the example generates a private CA and a server
+certificate, starts a local ClickHouse server in Docker configured with them, and connects using
+only the generated CA certificate. Requires a running Docker daemon.
+
+```shell
+mvn exec:java -Dexec.mainClass="com.clickhouse.examples.jdbc.SSLExamples"
+```
+
+Optional:
+- `-DchImage` - Docker image to use (default: `clickhouse/clickhouse-server:latest`)
+
+### Standalone mode (your own server)
+
+Once the local scenario works, verify your own instance by passing its JDBC URL and the CA
+certificate that signed its server certificate:
+
+```shell
+mvn exec:java -Dexec.mainClass="com.clickhouse.examples.jdbc.SSLExamples" \
+  -DchUrl="jdbc:clickhouse://clickhouse.example.com:8443/default" \
+  -DchUser="default" \
+  -DchPassword="secret" \
+  -DchRootCert="/path/to/ca.crt"
+```
+
+`-DchRootCert` is required in this mode and must point to the CA certificate in PEM format.
+
+### Setting up a Docker dev instance with a self-signed certificate manually
+
+The local mode does all of this automatically, but the same setup can be created by hand.
+
+1. Generate a private CA and a server certificate signed by it (`CN`/SAN must match the hostname
+you will connect to, `localhost` in this example):
+
+```shell
+# Private CA
+openssl req -x509 -newkey rsa:2048 -days 365 -nodes \
+  -keyout ca.key -out ca.crt -subj "/CN=ExamplePrivateCA"
+
+# Server key and certificate signing request
+openssl req -newkey rsa:2048 -nodes \
+  -keyout server.key -out server.csr -subj "/CN=localhost"
+
+# Server certificate signed by the CA, with SANs for localhost
+openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
+  -days 365 -out server.crt \
+  -extfile <(printf "subjectAltName=DNS:localhost,IP:127.0.0.1")
+```
+
+2. Create a `config.d` overlay enabling the HTTPS interface, e.g. `zzz_ssl.xml`:
+
+```xml
+<clickhouse>
+    <https_port>8443</https_port>
+    <openSSL>
+        <server>
+            <certificateFile>/etc/clickhouse-server/certs/server.crt</certificateFile>
+            <privateKeyFile>/etc/clickhouse-server/certs/server.key</privateKeyFile>
+            <verificationMode>none</verificationMode>
+            <loadDefaultCAFile>true</loadDefaultCAFile>
+            <disableProtocols>sslv2,sslv3</disableProtocols>
+            <preferServerCiphers>true</preferServerCiphers>
+        </server>
+    </openSSL>
+</clickhouse>
+```
+
+3. Start the server with the certificates and the configuration mounted:
+
+```shell
+docker run -d --name clickhouse-ssl -p 8443:8443 \
+  -v "$PWD/server.crt:/etc/clickhouse-server/certs/server.crt:ro" \
+  -v "$PWD/server.key:/etc/clickhouse-server/certs/server.key:ro" \
+  -v "$PWD/zzz_ssl.xml:/etc/clickhouse-server/config.d/zzz_ssl.xml:ro" \
+  clickhouse/clickhouse-server:latest
+```
+
+4. Run the example in standalone mode with
+`-DchUrl="jdbc:clickhouse://localhost:8443/default" -DchRootCert="$PWD/ca.crt"`.
+
+The full description of the server-side TLS configuration is in the official documentation:
+[Configuring SSL-TLS](https://clickhouse.com/docs/en/guides/sre/configuring-ssl).

--- a/examples/jdbc/README.md
+++ b/examples/jdbc/README.md
@@ -79,9 +79,12 @@ openssl req -newkey rsa:2048 -nodes \
 openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
   -days 365 -out server.crt \
   -extfile <(printf "subjectAltName=DNS:localhost,IP:127.0.0.1")
+  
+# Only for demo purpose we make key readable by all. On production should be readable only by owner, not even by group.^M
+chmod a+r server.key
 ```
 
-2. Create a `config.d` overlay enabling the HTTPS interface, e.g. `zzz_ssl.xml`:
+2. Create a `config.d` overlay enabling the HTTPS interface, e.g. `my_ssl.xml`:
 
 ```xml
 <clickhouse>
@@ -105,12 +108,22 @@ openssl x509 -req -in server.csr -CA ca.crt -CAkey ca.key -CAcreateserial \
 docker run -d --name clickhouse-ssl -p 8443:8443 \
   -v "$PWD/server.crt:/etc/clickhouse-server/certs/server.crt:ro" \
   -v "$PWD/server.key:/etc/clickhouse-server/certs/server.key:ro" \
-  -v "$PWD/zzz_ssl.xml:/etc/clickhouse-server/config.d/zzz_ssl.xml:ro" \
+  -v "$PWD/my_ssl.xml:/etc/clickhouse-server/config.d/my_ssl.xml:ro" \
+  -e CLICKHOUSE_PASSWORD="secret" \
   clickhouse/clickhouse-server:latest
 ```
 
 4. Run the example in standalone mode with
 `-DchUrl="jdbc:clickhouse://localhost:8443/default" -DchRootCert="$PWD/ca.crt"`.
+
+```shell
+mvn exec:java -Dexec.mainClass="com.clickhouse.examples.jdbc.SSLExamples" \
+  -DchUrl="jdbc:clickhouse:https://localhost:8443/default" \
+  -DchUser="default" \
+  -DchPassword="secret" \
+  -DchRootCert="$PWD/ca.crt"
+```
+
 
 The full description of the server-side TLS configuration is in the official documentation:
 [Configuring SSL-TLS](https://clickhouse.com/docs/en/guides/sre/configuring-ssl).

--- a/examples/jdbc/pom.xml
+++ b/examples/jdbc/pom.xml
@@ -91,6 +91,23 @@
             <version>${slf4j.version}</version>
             <scope>runtime</scope>
         </dependency>
+
+        <!-- For the SSL examples: local ClickHouse server in Docker with a self-signed certificate -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>2.0.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk18on</artifactId>
+            <version>1.84</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcpkix-jdk18on</artifactId>
+            <version>1.84</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/examples/jdbc/src/main/java/com/clickhouse/examples/jdbc/SSLExamples.java
+++ b/examples/jdbc/src/main/java/com/clickhouse/examples/jdbc/SSLExamples.java
@@ -1,0 +1,120 @@
+package com.clickhouse.examples.jdbc;
+
+import com.clickhouse.client.api.ClientConfigProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+/**
+ * Examples showing how to configure secure (TLS/HTTPS) connections with the JDBC driver.
+ *
+ * <p>Currently covered:</p>
+ * <ul>
+ *     <li>Connecting to a server whose certificate is signed by a custom (private) CA -
+ *     the CA certificate is passed with the {@code sslrootcert} connection property.
+ *     No trust store configuration is needed: the certificate is added to a trust store
+ *     used only by this connection, so the JVM default trust store stays untouched.</li>
+ * </ul>
+ *
+ * <p>More SSL examples (mTLS, trust stores, SNI) will be added to this class later.</p>
+ *
+ * <p>The example runs in one of two modes:</p>
+ * <ul>
+ *     <li><b>Local mode</b> (default, when {@code chUrl} is not set) - starts a local ClickHouse
+ *     server in Docker with a freshly generated self-signed certificate and verifies the whole
+ *     scenario end to end. Requires a running Docker daemon.</li>
+ *     <li><b>Standalone mode</b> (when {@code chUrl} is set) - connects to your own server using
+ *     the provided CA certificate. Use it to verify your own instance once the local scenario works.</li>
+ * </ul>
+ *
+ * <p>Supported startup properties:</p>
+ * <ul>
+ *     <li>{@code chUrl} - ClickHouse JDBC URL, e.g. {@code jdbc:clickhouse://my-host:8443/default}.
+ *     When set, standalone mode is used</li>
+ *     <li>{@code chUser} and {@code chPassword} - credentials (standalone mode)</li>
+ *     <li>{@code chRootCert} - path to the root CA certificate in PEM format (required in standalone mode)</li>
+ *     <li>{@code chImage} - Docker image for local mode, default {@code clickhouse/clickhouse-server:latest}</li>
+ * </ul>
+ */
+public class SSLExamples {
+    private static final Logger log = LoggerFactory.getLogger(SSLExamples.class);
+
+    public static void main(String[] args) {
+        final String url = trimToNull(System.getProperty("chUrl"));
+
+        if (url != null) {
+            // Standalone mode: verify a user-provided instance.
+            final String user = System.getProperty("chUser", "default");
+            final String password = System.getProperty("chPassword", "");
+            final String rootCert = trimToNull(System.getProperty("chRootCert"));
+            if (rootCert == null) {
+                log.error("chRootCert is required when chUrl is set. "
+                        + "Pass the path to the CA certificate (PEM) that signed the server certificate.");
+                return;
+            }
+
+            log.info("Running in standalone mode against {}", url);
+            try {
+                connectWithCustomRootCertificate(url, user, password, rootCert);
+            } catch (SQLException e) {
+                log.error("Secure connection with a custom root CA certificate failed", e);
+            }
+            return;
+        }
+
+        // Local mode: start a dockerized ClickHouse with a self-signed certificate and
+        // verify the whole scenario end to end.
+        final String image = System.getProperty("chImage", "clickhouse/clickhouse-server:latest");
+        log.info("Running in local mode (set -DchUrl to verify your own server)");
+        try (SecureServerSupport server = SecureServerSupport.start(image)) {
+            connectWithCustomRootCertificate(server.getJdbcUrl(),
+                    SecureServerSupport.USER, SecureServerSupport.PASSWORD, server.getCaCertPath());
+        } catch (Exception e) {
+            log.error("Failed to run the SSL example against a local Docker server", e);
+            Runtime.getRuntime().exit(-1);
+        }
+        // Explicit exit: testcontainers keeps non-daemon threads alive after the scenario is done.
+        Runtime.getRuntime().exit(0);
+    }
+
+    /**
+     * Connects to a ClickHouse server using a custom root CA certificate.
+     * Use this when the server certificate is signed by a private CA (corporate CA,
+     * self-managed Kubernetes CA, etc.) that is not present in the JVM default trust store.
+     */
+    static void connectWithCustomRootCertificate(String url, String user, String password, String rootCert)
+            throws SQLException {
+        log.info("Connecting to {} using root CA certificate from {}", url, rootCert);
+
+        Properties properties = new Properties();
+        properties.setProperty(ClientConfigProperties.USER.getKey(), user); // user
+        properties.setProperty(ClientConfigProperties.PASSWORD.getKey(), password); // password
+        properties.setProperty("ssl", "true"); // enable TLS even if the URL has no https scheme
+        // Only the CA certificate is required. The server certificate chain will be
+        // validated against it, and hostname verification stays enabled.
+        properties.setProperty(ClientConfigProperties.CA_CERTIFICATE.getKey(), rootCert); // sslrootcert
+
+        try (Connection connection = DriverManager.getConnection(url, properties);
+             Statement stmt = connection.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT currentUser() AS user, version() AS version")) {
+            if (rs.next()) {
+                log.info("Connected securely as '{}' to ClickHouse {}", rs.getString("user"), rs.getString("version"));
+            }
+        }
+    }
+
+    private static String trimToNull(String value) {
+        if (value == null) {
+            return null;
+        }
+
+        String trimmed = value.trim();
+        return trimmed.isEmpty() ? null : trimmed;
+    }
+}

--- a/examples/jdbc/src/main/java/com/clickhouse/examples/jdbc/SecureServerSupport.java
+++ b/examples/jdbc/src/main/java/com/clickhouse/examples/jdbc/SecureServerSupport.java
@@ -1,0 +1,272 @@
+package com.clickhouse.examples.jdbc;
+
+import org.bouncycastle.asn1.x500.X500Name;
+import org.bouncycastle.asn1.x509.BasicConstraints;
+import org.bouncycastle.asn1.x509.Extension;
+import org.bouncycastle.asn1.x509.GeneralName;
+import org.bouncycastle.asn1.x509.GeneralNames;
+import org.bouncycastle.asn1.x509.KeyUsage;
+import org.bouncycastle.cert.X509v3CertificateBuilder;
+import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
+import org.bouncycastle.cert.jcajce.JcaX509ExtensionUtils;
+import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.openssl.jcajce.JcaPEMWriter;
+import org.bouncycastle.operator.ContentSigner;
+import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.BindMode;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.wait.strategy.Wait;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.Writer;
+import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.security.KeyPair;
+import java.security.KeyPairGenerator;
+import java.security.PrivateKey;
+import java.security.PublicKey;
+import java.security.SecureRandom;
+import java.security.Security;
+import java.security.cert.X509Certificate;
+import java.time.Duration;
+import java.util.Date;
+import java.util.stream.Stream;
+
+/**
+ * Support class for SSL examples: starts a local ClickHouse server in Docker configured with a
+ * freshly generated self-signed certificate (a private CA signs the server certificate).
+ *
+ * <p>All TLS material is generated at runtime and removed when the server is closed, so the
+ * examples are fully self-contained. The same setup can be reproduced manually with
+ * {@code openssl} - see the project README. The server-side TLS configuration is described in the
+ * official documentation: <a href="https://clickhouse.com/docs/en/guides/sre/configuring-ssl">Configuring SSL-TLS</a>.</p>
+ */
+public class SecureServerSupport implements AutoCloseable {
+    private static final Logger log = LoggerFactory.getLogger(SecureServerSupport.class);
+
+    /** Credentials of the user created in the local container. */
+    public static final String USER = "ssl_demo";
+    public static final String PASSWORD = "ssl_demo_password";
+
+    private static final int HTTP_PORT = 8123;
+    private static final int HTTPS_PORT = 8443;
+    private static final long CERTIFICATE_DAYS_VALID = 365;
+    private static final SecureRandom SECURE_RANDOM = new SecureRandom();
+    private static final String BC_PROVIDER = BouncyCastleProvider.PROVIDER_NAME;
+
+    static {
+        if (Security.getProvider(BC_PROVIDER) == null) {
+            Security.addProvider(new BouncyCastleProvider());
+        }
+    }
+
+    private final GenericContainer<?> container;
+    private final Path certDir;
+    private final Path confDir;
+
+    private SecureServerSupport(GenericContainer<?> container, Path certDir, Path confDir) {
+        this.container = container;
+        this.certDir = certDir;
+        this.confDir = confDir;
+    }
+
+    /**
+     * Generates a private CA and a server certificate, writes the ClickHouse SSL configuration and
+     * starts a ClickHouse container with HTTPS enabled.
+     */
+    public static SecureServerSupport start(String image) throws Exception {
+        Path certDir = Files.createTempDirectory("ch-ssl-example-certs-");
+        Path confDir = Files.createTempDirectory("ch-ssl-example-config-");
+        Path sslConfig = confDir.resolve("zzz_ssl.xml");
+
+        log.info("Generating an ephemeral private CA and a server certificate in {}", certDir);
+        generatePrivateCaAndServerCertificate(certDir);
+        writeClickHouseSslConfig(sslConfig);
+        // The TLS material must be readable by the 'clickhouse' user inside the container,
+        // while temp directories are created accessible to the current user only.
+        makeReadableByContainer(certDir);
+        makeReadableByContainer(confDir);
+
+        log.info("Starting ClickHouse container from image: {}", image);
+        GenericContainer<?> container = new GenericContainer<>(image)
+                .withExposedPorts(HTTP_PORT, HTTPS_PORT)
+                .withEnv("CLICKHOUSE_USER", USER)
+                .withEnv("CLICKHOUSE_PASSWORD", PASSWORD)
+                .withFileSystemBind(certDir.toAbsolutePath().toString(),
+                        "/etc/clickhouse-server/certs", BindMode.READ_ONLY)
+                .withFileSystemBind(sslConfig.toAbsolutePath().toString(),
+                        "/etc/clickhouse-server/config.d/zzz_ssl.xml", BindMode.READ_ONLY)
+                .waitingFor(Wait.forHttp("/ping")
+                        .forPort(HTTP_PORT)
+                        .forStatusCode(200)
+                        .withStartupTimeout(Duration.ofMinutes(3)));
+        try {
+            container.start();
+        } catch (Exception e) {
+            log.error("ClickHouse container failed to start. Container logs:\n{}", safeGetLogs(container));
+            deleteRecursively(certDir);
+            deleteRecursively(confDir);
+            throw e;
+        }
+        log.info("ClickHouse container is ready on https://localhost:{}", container.getMappedPort(HTTPS_PORT));
+        return new SecureServerSupport(container, certDir, confDir);
+    }
+
+    /** JDBC URL of the started container (HTTPS). */
+    public String getJdbcUrl() {
+        return "jdbc:clickhouse://localhost:" + container.getMappedPort(HTTPS_PORT) + "/default?ssl=true";
+    }
+
+    /** Path to the CA certificate (PEM) that signed the server certificate. */
+    public String getCaCertPath() {
+        return certDir.resolve("ca.crt").toAbsolutePath().toString();
+    }
+
+    @Override
+    public void close() {
+        log.info("Stopping ClickHouse container and deleting temporary TLS artifacts");
+        container.stop();
+        deleteRecursively(certDir);
+        deleteRecursively(confDir);
+    }
+
+    private static void generatePrivateCaAndServerCertificate(Path outputDir) throws Exception {
+        KeyPair caKeys = generateRsaKeyPair();
+        X500Name caSubject = new X500Name("CN=ExamplePrivateCA");
+        X509Certificate caCertificate = generateCertificate(caSubject, caSubject,
+                caKeys.getPublic(), caKeys.getPrivate(), caKeys.getPublic(), true, null);
+
+        KeyPair serverKeys = generateRsaKeyPair();
+        X500Name serverSubject = new X500Name("CN=localhost");
+        GeneralNames serverSans = new GeneralNames(new GeneralName[]{
+                new GeneralName(GeneralName.dNSName, "localhost"),
+                new GeneralName(GeneralName.iPAddress, "127.0.0.1")
+        });
+        X509Certificate serverCertificate = generateCertificate(serverSubject, caSubject,
+                serverKeys.getPublic(), caKeys.getPrivate(), caKeys.getPublic(), false, serverSans);
+
+        writePemObject(outputDir.resolve("ca.crt"), caCertificate);
+        writePemObject(outputDir.resolve("server.crt"), serverCertificate);
+        writePemObject(outputDir.resolve("server.key"), serverKeys.getPrivate());
+    }
+
+    private static KeyPair generateRsaKeyPair() throws Exception {
+        KeyPairGenerator keyPairGenerator = KeyPairGenerator.getInstance("RSA");
+        keyPairGenerator.initialize(2048, SECURE_RANDOM);
+        return keyPairGenerator.generateKeyPair();
+    }
+
+    private static X509Certificate generateCertificate(
+            X500Name subject,
+            X500Name issuer,
+            PublicKey subjectPublicKey,
+            PrivateKey issuerPrivateKey,
+            PublicKey issuerPublicKey,
+            boolean isCa,
+            GeneralNames subjectAlternativeNames) throws Exception {
+        Date notBefore = new Date(System.currentTimeMillis() - 60_000L);
+        Date notAfter = new Date(System.currentTimeMillis() + Duration.ofDays(CERTIFICATE_DAYS_VALID).toMillis());
+        BigInteger serial = new BigInteger(160, SECURE_RANDOM).abs().add(BigInteger.ONE);
+
+        X509v3CertificateBuilder certBuilder = new JcaX509v3CertificateBuilder(
+                issuer, serial, notBefore, notAfter, subject, subjectPublicKey);
+        certBuilder.addExtension(Extension.basicConstraints, true, new BasicConstraints(isCa));
+        certBuilder.addExtension(Extension.keyUsage, true, new KeyUsage(isCa
+                ? KeyUsage.keyCertSign | KeyUsage.cRLSign
+                : KeyUsage.digitalSignature | KeyUsage.keyEncipherment));
+
+        JcaX509ExtensionUtils extensionUtils = new JcaX509ExtensionUtils();
+        certBuilder.addExtension(Extension.subjectKeyIdentifier, false,
+                extensionUtils.createSubjectKeyIdentifier(subjectPublicKey));
+        certBuilder.addExtension(Extension.authorityKeyIdentifier, false,
+                extensionUtils.createAuthorityKeyIdentifier(issuerPublicKey));
+        if (subjectAlternativeNames != null) {
+            certBuilder.addExtension(Extension.subjectAlternativeName, false, subjectAlternativeNames);
+        }
+
+        ContentSigner signer = new JcaContentSignerBuilder("SHA256withRSA")
+                .setProvider(BC_PROVIDER)
+                .build(issuerPrivateKey);
+        X509Certificate certificate = new JcaX509CertificateConverter()
+                .setProvider(BC_PROVIDER)
+                .getCertificate(certBuilder.build(signer));
+        certificate.checkValidity(new Date());
+        certificate.verify(issuerPublicKey);
+        return certificate;
+    }
+
+    private static void writePemObject(Path targetPath, Object value) throws IOException {
+        try (Writer fileWriter = Files.newBufferedWriter(targetPath, StandardCharsets.US_ASCII);
+             JcaPEMWriter pemWriter = new JcaPEMWriter(fileWriter)) {
+            pemWriter.writeObject(value);
+        }
+    }
+
+    /**
+     * Writes a config.d overlay enabling the HTTPS interface. The full description of the
+     * server-side options is in the official documentation:
+     * https://clickhouse.com/docs/en/guides/sre/configuring-ssl
+     */
+    private static void writeClickHouseSslConfig(Path configPath) throws IOException {
+        String config = "<clickhouse>\n"
+                + "    <https_port>" + HTTPS_PORT + "</https_port>\n"
+                + "    <openSSL>\n"
+                + "        <server>\n"
+                + "            <certificateFile>/etc/clickhouse-server/certs/server.crt</certificateFile>\n"
+                + "            <privateKeyFile>/etc/clickhouse-server/certs/server.key</privateKeyFile>\n"
+                + "            <verificationMode>none</verificationMode>\n"
+                + "            <loadDefaultCAFile>true</loadDefaultCAFile>\n"
+                + "            <disableProtocols>sslv2,sslv3</disableProtocols>\n"
+                + "            <preferServerCiphers>true</preferServerCiphers>\n"
+                + "        </server>\n"
+                + "    </openSSL>\n"
+                + "</clickhouse>\n";
+        Files.write(configPath, config.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static void makeReadableByContainer(Path dir) throws IOException {
+        try (Stream<Path> targets = Files.walk(dir)) {
+            for (Path target : targets.toArray(Path[]::new)) {
+                File file = target.toFile();
+                if (!file.setReadable(true, false)) {
+                    log.warn("Failed to make {} world-readable", target);
+                }
+                if (Files.isDirectory(target) && !file.setExecutable(true, false)) {
+                    log.warn("Failed to make {} world-executable", target);
+                }
+            }
+        }
+    }
+
+    private static String safeGetLogs(GenericContainer<?> container) {
+        try {
+            return container.getLogs();
+        } catch (Exception e) {
+            return "<not available: " + e.getMessage() + ">";
+        }
+    }
+
+    private static void deleteRecursively(Path path) {
+        if (path == null || !Files.exists(path)) {
+            return;
+        }
+        try (Stream<Path> targets = Files.walk(path)) {
+            targets.sorted((left, right) -> right.getNameCount() - left.getNameCount())
+                    .forEach(target -> {
+                        try {
+                            Files.deleteIfExists(target);
+                        } catch (IOException ignored) {
+                            // Best effort cleanup for temporary example files.
+                        }
+                    });
+        } catch (IOException ignored) {
+            // Best effort cleanup for temporary example files.
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Adds example for case when self-signed certificate is used and it is passed to the client config
- Test for only CA cert is passed in client configuration (mocked server). 
- Examples added to `client-v2` and `jdbc` projects and use testcontainer with specially configured server. Also allows run against user configured endpoint 

This PR is part 1 in series of changes for SSL support and different configurations. 

 
## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> HttpAPIClientHelper drops the SPI-style SSL provider in favor of a fixed default implementation, which is a small TLS wiring change in production code; most of the PR is examples and tests.
> 
> **Overview**
> Adds **client-v2** and **JDBC** runnable examples for HTTPS when the server chain is signed by a **private CA**, using `setRootCertificate` / `sslrootcert` without a JVM trust store. Local runs spin up Docker ClickHouse with ephemeral certs via new `SSLExamples` and `SecureServerSupport`; standalone mode targets a user-supplied host and CA PEM path. READMEs document both modes and manual OpenSSL/Docker setup.
> 
> **client-v2** gains an integration test (`testCustomCaCertificate`) that builds a CA-signed server cert, serves HTTPS with WireMock, and asserts a client with only the root CA can ping/query while the default-trust client fails. **HttpAPIClientHelper** wires TLS through an instance of `ClickHouseDefaultSslContextProvider` instead of the pluggable `ClickHouseSslContextProvider` lookup (behavior for trust store vs cert paths unchanged). Test/example modules add BouncyCastle and Testcontainers; `.gitignore` ignores generated cert/key artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ac5a16f24765e8c8cfe4238a5b9acd70500fe2f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->