### PR TITLE
Added literal prefix and suffix to getTypeInfo() to be close to v1

### DIFF
--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java
@@ -1451,7 +1451,7 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
         mBuilder.put("LineString", new TypeLiteralInfo("[", "]"));
         mBuilder.put("MultiLineString", new TypeLiteralInfo("[", "]"));
 
-        TYPE_LITERAL_INFO_MAP = mBuilder.buildKeepingLast();
+        TYPE_LITERAL_INFO_MAP = mBuilder.buildOrThrow();
     }
 
     private static final Consumer<Map<String, Object>> TYPE_INFO_LITERAL_FUNCTION = row -> {
@@ -1459,8 +1459,8 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
 
         TypeLiteralInfo literalInfo = TYPE_LITERAL_INFO_MAP.get(typeName);
         if (literalInfo != null) {
-            row.put("LITERAL_PREFIX", literalInfo.prefix);
-            row.put("LITERAL_SUFFIX", literalInfo.suffix);
+            row.put("LITERAL_PREFIX", literalInfo.getPrefix());
+            row.put("LITERAL_SUFFIX", literalInfo.getSuffix());
         }
     };
 

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataImpl.java
@@ -13,6 +13,7 @@ import com.clickhouse.jdbc.internal.ExceptionUtils;
 import com.clickhouse.jdbc.internal.JdbcUtils;
 import com.clickhouse.logging.Logger;
 import com.clickhouse.logging.LoggerFactory;
+import com.google.common.collect.ImmutableMap;
 
 import java.sql.Connection;
 import java.sql.JDBCType;
@@ -1344,9 +1345,129 @@ public class DatabaseMetaDataImpl implements java.sql.DatabaseMetaData, JdbcV2Wr
         row.put("DATA_TYPE", type.getVendorTypeNumber());
     };
 
+    private static class TypeLiteralInfo {
+        private final String prefix;
+        private final String suffix;
+        TypeLiteralInfo(String prefix, String suffix){
+            this.prefix = prefix;
+            this.suffix = suffix;
+        }
+
+        public String getPrefix() {
+            return prefix;
+        }
+
+        public String getSuffix() {
+            return suffix;
+        }
+    }
+
+    private static final Map<String, TypeLiteralInfo> TYPE_LITERAL_INFO_MAP;
+    static {
+        ImmutableMap.Builder<String, TypeLiteralInfo> mBuilder = ImmutableMap.builder();
+        // ---------------------------------------------------------
+        // Core String, Text & Binary Types
+        // ---------------------------------------------------------
+        mBuilder.put("String", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("FixedString", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("UUID", new TypeLiteralInfo("'", "'"));
+
+        // Aliased String/Binary Types from your list
+        mBuilder.put("BINARY", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("NATIONAL CHAR VARYING", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("BINARY VARYING", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("NCHAR LARGE OBJECT", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("NATIONAL CHARACTER VARYING", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("NATIONAL CHARACTER LARGE OBJECT", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("NATIONAL CHAR", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("CHAR LARGE OBJECT", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("CHARACTER VARYING", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("NATIONAL CHARACTER", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("LONGBLOB", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("CHAR VARYING", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("MEDIUMBLOB", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("CLOB", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("LONGTEXT", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("MEDIUMTEXT", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("TINYTEXT", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("NVARCHAR", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("TINYBLOB", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("CHARACTER", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("CHAR", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("BLOB", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("VARCHAR2", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("TEXT", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("NCHAR", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("NCHAR VARYING", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("BINARY LARGE OBJECT", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("VARBINARY", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("BYTEA", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("VARCHAR", new TypeLiteralInfo("'", "'"));
+
+        // ---------------------------------------------------------
+        // Date & Time Types (including aliases)
+        // ---------------------------------------------------------
+        mBuilder.put("DateTime", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("DateTime32", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("DateTime64", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("Date", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("Date32", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("Time", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("Time64", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("TIMESTAMP", new TypeLiteralInfo("'", "'"));
+
+        // ---------------------------------------------------------
+        // Network Types (including aliases)
+        // ---------------------------------------------------------
+        mBuilder.put("IPv4", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("IPv6", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("INET4", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("INET6", new TypeLiteralInfo("'", "'"));
+
+        // ---------------------------------------------------------
+        // Enum Types (including aliases)
+        // ---------------------------------------------------------
+        mBuilder.put("Enum", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("Enum8", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("Enum16", new TypeLiteralInfo("'", "'"));
+        mBuilder.put("ENUM", new TypeLiteralInfo("'", "'"));
+
+        // ---------------------------------------------------------
+        // Complex / Collection Types
+        // ---------------------------------------------------------
+        mBuilder.put("Array", new TypeLiteralInfo("[", "]"));
+        mBuilder.put("Map", new TypeLiteralInfo("{", "}"));
+        mBuilder.put("Tuple", new TypeLiteralInfo("(", ")"));
+        mBuilder.put("AggregateFunction", new TypeLiteralInfo("(", ")"));
+        mBuilder.put("SimpleAggregateFunction", new TypeLiteralInfo("(", ")"));
+
+        // ---------------------------------------------------------
+        // Geo Types
+        // ---------------------------------------------------------
+        mBuilder.put("Point", new TypeLiteralInfo("(", ")"));
+        mBuilder.put("Ring", new TypeLiteralInfo("[", "]"));
+        mBuilder.put("Polygon", new TypeLiteralInfo("[", "]"));
+        mBuilder.put("MultiPolygon", new TypeLiteralInfo("[", "]"));
+        mBuilder.put("LineString", new TypeLiteralInfo("[", "]"));
+        mBuilder.put("MultiLineString", new TypeLiteralInfo("[", "]"));
+
+        TYPE_LITERAL_INFO_MAP = mBuilder.buildKeepingLast();
+    }
+
+    private static final Consumer<Map<String, Object>> TYPE_INFO_LITERAL_FUNCTION = row -> {
+        String typeName = (String) row.get("TYPE_NAME");
+
+        TypeLiteralInfo literalInfo = TYPE_LITERAL_INFO_MAP.get(typeName);
+        if (literalInfo != null) {
+            row.put("LITERAL_PREFIX", literalInfo.prefix);
+            row.put("LITERAL_SUFFIX", literalInfo.suffix);
+        }
+    };
+
     private static final List<Consumer<Map<String, Object>>> GET_TYPE_INFO_MUTATORS = Arrays.asList(
             TYPE_INFO_VALUE_FUNCTION,
-            NULLABILITY_VALUE_FUNCTION
+            NULLABILITY_VALUE_FUNCTION,
+            TYPE_INFO_LITERAL_FUNCTION
     );
 
     private static final String DATA_TYPE_INFO_SQL = getDataTypeInfoSql();

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/metadata/DatabaseMetaDataTest.java
@@ -567,6 +567,47 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
         }
     }
 
+    private static final java.util.Map<ClickHouseDataType, String[]> TYPE_LITERAL_EXPECTATIONS;
+    static {
+        java.util.Map<ClickHouseDataType, String[]> map = new java.util.EnumMap<>(ClickHouseDataType.class);
+        
+        String[] quote = new String[]{"'", "'"};
+        map.put(ClickHouseDataType.String, quote);
+        map.put(ClickHouseDataType.FixedString, quote);
+        map.put(ClickHouseDataType.UUID, quote);
+        map.put(ClickHouseDataType.Date, quote);
+        map.put(ClickHouseDataType.Date32, quote);
+        map.put(ClickHouseDataType.DateTime, quote);
+        map.put(ClickHouseDataType.DateTime32, quote);
+        map.put(ClickHouseDataType.DateTime64, quote);
+        map.put(ClickHouseDataType.Time, quote);
+        map.put(ClickHouseDataType.Time64, quote);
+        map.put(ClickHouseDataType.Enum, quote);
+        map.put(ClickHouseDataType.Enum8, quote);
+        map.put(ClickHouseDataType.Enum16, quote);
+        map.put(ClickHouseDataType.IPv4, quote);
+        map.put(ClickHouseDataType.IPv6, quote);
+
+        String[] bracket = new String[]{"[", "]"};
+        map.put(ClickHouseDataType.Array, bracket);
+        map.put(ClickHouseDataType.Ring, bracket);
+        map.put(ClickHouseDataType.Polygon, bracket);
+        map.put(ClickHouseDataType.MultiPolygon, bracket);
+        map.put(ClickHouseDataType.LineString, bracket);
+        map.put(ClickHouseDataType.MultiLineString, bracket);
+
+        String[] brace = new String[]{"{", "}"};
+        map.put(ClickHouseDataType.Map, brace);
+
+        String[] parenthesis = new String[]{"(", ")"};
+        map.put(ClickHouseDataType.Tuple, parenthesis);
+        map.put(ClickHouseDataType.Point, parenthesis);
+        map.put(ClickHouseDataType.AggregateFunction, parenthesis);
+        map.put(ClickHouseDataType.SimpleAggregateFunction, parenthesis);
+
+        TYPE_LITERAL_EXPECTATIONS = java.util.Collections.unmodifiableMap(map);
+    }
+
     @Test(groups = { "integration" })
     public void testGetTypeInfo() throws Exception {
         try (Connection conn = getJdbcConnection()) {
@@ -638,8 +679,16 @@ public class DatabaseMetaDataTest extends JdbcIntegrationTest {
                     assertEquals(rs.getInt("DATA_TYPE"), rs.getObject("DATA_TYPE"));
 
                     assertEquals(rs.getInt("PRECISION"), dataType.getMaxPrecision());
-                    assertNull(rs.getString("LITERAL_PREFIX"));
-                    assertNull(rs.getString("LITERAL_SUFFIX"));
+                    
+                    String[] expectedLiterals = TYPE_LITERAL_EXPECTATIONS.get(dataType);
+                    if (expectedLiterals != null) {
+                        assertEquals(rs.getString("LITERAL_PREFIX"), expectedLiterals[0]);
+                        assertEquals(rs.getString("LITERAL_SUFFIX"), expectedLiterals[1]);
+                    } else {
+                        assertNull(rs.getString("LITERAL_PREFIX"), "Expected null prefix for " + dataType);
+                        assertNull(rs.getString("LITERAL_SUFFIX"), "Expected null suffix for " + dataType);
+                    }
+                    
                     assertEquals(rs.getInt("MINIMUM_SCALE"), dataType.getMinScale());
                     assertEquals(rs.getInt("MAXIMUM_SCALE"), dataType.getMaxScale());
                     assertNull(rs.getString("CREATE_PARAMS"));


### PR DESCRIPTION
## Summary

- Adds `LITERAL_PREFIX` and `LITERAL_SUFFIX` proper values in `DataBaseMetadata#getTypeInfo` result set. Previously information was all null 
- Adds specific test to verify this information is not changes in the future unnoticed.  


After the change type info looks like (nulls because no string literal should be used) : 
```
--- ALL DATA TYPES SUPPORTED BY ClickHouse (from DatabaseMetaData.getTypeInfo()) ---
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
TYPE_NAME                      | DATA_TYPE | PRECISION       | LITERAL_PREFIX | LITERAL_SUFFIX  | NULLABLE   | CASE_SENS  | SEARCHABLE | CREATE_PARAMS            
------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
AggregateFunction              | 1111   | 0               | '('          | ')'             | NO         | true       | ALL        |                          
Array                          | 2003   | 0               | '['          | ']'             | NO         | true       | ALL        |                          
BFloat16                       | 6      | 3               | null         | null            | NO         | true       | ALL        |                          
Bool                           | 16     | 1               | null         | null            | NO         | false      | ALL        |                          
Date                           | 91     | 10              | '''          | '''             | NO         | false      | ALL        |                          
Date32                         | 91     | 10              | '''          | '''             | NO         | false      | ALL        |                          
DateTime                       | 93     | 29              | '''          | '''             | NO         | false      | ALL        |                          
DateTime32                     | 93     | 19              | '''          | '''             | NO         | false      | ALL        |                          
DateTime64                     | 93     | 29              | '''          | '''             | NO         | false      | ALL        |                          
Decimal                        | 3      | 76              | null         | null            | NO         | false      | ALL        |                          
Decimal128                     | 3      | 38              | null         | null            | NO         | false      | ALL        |                          
Decimal256                     | 3      | 76              | null         | null            | NO         | false      | ALL        |                          
Decimal32                      | 3      | 9               | null         | null            | NO         | false      | ALL        |                          
Decimal64                      | 3      | 18              | null         | null            | NO         | false      | ALL        |                          
Dynamic                        | 1111   | 0               | null         | null            | YES        | true       | ALL        |                          
Enum                           | 12     | 0               | '''          | '''             | NO         | false      | ALL        |                          
Enum16                         | 12     | 0               | '''          | '''             | NO         | true       | ALL        |                          
Enum8                          | 12     | 0               | '''          | '''             | NO         | true       | ALL        |                          
FixedString                    | 12     | 0               | '''          | '''             | NO         | true       | ALL        |                          
Float32                        | 6      | 12              | null         | null            | NO         | true       | ALL        |                          
Float64                        | 8      | 22              | null         | null            | NO         | true       | ALL        |                          
Geometry                       | 2003   | 0               | null         | null            | NO         | true       | ALL        |                          
IPv4                           | 1111   | 10              | '''          | '''             | NO         | true       | ALL        |                          
IPv6                           | 1111   | 39              | '''          | '''             | NO         | true       | ALL        |                          
Int128                         | 2      | 39              | null         | null            | NO         | true       | ALL        |                          
Int16                          | 5      | 5               | null         | null            | NO         | true       | ALL        |                          
Int256                         | 2      | 77              | null         | null            | NO         | true       | ALL        |                          
Int32                          | 4      | 10              | null         | null            | NO         | true       | ALL        |                          
Int64                          | -5     | 19              | null         | null            | NO         | true       | ALL        |                          
Int8                           | -6     | 3               | null         | null            | NO         | true       | ALL        |                          
IntervalDay                    | -5     | 19              | null         | null            | NO         | true       | ALL        |                          
IntervalHour                   | -5     | 19              | null         | null            | NO         | true       | ALL        |                          
IntervalMicrosecond            | -5     | 19              | null         | null            | NO         | true       | ALL        |                          
IntervalMillisecond            | -5     | 19              | null         | null            | NO         | true       | ALL        |                          
IntervalMinute                 | -5     | 19              | null         | null            | NO         | true       | ALL        |                          
IntervalMonth                  | -5     | 19              | null         | null            | NO         | true       | ALL        |                          
IntervalNanosecond             | -5     | 19              | null         | null            | NO         | true       | ALL        |                          
IntervalQuarter                | -5     | 19              | null         | null            | NO         | true       | ALL        |                          
IntervalSecond                 | -5     | 19              | null         | null            | NO         | true       | ALL        |                          
IntervalWeek                   | -5     | 19              | null         | null            | NO         | true       | ALL        |                          
IntervalYear                   | -5     | 19              | null         | null            | NO         | true       | ALL        |                          
JSON                           | 1111   | 0               | null         | null            | NO         | false      | ALL        |                          
LineString                     | 2003   | 0               | '['          | ']'             | NO         | true       | ALL        |                          
LowCardinality                 | 1111   | 0               | null         | null            | NO         | true       | ALL        |                          
Map                            | 1111   | 0               | '{'          | '}'             | NO         | true       | ALL        |                          
MultiLineString                | 2003   | 0               | '['          | ']'             | NO         | true       | ALL        |                          
MultiPolygon                   | 2003   | 0               | '['          | ']'             | NO         | true       | ALL        |                          
Nested                         | 2003   | 0               | null         | null            | NO         | true       | ALL        |                          
Nothing                        | 1111   | 0               | null         | null            | NO         | true       | ALL        |                          
Nullable                       | 1111   | 0               | null         | null            | YES        | true       | ALL        |                          
Point                          | 2003   | 0               | '('          | ')'             | NO         | true       | ALL        |                          
Polygon                        | 2003   | 0               | '['          | ']'             | NO         | true       | ALL        |                          
QBit                           | 1111   | 0               | null         | null            | NO         | true       | ALL        |                          
Ring                           | 2003   | 0               | '['          | ']'             | NO         | true       | ALL        |                          
SimpleAggregateFunction        | 1111   | 0               | '('          | ')'             | NO         | true       | ALL        |                          
String                         | 12     | 0               | '''          | '''             | NO         | true       | ALL        |                          
Time                           | 92     | 9               | '''          | '''             | NO         | false      | ALL        |                          
Time64                         | 92     | 9               | '''          | '''             | NO         | false      | ALL        |                          
Tuple                          | 1111   | 0               | '('          | ')'             | NO         | true       | ALL        |                          
UInt128                        | 2      | 39              | null         | null            | NO         | true       | ALL        |                          
UInt16                         | 4      | 5               | null         | null            | NO         | true       | ALL        |                          
UInt256                        | 2      | 78              | null         | null            | NO         | true       | ALL        |                          
UInt32                         | -5     | 10              | null         | null            | NO         | true       | ALL        |                          
UInt64                         | 2      | 20              | null         | null            | NO         | true       | ALL        |                          
UInt8                          | 5      | 3               | null         | null            | NO         | true       | ALL        |                          
UUID                           | 1111   | 69              | '''          | '''             | NO         | true       | ALL        |                          
Variant                        | 1111   | 0               | null         | null            | NO         | true       | ALL        | 
```


Closes: https://github.com/ClickHouse/clickhouse-java/issues/2743


## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only change to getTypeInfo() result shaping; no query execution or connection behavior changes. Wrong literals could mislead BI/SQL generators but scope is limited to JDBC metadata consumers.
> 
> **Overview**
> **`DatabaseMetaData#getTypeInfo()`** now fills **`LITERAL_PREFIX`** and **`LITERAL_SUFFIX`** per type instead of leaving them always null, aligning JDBC v2 with v1 behavior for tools that build SQL literals from type metadata.
> 
> A static **`TYPE_LITERAL_INFO_MAP`** (Guava `ImmutableMap`) maps ClickHouse type names—and many SQL-style aliases—to quote (`'`), bracket (`[]`), brace (`{}`), or parenthesis delimiters. A new row mutator **`TYPE_INFO_LITERAL_FUNCTION`** runs with the existing `getTypeInfo` post-processors to set those columns when a type is known; numeric and similar types stay null.
> 
> **`testGetTypeInfo`** gains **`TYPE_LITERAL_EXPECTATIONS`** and asserts prefix/suffix per `ClickHouseDataType` so regressions are caught in integration tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7156c2e8bae59bd2a6221cca3857c5f968a57f76. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->