### PR TITLE
Added pr triage workflow

### DIFF
--- a/.github/workflows/claude-pr-triage.yml
+++ b/.github/workflows/claude-pr-triage.yml
@@ -63,62 +63,48 @@ jobs:
 
         - **Public API shape** changed — return types, reader/result columns,
           serialization layout, anything that could silently break consumers.
-        - **Type system** — changes in `ClickHouse.Driver/Types/`, especially
-          `TypeConverter.cs`, type grammar parsers, or binary read/write paths.
-          Read AND write paths must usually move together; if only one side moves,
-          that's also a Concern.
-        - **Binary protocol / `Copy/`** — serialization layout or framing changes.
-        - **Connection pool / `Http/`** — lifecycle, pooling, streaming-vs-buffering
-          changes.
-        - **Concurrency** — new locks, atomics, `Interlocked`, `lock`,
-          `SemaphoreSlim`, `Volatile`, `Memory<T>` aliasing, or any change that
-          could introduce a deadlock or race.
-        - **Performance** — slow code in the hot path, new allocations, or any use
-          of reflection.
+        - **Type system** — changes in `com.clickhouse.data` package.
+        - **Readers** and **Writers** — changes in client-v2 readers and writers.
+        - **Concurrency** — itroduction of new synchronization primitives, usnig non-threadsafe collections,
+          synchronization on static object (big no-no). 
+        - **Performance** — using reflection, new object creation, synchronized collection in hot-path.
         - **Recursion** introduced into hot paths or applied to unbounded inputs
           (e.g. nested type parsing).
         - **Cross-module refactor** — touches three or more of `clickhouse-data/`, `clickhouse-client/`,
           `clickhouse-http-client/`, `clickhouse-jdbc/`, `clickhouse-r2dbc/`, `client-v2/`, `jdbc-v2/`.
         - **Security** — auth, certificate, credential, or trust-boundary handling
           change; potential SQL injection; logging that could leak PII or secrets
-          (URLs, headers, query parameters).
-        - **Major version bump** of a transport or crypto dependency (e.g.
-          `System.Net.Http`, `System.Security.Cryptography.*`, `BouncyCastle`).
-        - **`FeatureSwitch` / `ClickHouseFeatureMap`** — multi-version compatibility
+          (URLs, headers, query parameters); input validation, especially when done with regexp or 3rd-party libraries;
+          Usage of `String.format`;
+        - **Major version bump** of any dependency.
+        - **Missing Feature Flag** — new feature in existing logic added without feature flag; multi-version compatibility
           surface.
         - **Permission change for the repo** — change of code owners, extracting
           GitHub variables, or any other unauthorized act.
         - **Changes to release workflow** — any change to the GitHub action for
           releasing a package.
+        - **Large diff** - more than 400 lines of code or many changed files. Request split.
 
         ## Medium risk
 
         Any one (only if no High rule fired):
 
-        - **Behavioral change in a single hot-path module** (`clickhouse-data/`, `clickhouse-client/`,
-          `clickhouse-http-client/`, `clickhouse-jdbc/`, `clickhouse-r2dbc/`, `client-v2/`, `jdbc-v2/`).
-        - **New connection-string setting**, or **changed default value** of an
-          existing setting.
-        - **Algorithm change with measurable performance implication** — flag a
-          benchmark request against `ClickHouse.Driver.Benchmark`.
-        - **Logging changes** — level promotion, hot-path logging, message-format
-          change.
-        - **Test-infra changes** that affect how the matrix runs.
+        - **Behavioral change in a single hot-path module** (`clickhouse-data/`, `client-v2/`, `jdbc-v2/`).
+        - **New connection-string setting**, or **changed default value** of an existing setting.
+        - **Algorithm change with measurable performance implication** — flag a benchmark request against library.
+        - **Logging changes** — level promotion, hot-path logging, message-format change.
+        - **Test-infra changes** - when affects scope of tests (modules excluded, version excluded and no new added).
         - **Major version dependency bump.**
         - **Minor dependency bump** on a security-sensitive package.
-        - **Large diff** without obvious reason (~500+ LoC across ~15+ files).
-        - **Multi-framework guard** added (`#if NET10_0_OR_GREATER` etc.) on a
-          non-trivial code path.
         - **GitHub workflow changes** — any other changes in the `.github` directory.
 
         ## Low risk
 
         Default if neither set fires:
 
-        - Doc-only / comment-only.
+        - Updates in `docs/` AGENTS.md, CHANGELOG.md and similar files. No sources changed.
         - Minor patch dependency bump from Dependabot, CI green, no CVE in changelog.
-        - Isolated bug fix with a regression test in a non-hot-path file.
-        - Test-only additions (no source changes).
+        - Test-only additions. No sources changed.
         - CI-only tweaks that don't change build/release output.
 
         ## Reviewer-action policy
@@ -126,6 +112,6 @@ jobs:
         Emit one "Required reviewer action" line matching the assigned risk:
         - low — AI review with no comments → eligible for auto-merge per repo policy.
         - medium — at least one human reviewer.
-        - high — PR body must include an architectural description before review.
+        - high — at least one human reviewer.
     secrets:
       ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}

--- a/.github/workflows/claude-pr-triage.yml
+++ b/.github/workflows/claude-pr-triage.yml
@@ -2,8 +2,8 @@ name: PR Triage
 on:
   pull_request:
     types: [ ready_for_review, synchronize ]
-  pull_request_review_comment:
-    types: [created ]
+  issue_comment:
+    types: [ created ]
 
 permissions:
   contents: read
@@ -11,18 +11,20 @@ permissions:
   pull-requests: write
 
 concurrency:
-  group: claude-triage-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  group: claude-triage-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: true
 
 jobs:
   triage:
     if: |
       startsWith(github.repository, 'ClickHouse/') &&
       (
-        github.event_name == 'schedule' ||
-        github.event_name == 'workflow_dispatch' ||
-        github.event_name == 'pull_request' || 
         (
-          github.event_name == 'pull_request_review_comment' &&
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.draft == false
+        ) ||
+        (
+          github.event_name == 'issue_comment' &&
           github.event.issue.pull_request != null &&
           github.event.sender.type != 'Bot' &&
           github.event.comment.user.type != 'Bot' &&
@@ -30,9 +32,9 @@ jobs:
           contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
         )
       )
-    uses: ClickHouse/integrations-shared-workflows/.github/workflows/claude-pr-triage.yml@main
+    uses: ClickHouse/integrations-shared-workflows/.github/workflows/claude-pr-triage.yml@3d91ad26a6d8e9164eb120fb0433ec2defd5c68a
     with:
-      pr_number: ${{ github.event.inputs.pr_number }}
+      pr_number: ${{ github.event.pull_request.number || github.event.issue.number }}
       triage_instructions: |
         ## Category meanings
 

--- a/.github/workflows/claude-pr-triage.yml
+++ b/.github/workflows/claude-pr-triage.yml
@@ -2,7 +2,7 @@ name: PR Triage
 on:
   pull_request:
     types: [ ready_for_review, synchronize ]
-  issue_comment:
+  pull_request_review_comment:
     types: [created ]
 
 permissions:
@@ -22,7 +22,7 @@ jobs:
         github.event_name == 'workflow_dispatch' ||
         github.event_name == 'pull_request' || 
         (
-          github.event_name == 'issue_comment' &&
+          github.event_name == 'pull_request_review_comment' &&
           github.event.issue.pull_request != null &&
           github.event.sender.type != 'Bot' &&
           github.event.comment.user.type != 'Bot' &&

--- a/.github/workflows/claude-pr-triage.yml
+++ b/.github/workflows/claude-pr-triage.yml
@@ -2,7 +2,7 @@ name: PR Triage
 on:
   pull_request:
     types: [ ready_for_review, synchronize ]
-  pull_request_review_comment:
+  issue_comment:
     types: [created ]
 
 permissions:
@@ -17,8 +17,9 @@ jobs:
       (
         github.event_name == 'schedule' ||
         github.event_name == 'workflow_dispatch' ||
+        github.event_name == 'pull_request' || 
         (
-          github.event_name == 'pull_request' &&
+          github.event_name == 'issue_comment' &&
           github.event.issue.pull_request != null &&
           github.event.sender.type != 'Bot' &&
           github.event.comment.user.type != 'Bot' &&
@@ -70,8 +71,8 @@ jobs:
           of reflection.
         - **Recursion** introduced into hot paths or applied to unbounded inputs
           (e.g. nested type parsing).
-        - **Cross-module refactor** — touches three or more of `ADO/`, `Types/`,
-          `Utility/`, `Http/`, `Copy/`.
+        - **Cross-module refactor** — touches three or more of `clickhouse-data/`, `clickhouse-client/`,
+          `clickhouse-http-client/`, `clickhouse-jdbc/`, `clickhouse-r2dbc/`, `client-v2/`, `jdbc-v2/`.
         - **Security** — auth, certificate, credential, or trust-boundary handling
           change; potential SQL injection; logging that could leak PII or secrets
           (URLs, headers, query parameters).
@@ -88,8 +89,8 @@ jobs:
 
         Any one (only if no High rule fired):
 
-        - **Behavioral change in a single hot-path module** (`ADO/`, `Types/`,
-          `Utility/`).
+        - **Behavioral change in a single hot-path module** (`clickhouse-data/`, `clickhouse-client/`,
+          `clickhouse-http-client/`, `clickhouse-jdbc/`, `clickhouse-r2dbc/`, `client-v2/`, `jdbc-v2/`).
         - **New connection-string setting**, or **changed default value** of an
           existing setting.
         - **Algorithm change with measurable performance implication** — flag a

--- a/.github/workflows/claude-pr-triage.yml
+++ b/.github/workflows/claude-pr-triage.yml
@@ -10,6 +10,9 @@ permissions:
   issues: read
   pull-requests: write
 
+concurrency:
+  group: claude-triage-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+
 jobs:
   triage:
     if: |
@@ -29,6 +32,7 @@ jobs:
       )
     uses: ClickHouse/integrations-shared-workflows/.github/workflows/claude-pr-triage.yml@main
     with:
+      pr_number: ${{ github.event.inputs.pr_number }}
       triage_instructions: |
         ## Category meanings
 

--- a/.github/workflows/claude-pr-triage.yml
+++ b/.github/workflows/claude-pr-triage.yml
@@ -1,0 +1,124 @@
+name: PR Triage
+on:
+  pull_request:
+    types: [ ready_for_review, synchronize ]
+  pull_request_review_comment:
+    types: [created ]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: write
+
+jobs:
+  triage:
+    if: |
+      startsWith(github.repository, 'ClickHouse/') &&
+      (
+        github.event_name == 'schedule' ||
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event_name == 'pull_request' &&
+          github.event.issue.pull_request != null &&
+          github.event.sender.type != 'Bot' &&
+          github.event.comment.user.type != 'Bot' &&
+          startsWith(github.event.comment.body, '/triage') &&
+          contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+        )
+      )
+    uses: ClickHouse/integrations-shared-workflows/.github/workflows/claude-pr-triage.yml@main
+    with:
+      triage_instructions: |
+        ## Category meanings
+
+        | Category | When |
+        |---|---|
+        | `bugfix` | Fixes a defect. Should have a regression test. |
+        | `feature` | New capability — new type, new API surface, new format. |
+        | `refactor` | Internal restructuring, no behavior change intended. |
+        | `perf` | Performance optimization. |
+        | `deps` | Dependency bump (NuGet, GitHub Actions). |
+        | `docs` | README / XML doc / CHANGELOG / RELEASENOTES only. |
+        | `tests` | Test-only changes, no source change. |
+        | `infra` | CI, build scripts, tooling, llm workflows. |
+
+        If multiple apply, pick the most consequential (`bugfix`/`feature` outrank
+        `refactor`; `perf` outranks `refactor` if measurable).
+
+        Flag intent drift (in Concerns) if:
+        - Files touched are out of scope vs. the issue/body.
+        - Multiple unrelated concerns are bundled in one PR.
+        - A significant non-trivial change has no linked issue.
+
+        ## High risk
+
+        Any one is sufficient:
+
+        - **Public API shape** changed — return types, reader/result columns,
+          serialization layout, anything that could silently break consumers.
+        - **Type system** — changes in `ClickHouse.Driver/Types/`, especially
+          `TypeConverter.cs`, type grammar parsers, or binary read/write paths.
+          Read AND write paths must usually move together; if only one side moves,
+          that's also a Concern.
+        - **Binary protocol / `Copy/`** — serialization layout or framing changes.
+        - **Connection pool / `Http/`** — lifecycle, pooling, streaming-vs-buffering
+          changes.
+        - **Concurrency** — new locks, atomics, `Interlocked`, `lock`,
+          `SemaphoreSlim`, `Volatile`, `Memory<T>` aliasing, or any change that
+          could introduce a deadlock or race.
+        - **Performance** — slow code in the hot path, new allocations, or any use
+          of reflection.
+        - **Recursion** introduced into hot paths or applied to unbounded inputs
+          (e.g. nested type parsing).
+        - **Cross-module refactor** — touches three or more of `ADO/`, `Types/`,
+          `Utility/`, `Http/`, `Copy/`.
+        - **Security** — auth, certificate, credential, or trust-boundary handling
+          change; potential SQL injection; logging that could leak PII or secrets
+          (URLs, headers, query parameters).
+        - **Major version bump** of a transport or crypto dependency (e.g.
+          `System.Net.Http`, `System.Security.Cryptography.*`, `BouncyCastle`).
+        - **`FeatureSwitch` / `ClickHouseFeatureMap`** — multi-version compatibility
+          surface.
+        - **Permission change for the repo** — change of code owners, extracting
+          GitHub variables, or any other unauthorized act.
+        - **Changes to release workflow** — any change to the GitHub action for
+          releasing a package.
+
+        ## Medium risk
+
+        Any one (only if no High rule fired):
+
+        - **Behavioral change in a single hot-path module** (`ADO/`, `Types/`,
+          `Utility/`).
+        - **New connection-string setting**, or **changed default value** of an
+          existing setting.
+        - **Algorithm change with measurable performance implication** — flag a
+          benchmark request against `ClickHouse.Driver.Benchmark`.
+        - **Logging changes** — level promotion, hot-path logging, message-format
+          change.
+        - **Test-infra changes** that affect how the matrix runs.
+        - **Major version dependency bump.**
+        - **Minor dependency bump** on a security-sensitive package.
+        - **Large diff** without obvious reason (~500+ LoC across ~15+ files).
+        - **Multi-framework guard** added (`#if NET10_0_OR_GREATER` etc.) on a
+          non-trivial code path.
+        - **GitHub workflow changes** — any other changes in the `.github` directory.
+
+        ## Low risk
+
+        Default if neither set fires:
+
+        - Doc-only / comment-only.
+        - Minor patch dependency bump from Dependabot, CI green, no CVE in changelog.
+        - Isolated bug fix with a regression test in a non-hot-path file.
+        - Test-only additions (no source changes).
+        - CI-only tweaks that don't change build/release output.
+
+        ## Reviewer-action policy
+
+        Emit one "Required reviewer action" line matching the assigned risk:
+        - low — AI review with no comments → eligible for auto-merge per repo policy.
+        - medium — at least one human reviewer.
+        - high — PR body must include an architectural description before review.
+    secrets:
+      ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}


### PR DESCRIPTION
## Summary
- Adds calling shared workflow to triage PRs
- Adds command `/triage` to call on some PR

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only addition with no library or runtime behavior changes; it consumes an existing org secret and follows the same reusable-workflow pattern as other `.github` workflows.
> 
> **Overview**
> Adds a **PR Triage** GitHub Actions workflow that runs automated Claude-based triage for non-draft PRs on `ClickHouse/*` repos when a PR becomes ready or is updated, and on demand when a trusted collaborator posts `/triage` on the PR thread.
> 
> The workflow delegates to a pinned reusable workflow in `ClickHouse/integrations-shared-workflows` and passes repo-specific **`triage_instructions`**: PR category labels (`bugfix`, `feature`, `infra`, etc.), ClickHouse .NET driver **high/medium/low risk** heuristics (API, types, protocol, security, `.github` changes, and more), and **required reviewer actions** tied to risk level. It uses `pull-requests: write`, per-PR concurrency with cancel-in-progress, and `ANTHROPIC_API_KEY`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bf30b5352a76eeb8b4afa851d069bdfcd6963d38. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->