### PR TITLE
Fix client v2 varint overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes 
 
+- **[client-v2]** Fixed binary varint decoding for length and count fields so overflowing or overlong values fail with an `IOException` instead of being decoded into corrupted or negative `int` values. (https://github.com/ClickHouse/clickhouse-java/issues/2902)
+
 - **[client-v2]** Fixed container query parameters being sent unquoted, so `Client.query(sql, params, settings)` binding
   a `List<LocalDate>` (or an array/`Map`) to a placeholder like `{ids:Array(Date)}` was rejected by the server with
   `CANNOT_PARSE_INPUT_ASSERTION_FAILED`. Parameter values are now formatted by

--- a/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReader.java
@@ -959,16 +959,20 @@ public class BinaryStreamReader {
     public static int readVarInt(InputStream input) throws IOException {
         int value = 0;
 
-        for (int i = 0; i < 10; i++) {
+        for (int i = 0; i < 5; i++) {
             byte b = (byte) readByteOrEOF(input);
+            if (i == 4 && (b & 0xF8) != 0) {
+                throw new IOException("VarInt is too large for int");
+            }
+
             value |= (b & 0x7F) << (7 * i);
 
             if ((b & 0x80) == 0) {
-                break;
+                return value;
             }
         }
 
-        return value;
+        throw new IOException("Malformed VarInt");
     }
 
     /**

--- a/client-v2/src/test/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReaderTests.java
+++ b/client-v2/src/test/java/com/clickhouse/client/api/data_formats/internal/BinaryStreamReaderTests.java
@@ -204,4 +204,26 @@ public class BinaryStreamReaderTests {
 
         Assert.assertNull(reader.readValue(column));
     }
+
+    @Test
+    public void testReadVarIntReadsMaxInt() throws IOException {
+        Assert.assertEquals(readVarInt((byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF, (byte) 0x07),
+                Integer.MAX_VALUE);
+    }
+
+    @Test
+    public void testReadVarIntRejectsOverflow() {
+        Assert.assertThrows(IOException.class,
+                () -> readVarInt((byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x08));
+    }
+
+    @Test
+    public void testReadVarIntRejectsOverlongValue() {
+        Assert.assertThrows(IOException.class,
+                () -> readVarInt((byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x80, (byte) 0x01));
+    }
+
+    private static int readVarInt(byte... bytes) throws IOException {
+        return BinaryStreamReader.readVarInt(new ByteArrayInputStream(bytes));
+    }
 }


### PR DESCRIPTION
## Summary
Fixes `BinaryStreamReader.readVarInt` in `client-v2` so malformed or overflowing varints are rejected instead of being decoded into corrupted or negative `int` values.

The previous implementation accumulated into an `int` while looping up to 10 bytes. For bytes after the 5th, Java masks `int` shift distances modulo 32, so overlong varints could corrupt lower bits. It also allowed 5-byte values above `Integer.MAX_VALUE`, which can become negative sizes/counts.

This PR covers one of the cases described in the issue https://github.com/ClickHouse/clickhouse-java/issues/2902.

## Changes

- Limit `readVarInt` decoding to 5 bytes.
- Reject fifth-byte payloads that exceed non-negative `int` range or continue past 5 bytes.
- Add focused tests for:
  - `Integer.MAX_VALUE`
  - overflow above `Integer.MAX_VALUE`
  - overlong varint encoding

## Compatibility

This changes handling of malformed/overflowing binary varints from silent decoding to `IOException`. Valid non-negative `int` varints are unchanged.

## Testing

- `mvn -Duser.timezone=UTC -pl client-v2 -am -Dtest=BinaryStreamReaderTests -Dsurefire.failIfNoSpecifiedTests=false test`
- `mvn -Duser.timezone=UTC -DskipITs clean verify`

## Checklist
- [x] Unit tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG