### PR TITLE
[JDBC-v2] Readonly Profile tests 

### DIFF
--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -138,7 +138,9 @@ Prefer the smallest safe optimization that preserves behavior.
 ## Tests and docs
 
 **Note**: carefully evaluate tests that involve creating database, users and deal with `GRANT` operations. If user is created within test 
-it must have secure random password. This password should never be logged or accessible externally. User should be deleted in the `finally` block. If `GRANT` is executted then it must be against test database only. Question if `GRANT ALL` should be used. Test can be run against cloud instance and it is crucial to review what is created in database. Flag any unusuall things in queries.
+it must have secure random password. This password should never be logged or accessible externally. User should be deleted in the `finally` block. 
+If `GRANT` is executed then it must be against test database only. Question if `GRANT ALL` should be used. Test can be run against cloud instance, 
+and it is crucial to review what is created in database. Flag any unusual things in queries.
 
 Call out missing focused tests when a change affects:
 

--- a/docs/ai-review.md
+++ b/docs/ai-review.md
@@ -137,6 +137,9 @@ Prefer the smallest safe optimization that preserves behavior.
 
 ## Tests and docs
 
+**Note**: carefully evaluate tests that involve creating database, users and deal with `GRANT` operations. If user is created within test 
+it must have secure random password. This password should never be logged or accessible externally. User should be deleted in the `finally` block. If `GRANT` is executted then it must be against test database only. Question if `GRANT ALL` should be used. Test can be run against cloud instance and it is crucial to review what is created in database. Flag any unusuall things in queries.
+
 Call out missing focused tests when a change affects:
 
 - public API behavior

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/JdbcDataTypeTests.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/JdbcDataTypeTests.java
@@ -2863,12 +2863,23 @@ public class JdbcDataTypeTests extends JdbcIntegrationTest {
 
                 assertTrue(rs.next());
                 Object jsonObj = rs.getObject(1);
+                assertTrue(jsonObj instanceof Map, "JSON should be read as a Map");
+                Map<String, Object> jsonMap = (Map<String, Object>) jsonObj;
+                
                 if (expected == null) {
                     expected = jsonToClientMap(json);
                 }
-                assertEquals(jsonObj, expected);
+                Map<String, Object> expectedMap = (Map<String, Object>) expected;
+                
+                assertEquals(jsonMap, expectedMap);
+                for (Map.Entry<String, Object> entry : expectedMap.entrySet()) {
+                    assertTrue(jsonMap.containsKey(entry.getKey()), "Map should contain key: " + entry.getKey());
+                    assertEquals(jsonMap.get(entry.getKey()), entry.getValue(), "Values should match for key: " + entry.getKey());
+                }
+
                 assertTrue(rs.next());
                 Object emptyJsonObj = rs.getObject(1);
+                assertTrue(emptyJsonObj instanceof Map, "Empty JSON should be returned as Map");
                 assertEquals(emptyJsonObj, EMPTY_JSON);
                 assertFalse(rs.next());
             }

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/ReadonlyProfileTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/ReadonlyProfileTest.java
@@ -12,20 +12,25 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Properties;
+import java.util.UUID;
 
 public class ReadonlyProfileTest extends JdbcIntegrationTest {
 
+    private String password;
+
     @BeforeClass(groups = { "integration" })
     public void setup() throws SQLException {
+        password = UUID.randomUUID().toString();
         com.clickhouse.client.ClickHouseServerForTest.beforeSuite();
         try (Connection conn = getJdbcConnection();
              Statement stmt = conn.createStatement()) {
             stmt.execute("CREATE SETTINGS PROFILE IF NOT EXISTS profile_readonly_1 SETTINGS readonly=1");
             stmt.execute("CREATE SETTINGS PROFILE IF NOT EXISTS profile_readonly_2 SETTINGS readonly=2");
-            stmt.execute("CREATE USER IF NOT EXISTS user_readonly_1 IDENTIFIED WITH no_password SETTINGS PROFILE profile_readonly_1");
-            stmt.execute("CREATE USER IF NOT EXISTS user_readonly_2 IDENTIFIED WITH no_password SETTINGS PROFILE profile_readonly_2");
-            stmt.execute("GRANT SELECT ON *.* TO user_readonly_1");
-            stmt.execute("GRANT SELECT ON *.* TO user_readonly_2");
+            stmt.execute("CREATE USER IF NOT EXISTS user_readonly_1 IDENTIFIED WITH plaintext_password BY '" + password + "' SETTINGS PROFILE profile_readonly_1");
+            stmt.execute("CREATE USER IF NOT EXISTS user_readonly_2 IDENTIFIED WITH plaintext_password BY '" + password + "' SETTINGS PROFILE profile_readonly_2");
+            String db = getDatabase();
+            stmt.execute("GRANT SELECT ON " + db + ".* TO user_readonly_1");
+            stmt.execute("GRANT SELECT ON " + db + ".* TO user_readonly_2");
         }
     }
 
@@ -44,7 +49,7 @@ public class ReadonlyProfileTest extends JdbcIntegrationTest {
     public void testReadonly1CannotChangeSettings() throws Exception {
         Properties properties = new Properties();
         properties.setProperty("user", "user_readonly_1");
-        properties.setProperty("password", "");
+        properties.setProperty("password", password);
         properties.put(ClientConfigProperties.serverSetting(ServerSettings.OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING), "1");
         
         try (Connection conn = getJdbcConnection(properties)) {
@@ -65,7 +70,7 @@ public class ReadonlyProfileTest extends JdbcIntegrationTest {
 
         Properties properties = new Properties();
         properties.setProperty("user", "user_readonly_2");
-        properties.setProperty("password", "");
+        properties.setProperty("password", password);
         properties.put(ClientConfigProperties.serverSetting(ServerSettings.OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING), "1");
         properties.put(ClientConfigProperties.serverSetting("allow_experimental_json_type"), "1");
         

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/ReadonlyProfileTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/ReadonlyProfileTest.java
@@ -20,7 +20,9 @@ public class ReadonlyProfileTest extends JdbcIntegrationTest {
 
     @BeforeClass(groups = { "integration" })
     public void setup() throws SQLException {
-        password = UUID.randomUUID().toString();
+        // Append fixed character classes so the random password satisfies server
+        // password-complexity policies (uppercase, lowercase, digit, special).
+        password = UUID.randomUUID().toString() + "Aa1!";
         com.clickhouse.client.ClickHouseServerForTest.beforeSuite();
         try (Connection conn = getJdbcConnection();
              Statement stmt = conn.createStatement()) {

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/ReadonlyProfileTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/ReadonlyProfileTest.java
@@ -24,13 +24,15 @@ public class ReadonlyProfileTest extends JdbcIntegrationTest {
         com.clickhouse.client.ClickHouseServerForTest.beforeSuite();
         try (Connection conn = getJdbcConnection();
              Statement stmt = conn.createStatement()) {
-            stmt.execute("CREATE SETTINGS PROFILE IF NOT EXISTS profile_readonly_1 SETTINGS readonly=1");
-            stmt.execute("CREATE SETTINGS PROFILE IF NOT EXISTS profile_readonly_2 SETTINGS readonly=2");
-            stmt.execute("CREATE USER IF NOT EXISTS user_readonly_1 IDENTIFIED WITH plaintext_password BY '" + password + "' SETTINGS PROFILE profile_readonly_1");
-            stmt.execute("CREATE USER IF NOT EXISTS user_readonly_2 IDENTIFIED WITH plaintext_password BY '" + password + "' SETTINGS PROFILE profile_readonly_2");
+            stmt.execute("CREATE SETTINGS PROFILE IF NOT EXISTS jdbc_test_profile_readonly_1 SETTINGS readonly=1");
+            stmt.execute("CREATE SETTINGS PROFILE IF NOT EXISTS jdbc_test_profile_readonly_2 SETTINGS readonly=2");
+            stmt.execute("DROP USER IF EXISTS jdbc_test_user_readonly_1");
+            stmt.execute("DROP USER IF EXISTS jdbc_test_user_readonly_2");
+            stmt.execute("CREATE USER jdbc_test_user_readonly_1 IDENTIFIED WITH plaintext_password BY '" + password + "' SETTINGS PROFILE jdbc_test_profile_readonly_1");
+            stmt.execute("CREATE USER jdbc_test_user_readonly_2 IDENTIFIED WITH plaintext_password BY '" + password + "' SETTINGS PROFILE jdbc_test_profile_readonly_2");
             String db = getDatabase();
-            stmt.execute("GRANT SELECT ON " + db + ".* TO user_readonly_1");
-            stmt.execute("GRANT SELECT ON " + db + ".* TO user_readonly_2");
+            stmt.execute("GRANT SELECT ON " + db + ".* TO jdbc_test_user_readonly_1");
+            stmt.execute("GRANT SELECT ON " + db + ".* TO jdbc_test_user_readonly_2");
         }
     }
 
@@ -38,17 +40,17 @@ public class ReadonlyProfileTest extends JdbcIntegrationTest {
     public void teardown() throws SQLException {
         try (Connection conn = getJdbcConnection();
              Statement stmt = conn.createStatement()) {
-            stmt.execute("DROP USER IF EXISTS user_readonly_1");
-            stmt.execute("DROP USER IF EXISTS user_readonly_2");
-            stmt.execute("DROP SETTINGS PROFILE IF EXISTS profile_readonly_1");
-            stmt.execute("DROP SETTINGS PROFILE IF EXISTS profile_readonly_2");
+            stmt.execute("DROP USER IF EXISTS jdbc_test_user_readonly_1");
+            stmt.execute("DROP USER IF EXISTS jdbc_test_user_readonly_2");
+            stmt.execute("DROP SETTINGS PROFILE IF EXISTS jdbc_test_profile_readonly_1");
+            stmt.execute("DROP SETTINGS PROFILE IF EXISTS jdbc_test_profile_readonly_2");
         }
     }
 
     @Test(groups = { "integration" })
     public void testReadonly1CannotChangeSettings() throws Exception {
         Properties properties = new Properties();
-        properties.setProperty("user", "user_readonly_1");
+        properties.setProperty("user", "jdbc_test_user_readonly_1");
         properties.setProperty("password", password);
         properties.put(ClientConfigProperties.serverSetting(ServerSettings.OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING), "1");
         
@@ -69,7 +71,7 @@ public class ReadonlyProfileTest extends JdbcIntegrationTest {
         }
 
         Properties properties = new Properties();
-        properties.setProperty("user", "user_readonly_2");
+        properties.setProperty("user", "jdbc_test_user_readonly_2");
         properties.setProperty("password", password);
         properties.put(ClientConfigProperties.serverSetting(ServerSettings.OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING), "1");
         properties.put(ClientConfigProperties.serverSetting("allow_experimental_json_type"), "1");

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/ReadonlyProfileTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/ReadonlyProfileTest.java
@@ -1,0 +1,80 @@
+package com.clickhouse.jdbc;
+
+import com.clickhouse.client.api.ClientConfigProperties;
+import com.clickhouse.client.api.internal.ServerSettings;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Properties;
+
+public class ReadonlyProfileTest extends JdbcIntegrationTest {
+
+    @BeforeClass(groups = { "integration" })
+    public void setup() throws SQLException {
+        com.clickhouse.client.ClickHouseServerForTest.beforeSuite();
+        try (Connection conn = getJdbcConnection();
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("CREATE SETTINGS PROFILE IF NOT EXISTS profile_readonly_1 SETTINGS readonly=1");
+            stmt.execute("CREATE SETTINGS PROFILE IF NOT EXISTS profile_readonly_2 SETTINGS readonly=2");
+            stmt.execute("CREATE USER IF NOT EXISTS user_readonly_1 IDENTIFIED WITH no_password SETTINGS PROFILE profile_readonly_1");
+            stmt.execute("CREATE USER IF NOT EXISTS user_readonly_2 IDENTIFIED WITH no_password SETTINGS PROFILE profile_readonly_2");
+            stmt.execute("GRANT SELECT ON *.* TO user_readonly_1");
+            stmt.execute("GRANT SELECT ON *.* TO user_readonly_2");
+        }
+    }
+
+    @AfterClass(groups = { "integration" })
+    public void teardown() throws SQLException {
+        try (Connection conn = getJdbcConnection();
+             Statement stmt = conn.createStatement()) {
+            stmt.execute("DROP USER IF EXISTS user_readonly_1");
+            stmt.execute("DROP USER IF EXISTS user_readonly_2");
+            stmt.execute("DROP SETTINGS PROFILE IF EXISTS profile_readonly_1");
+            stmt.execute("DROP SETTINGS PROFILE IF EXISTS profile_readonly_2");
+        }
+    }
+
+    @Test(groups = { "integration" })
+    public void testReadonly1CannotChangeSettings() throws Exception {
+        Properties properties = new Properties();
+        properties.setProperty("user", "user_readonly_1");
+        properties.setProperty("password", "");
+        properties.put(ClientConfigProperties.serverSetting(ServerSettings.OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING), "1");
+        
+        try (Connection conn = getJdbcConnection(properties)) {
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT 1")) {
+                Assert.fail("Should have thrown an exception because readonly=1 prevents changing settings");
+            }
+        } catch (SQLException e) {
+            Assert.assertTrue(e.getMessage().contains("Cannot modify"), "Exception message should indicate setting cannot be modified: " + e.getMessage());
+        }
+    }
+
+    @Test(groups = { "integration" })
+    public void testReadonly2CanChangeSettings() throws Exception {
+        if (isVersionMatch("(,24.8]")) {
+            return; // JSON was introduced in 24.10
+        }
+
+        Properties properties = new Properties();
+        properties.setProperty("user", "user_readonly_2");
+        properties.setProperty("password", "");
+        properties.put(ClientConfigProperties.serverSetting(ServerSettings.OUTPUT_FORMAT_BINARY_WRITE_JSON_AS_STRING), "1");
+        properties.put(ClientConfigProperties.serverSetting("allow_experimental_json_type"), "1");
+        
+        try (Connection conn = getJdbcConnection(properties)) {
+            try (Statement stmt = conn.createStatement();
+                 ResultSet rs = stmt.executeQuery("SELECT '{\"key\":\"value\"}'::JSON")) {
+                Assert.assertTrue(rs.next());
+                Assert.assertEquals(rs.getString(1), "{\"key\":\"value\"}");
+            }
+        }
+    }
+}

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/ReadonlyProfileTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/ReadonlyProfileTest.java
@@ -21,6 +21,9 @@ public class ReadonlyProfileTest extends JdbcIntegrationTest {
 
     @BeforeClass(groups = { "integration" })
     public void setup() throws SQLException {
+        if (isCloud()) {
+            return;
+        }
         // Append fixed character classes so the random password satisfies server
         // password-complexity policies (uppercase, lowercase, digit, special).
         password = UUID.randomUUID().toString() + "Aa1!";
@@ -41,6 +44,9 @@ public class ReadonlyProfileTest extends JdbcIntegrationTest {
 
     @AfterClass(groups = { "integration" })
     public void teardown() throws SQLException {
+        if (isCloud()) {
+            return;
+        }
         try (Connection conn = getJdbcConnection();
              Statement stmt = conn.createStatement()) {
             stmt.execute("DROP USER IF EXISTS jdbc_test_user_readonly_1");

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/ReadonlyProfileTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/ReadonlyProfileTest.java
@@ -3,6 +3,7 @@ package com.clickhouse.jdbc;
 import com.clickhouse.client.api.ClientConfigProperties;
 import com.clickhouse.client.api.internal.ServerSettings;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -51,6 +52,9 @@ public class ReadonlyProfileTest extends JdbcIntegrationTest {
 
     @Test(groups = { "integration" })
     public void testReadonly1CannotChangeSettings() throws Exception {
+        if (isCloud()) {
+            throw new SkipException("Should not be tested in cloud because creates users and profiles");
+        }
         Properties properties = new Properties();
         properties.setProperty("user", "jdbc_test_user_readonly_1");
         properties.setProperty("password", password);
@@ -68,8 +72,11 @@ public class ReadonlyProfileTest extends JdbcIntegrationTest {
 
     @Test(groups = { "integration" })
     public void testReadonly2CanChangeSettings() throws Exception {
+        if (isCloud()) {
+            throw new SkipException("Should not be tested in cloud because creates users and profiles");
+        }
         if (isVersionMatch("(,24.8]")) {
-            return; // JSON was introduced in 24.10
+            throw new SkipException("Old versions do not support JSON");
         }
 
         Properties properties = new Properties();


### PR DESCRIPTION
## Summary
- Added tests for reaonly profiles in context of setting JSON related settings. 

Closes https://github.com/ClickHouse/clickhouse-java/issues/2760

## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only and documentation changes; no driver or public API behavior changes. Integration tests mutate server users/profiles locally and are skipped on cloud.
> 
> **Overview**
> Adds **integration coverage** for ClickHouse `readonly` settings profiles when the JDBC client sends JSON-related server settings (e.g. `output_format_binary_write_json_as_string`).
> 
> **`ReadonlyProfileTest`** provisions two users with `readonly=1` and `readonly=2`, grants **SELECT** only on the integration test database, and skips on cloud. One case expects a connection/query failure when `readonly=1` blocks overriding settings; the other expects success under `readonly=2` with experimental JSON enabled.
> 
> **`JdbcDataTypeTests.testJSONRead`** now asserts JSON columns from `getObject()` are **`Map`** instances and checks keys/values explicitly (including empty `{}`).
> 
> **`docs/ai-review.md`** adds reviewer notes for tests that create users, use **GRANT**, and handle passwords.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c170d3dad77366d30f9aa9050c86bae7b639a2f7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->