### PR TITLE
SSL Certificates input as string 

### DIFF
--- a/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseDefaultSslContextProvider.java
+++ b/clickhouse-client/src/main/java/com/clickhouse/client/config/ClickHouseDefaultSslContextProvider.java
@@ -1,6 +1,22 @@
 package com.clickhouse.client.config;
 
-import java.io.*;
+import com.clickhouse.client.ClickHouseConfig;
+import com.clickhouse.client.ClickHouseSslContextProvider;
+import com.clickhouse.data.ClickHouseUtils;
+
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.KeyManagerFactory;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLException;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.KeyManagementException;
 import java.security.KeyStore;
@@ -18,23 +34,29 @@ import java.security.spec.PKCS8EncodedKeySpec;
 import java.util.Base64;
 import java.util.Optional;
 
-import javax.net.ssl.KeyManager;
-import javax.net.ssl.KeyManagerFactory;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLException;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.TrustManagerFactory;
-import javax.net.ssl.X509TrustManager;
-
-import com.clickhouse.client.ClickHouseConfig;
-import com.clickhouse.client.ClickHouseSslContextProvider;
-import com.clickhouse.data.ClickHouseUtils;
-
 @Deprecated
 public class ClickHouseDefaultSslContextProvider implements ClickHouseSslContextProvider {
     static final String PEM_HEADER_PREFIX = "---BEGIN ";
     static final String PEM_HEADER_SUFFIX = " PRIVATE KEY---";
     static final String PEM_FOOTER_PREFIX = "---END ";
+
+    /** Standard PEM encapsulation boundary (RFC 7468). Present in any PEM content, never in a file path. */
+    static final String PEM_BEGIN_MARKER = "-----BEGIN";
+
+    /**
+     * Opens a stream over PEM material that may be supplied either as a file path (also searched in the home
+     * directory and on the classpath) or directly as PEM content.
+     *
+     * @param certOrContent file path or PEM content of a certificate or a private key
+     * @return stream over the PEM content
+     * @throws IOException when the value is a path and the file cannot be opened
+     */
+    static InputStream getCertificateInputStream(String certOrContent) throws IOException {
+        if (certOrContent.contains(PEM_BEGIN_MARKER)) {
+            return new ByteArrayInputStream(certOrContent.getBytes(StandardCharsets.US_ASCII));
+        }
+        return ClickHouseUtils.getFileInputStream(certOrContent);
+    }
 
     /**
      * An insecure {@link javax.net.ssl.TrustManager}, that don't validate the
@@ -71,7 +93,7 @@ public class ClickHouseDefaultSslContextProvider implements ClickHouseSslContext
         String algorithm = (String) ClickHouseDefaults.SSL_KEY_ALGORITHM.getEffectiveDefaultValue();
         StringBuilder builder = new StringBuilder();
         try (BufferedReader reader = new BufferedReader(
-                new InputStreamReader(ClickHouseUtils.getFileInputStream(keyFile)))) {
+                new InputStreamReader(getCertificateInputStream(keyFile)))) {
             String line = reader.readLine();
             if (line != null) {
                 algorithm = getAlgorithm(line, algorithm);
@@ -102,7 +124,7 @@ public class ClickHouseDefaultSslContextProvider implements ClickHouseSslContext
                     ClickHouseUtils.format("%s KeyStore not available", KeyStore.getDefaultType()));
         }
 
-        try (InputStream in = ClickHouseUtils.getFileInputStream(cert)) {
+        try (InputStream in = getCertificateInputStream(cert)) {
             CertificateFactory factory = CertificateFactory
                     .getInstance((String) ClickHouseDefaults.SSL_CERTIFICATE_TYPE.getEffectiveDefaultValue());
             if (key == null || key.isEmpty()) {

--- a/clickhouse-client/src/test/java/com/clickhouse/client/config/ClickHouseDefaultSslContextProviderTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/config/ClickHouseDefaultSslContextProviderTest.java
@@ -1,28 +1,20 @@
 package com.clickhouse.client.config;
 
-import java.io.ByteArrayOutputStream;
+import com.clickhouse.data.ClickHouseUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
 import java.io.FileNotFoundException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.security.KeyStore;
 import java.security.PrivateKey;
 
-import com.clickhouse.data.ClickHouseUtils;
-
-import org.testng.Assert;
-import org.testng.annotations.Test;
-
 public class ClickHouseDefaultSslContextProviderTest {
     static String readTestResource(String name) throws Exception {
-        ByteArrayOutputStream out = new ByteArrayOutputStream();
         try (InputStream in = ClickHouseUtils.getFileInputStream(name)) {
-            byte[] buffer = new byte[2048];
-            int read;
-            while ((read = in.read(buffer)) != -1) {
-                out.write(buffer, 0, read);
-            }
+            return new String(in.readAllBytes(), StandardCharsets.US_ASCII);
         }
-        return new String(out.toByteArray(), StandardCharsets.US_ASCII);
     }
 
     @Test(groups = { "unit" })

--- a/clickhouse-client/src/test/java/com/clickhouse/client/config/ClickHouseDefaultSslContextProviderTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/config/ClickHouseDefaultSslContextProviderTest.java
@@ -56,6 +56,9 @@ public class ClickHouseDefaultSslContextProviderTest {
         PrivateKey fromContent = ClickHouseDefaultSslContextProvider
                 .getPrivateKey(readTestResource("pkey4test.pem"));
         Assert.assertEquals(fromContent, fromFile);
+        Assert.assertEquals(fromContent.getAlgorithm(), fromFile.getAlgorithm());
+        Assert.assertEquals(fromContent.getFormat(), fromFile.getFormat());
+        Assert.assertEquals(fromContent.getEncoded(), fromFile.getEncoded());
     }
 
     @Test(groups = { "unit" })

--- a/clickhouse-client/src/test/java/com/clickhouse/client/config/ClickHouseDefaultSslContextProviderTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/config/ClickHouseDefaultSslContextProviderTest.java
@@ -1,9 +1,30 @@
 package com.clickhouse.client.config;
 
+import java.io.ByteArrayOutputStream;
+import java.io.FileNotFoundException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.KeyStore;
+import java.security.PrivateKey;
+
+import com.clickhouse.data.ClickHouseUtils;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 public class ClickHouseDefaultSslContextProviderTest {
+    static String readTestResource(String name) throws Exception {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        try (InputStream in = ClickHouseUtils.getFileInputStream(name)) {
+            byte[] buffer = new byte[2048];
+            int read;
+            while ((read = in.read(buffer)) != -1) {
+                out.write(buffer, 0, read);
+            }
+        }
+        return new String(out.toByteArray(), StandardCharsets.US_ASCII);
+    }
+
     @Test(groups = { "unit" })
     public void testGetAlgorithm() {
         Assert.assertEquals(ClickHouseDefaultSslContextProvider.getAlgorithm("", null), null);
@@ -18,5 +39,42 @@ public class ClickHouseDefaultSslContextProviderTest {
     public void testGetPrivateKey() throws Exception {
         // openssl genpkey -out pkey4test.pem -algorithm RSA -pkeyopt rsa_keygen_bits:2048
         Assert.assertNotNull(ClickHouseDefaultSslContextProvider.getPrivateKey("pkey4test.pem"));
+    }
+
+    @Test(groups = { "unit" })
+    public void testGetCertificateInputStream() throws Exception {
+        String pemContent = readTestResource("client.crt");
+        try (InputStream in = ClickHouseDefaultSslContextProvider.getCertificateInputStream(pemContent)) {
+            byte[] buffer = new byte[pemContent.length()];
+            int read = in.read(buffer);
+            Assert.assertEquals(new String(buffer, 0, read, StandardCharsets.US_ASCII), pemContent);
+        }
+
+        try (InputStream in = ClickHouseDefaultSslContextProvider.getCertificateInputStream("client.crt")) {
+            Assert.assertTrue(in.read() != -1);
+        }
+
+        Assert.assertThrows(FileNotFoundException.class,
+                () -> ClickHouseDefaultSslContextProvider.getCertificateInputStream("non-existent.crt"));
+    }
+
+    @Test(groups = { "unit" })
+    public void testGetPrivateKeyFromPemContent() throws Exception {
+        PrivateKey fromFile = ClickHouseDefaultSslContextProvider.getPrivateKey("pkey4test.pem");
+        PrivateKey fromContent = ClickHouseDefaultSslContextProvider
+                .getPrivateKey(readTestResource("pkey4test.pem"));
+        Assert.assertEquals(fromContent, fromFile);
+    }
+
+    @Test(groups = { "unit" })
+    public void testGetKeyStoreFromPemContent() throws Exception {
+        ClickHouseDefaultSslContextProvider provider = new ClickHouseDefaultSslContextProvider();
+
+        KeyStore trustStore = provider.getKeyStore(readTestResource("client.crt"), null);
+        Assert.assertNotNull(trustStore.getCertificate("cert1"));
+
+        KeyStore keyStore = provider.getKeyStore(readTestResource("some_user.crt"),
+                readTestResource("some_user.key"));
+        Assert.assertNotNull(keyStore.getKey("key", null));
     }
 }

--- a/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/HttpTransportTests.java
@@ -2186,7 +2186,7 @@ public class HttpTransportTests extends BaseIntegrationTest {
     @DataProvider(name = "testCustomCaCertificateProvider")
     public static Object[][] testCustomCaCertificateProvider() {
         return new Object[][]{
-                // TODO: decide if we need to support certificates via string {true},
+                {true},
                 {false}};
     }
 

--- a/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/SSLExamples.java
+++ b/examples/client-v2/src/main/java/com/clickhouse/examples/client_v2/SSLExamples.java
@@ -4,6 +4,10 @@ import com.clickhouse.client.api.Client;
 import com.clickhouse.client.api.query.GenericRecord;
 import lombok.extern.slf4j.Slf4j;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 
 /**
@@ -15,6 +19,9 @@ import java.util.List;
  *     the CA certificate is passed with {@link Client.Builder#setRootCertificate(String)}.
  *     No trust store configuration is needed: the certificate is added to a trust store
  *     used only by this client, so the JVM default trust store stays untouched.</li>
+ *     <li>Passing the CA certificate as a PEM string instead of a file path - useful when the
+ *     certificate comes from an environment variable or a secret manager (typical for
+ *     Kubernetes/cloud deployments) and you do not want to write it to disk.</li>
  * </ul>
  *
  * <p>More SSL examples (mTLS, trust stores, SNI) will be added to this class later.</p>
@@ -58,7 +65,9 @@ public class SSLExamples {
             }
 
             log.info("Running in standalone mode against {}:{}", host, port);
-            connectWithCustomRootCertificate("https://" + host + ":" + port, database, user, password, rootCert);
+            String endpoint = "https://" + host + ":" + port;
+            connectWithCustomRootCertificate(endpoint, database, user, password, rootCert);
+            connectWithRootCertificateAsString(endpoint, database, user, password, rootCert);
             return;
         }
 
@@ -68,6 +77,8 @@ public class SSLExamples {
         log.info("Running in local mode (set -DchHost to verify your own server)");
         try (SecureServerSupport server = SecureServerSupport.start(image)) {
             connectWithCustomRootCertificate(server.getEndpoint(), database,
+                    SecureServerSupport.USER, SecureServerSupport.PASSWORD, server.getCaCertPath());
+            connectWithRootCertificateAsString(server.getEndpoint(), database,
                     SecureServerSupport.USER, SecureServerSupport.PASSWORD, server.getCaCertPath());
         } catch (Exception e) {
             log.error("Failed to run the SSL example against a local Docker server", e);
@@ -100,6 +111,50 @@ public class SSLExamples {
                     rows.get(0).getString("version"));
         } catch (Exception e) {
             log.error("Secure connection with a custom root CA certificate failed", e);
+        }
+    }
+
+    /**
+     * Same as {@link #connectWithCustomRootCertificate}, but the CA certificate is passed as PEM
+     * content instead of a file path. {@link Client.Builder#setRootCertificate(String)} accepts both:
+     * any value containing a {@code -----BEGIN ...-----} block is treated as PEM content.
+     *
+     * <p>This is handy when the certificate is delivered through an environment variable or
+     * a secret manager (e.g. a Kubernetes secret projected into {@code CLICKHOUSE_CA_CERT}),
+     * so the application never has to write it to disk:</p>
+     *
+     * <pre>{@code
+     * String caPem = System.getenv("CLICKHOUSE_CA_CERT");
+     * Client client = new Client.Builder().setRootCertificate(caPem)...
+     * }</pre>
+     */
+    static void connectWithRootCertificateAsString(String endpoint, String database, String user, String password,
+                                                   String rootCertPath) {
+        final String rootCertPem;
+        try {
+            // In a real application the PEM content would typically come from an env variable
+            // or a secret manager; here we simply read the file generated for this example.
+            rootCertPem = new String(Files.readAllBytes(Paths.get(rootCertPath)), StandardCharsets.US_ASCII);
+        } catch (IOException e) {
+            log.error("Failed to read the CA certificate from {}", rootCertPath, e);
+            return;
+        }
+
+        log.info("Connecting to {} using root CA certificate passed as a PEM string", endpoint);
+        try (Client client = new Client.Builder()
+                .addEndpoint(endpoint)
+                .setUsername(user)
+                .setPassword(password)
+                .setDefaultDatabase(database)
+                // PEM content, not a path - detected by the "-----BEGIN" marker.
+                .setRootCertificate(rootCertPem)
+                .build()) {
+
+            List<GenericRecord> rows = client.queryAll("SELECT currentUser() AS user, version() AS version");
+            log.info("Connected securely (CA cert as string) as '{}' to ClickHouse {}",
+                    rows.get(0).getString("user"), rows.get(0).getString("version"));
+        } catch (Exception e) {
+            log.error("Secure connection with a CA certificate passed as a string failed", e);
         }
     }
 

--- a/examples/jdbc/src/main/java/com/clickhouse/examples/jdbc/SSLExamples.java
+++ b/examples/jdbc/src/main/java/com/clickhouse/examples/jdbc/SSLExamples.java
@@ -4,6 +4,10 @@ import com.clickhouse.client.api.ClientConfigProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
@@ -20,6 +24,9 @@ import java.util.Properties;
  *     the CA certificate is passed with the {@code sslrootcert} connection property.
  *     No trust store configuration is needed: the certificate is added to a trust store
  *     used only by this connection, so the JVM default trust store stays untouched.</li>
+ *     <li>Passing the CA certificate as a PEM string instead of a file path - useful when the
+ *     certificate comes from an environment variable or a secret manager (typical for
+ *     Kubernetes/cloud deployments) and you do not want to write it to disk.</li>
  * </ul>
  *
  * <p>More SSL examples (mTLS, trust stores, SNI) will be added to this class later.</p>
@@ -62,7 +69,8 @@ public class SSLExamples {
             log.info("Running in standalone mode against {}", url);
             try {
                 connectWithCustomRootCertificate(url, user, password, rootCert);
-            } catch (SQLException e) {
+                connectWithRootCertificateAsString(url, user, password, rootCert);
+            } catch (SQLException | IOException e) {
                 log.error("Secure connection with a custom root CA certificate failed", e);
             }
             return;
@@ -74,6 +82,8 @@ public class SSLExamples {
         log.info("Running in local mode (set -DchUrl to verify your own server)");
         try (SecureServerSupport server = SecureServerSupport.start(image)) {
             connectWithCustomRootCertificate(server.getJdbcUrl(),
+                    SecureServerSupport.USER, SecureServerSupport.PASSWORD, server.getCaCertPath());
+            connectWithRootCertificateAsString(server.getJdbcUrl(),
                     SecureServerSupport.USER, SecureServerSupport.PASSWORD, server.getCaCertPath());
         } catch (Exception e) {
             log.error("Failed to run the SSL example against a local Docker server", e);
@@ -105,6 +115,44 @@ public class SSLExamples {
              ResultSet rs = stmt.executeQuery("SELECT currentUser() AS user, version() AS version")) {
             if (rs.next()) {
                 log.info("Connected securely as '{}' to ClickHouse {}", rs.getString("user"), rs.getString("version"));
+            }
+        }
+    }
+
+    /**
+     * Same as {@link #connectWithCustomRootCertificate}, but the CA certificate is passed as PEM
+     * content instead of a file path. The {@code sslrootcert} property accepts both: any value
+     * containing a {@code -----BEGIN ...-----} block is treated as PEM content.
+     *
+     * <p>This is handy when the certificate is delivered through an environment variable or
+     * a secret manager (e.g. a Kubernetes secret projected into {@code CLICKHOUSE_CA_CERT}),
+     * so the application never has to write it to disk:</p>
+     *
+     * <pre>{@code
+     * properties.setProperty("sslrootcert", System.getenv("CLICKHOUSE_CA_CERT"));
+     * }</pre>
+     */
+    static void connectWithRootCertificateAsString(String url, String user, String password, String rootCertPath)
+            throws SQLException, IOException {
+        // In a real application the PEM content would typically come from an env variable
+        // or a secret manager; here we simply read the file generated for this example.
+        String rootCertPem = new String(Files.readAllBytes(Paths.get(rootCertPath)), StandardCharsets.US_ASCII);
+
+        log.info("Connecting to {} using root CA certificate passed as a PEM string", url);
+
+        Properties properties = new Properties();
+        properties.setProperty(ClientConfigProperties.USER.getKey(), user); // user
+        properties.setProperty(ClientConfigProperties.PASSWORD.getKey(), password); // password
+        properties.setProperty("ssl", "true"); // enable TLS even if the URL has no https scheme
+        // PEM content, not a path - detected by the "-----BEGIN" marker.
+        properties.setProperty(ClientConfigProperties.CA_CERTIFICATE.getKey(), rootCertPem); // sslrootcert
+
+        try (Connection connection = DriverManager.getConnection(url, properties);
+             Statement stmt = connection.createStatement();
+             ResultSet rs = stmt.executeQuery("SELECT currentUser() AS user, version() AS version")) {
+            if (rs.next()) {
+                log.info("Connected securely (CA cert as string) as '{}' to ClickHouse {}",
+                        rs.getString("user"), rs.getString("version"));
             }
         }
     }


### PR DESCRIPTION
## Summary

Client has support of SSL certificates and keys passed as path to file. This PR adds support of certificates passed as plain string. 
 This change allows more safely and easier to use client in k8s environment secrets are passed as env. variables and no writable disk so not possible to create a tmp file with certificate. 
Along the changes examples for jdbc and client are added.

## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes TLS trust/material parsing in a security-sensitive path, though behavior for file paths is preserved and PEM detection is narrow; misclassification of a path containing `-----BEGIN` is unlikely but would break file resolution.
> 
> **Overview**
> SSL certificate, root CA, and private key settings can now be supplied as **inline PEM text** as well as file paths. `ClickHouseDefaultSslContextProvider` adds `getCertificateInputStream`: if the value contains `-----BEGIN`, it is read from memory; otherwise behavior is unchanged (classpath/home/file path).
> 
> That path is wired through **private key** and **keystore** loading, so JDBC `sslrootcert` / client cert+key and Client v2 `setRootCertificate` (and related mTLS settings) work with env vars or secrets without writing temp files.
> 
> **Tests and docs:** unit coverage for PEM vs path; integration test `testCustomCaCertificate` now runs with CA passed as a string; JDBC and Client-v2 `SSLExamples` demonstrate PEM-string root CA usage.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d49e2741e54db98e2a3825bb44b4b2c781e376fd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->