### PR TITLE
[client-v2] Fix Metrics test to be stable

### DIFF
--- a/client-v2/src/test/java/com/clickhouse/client/metrics/MetricsTest.java
+++ b/client-v2/src/test/java/com/clickhouse/client/metrics/MetricsTest.java
@@ -54,6 +54,7 @@ public class MetricsTest extends BaseIntegrationTest {
                 .serverSetting(ServerSettings.ASYNC_INSERT, "0")
                 .serverSetting(ServerSettings.WAIT_END_OF_QUERY, "1")
                 .registerClientMetrics(meterRegistry, "pool-test")
+                .setKeepAliveTimeout(10, ChronoUnit.SECONDS) // enforce connection cleanup
                 .build()) {
 
             client.ping();
@@ -67,7 +68,11 @@ public class MetricsTest extends BaseIntegrationTest {
             Assert.assertEquals((int) leased.value(), 0);
 
             Runnable task = () -> {
+                final long maxDelay = 15;
+                long t1 = System.currentTimeMillis();
                 try (QueryResponse response = client.query("SELECT 1").get()) {
+                    long t = System.currentTimeMillis() - t1;
+                    Assert.assertTrue(t < maxDelay, "Unexpected delay (t = " + t + ", but expected < " + maxDelay + " ms)");
                     Assert.assertEquals((int) available.value(), 0);
                     Assert.assertEquals((int) leased.value(), 1);
                 } catch (Exception e) {

--- a/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/parser/javacc/ClickHouseSqlUtils.java
+++ b/jdbc-v2/src/main/java/com/clickhouse/jdbc/internal/parser/javacc/ClickHouseSqlUtils.java
@@ -69,7 +69,9 @@ public final class ClickHouseSqlUtils {
                 // Appended 05/27/2026
                 "CURSOR", "DETERMINISTIC", "ESCAPE", "SAMPLES", "STREAM", "UNKNOWN",
                 // Appended 06/10/2026
-                "IPV4_PREFIX_BITS", "IPV6_PREFIX_BITS", "TIMEZONE_HOUR", "TIMEZONE_MINUTE"
+                "IPV4_PREFIX_BITS", "IPV6_PREFIX_BITS", "TIMEZONE_HOUR", "TIMEZONE_MINUTE",
+                // Appended 06/26/2026
+                "ENUM", "HYPOTHETICAL", "WHATIF"
             );
     }
 


### PR DESCRIPTION
## Summary

Server sets keep-alive to 30 seconds. Test expects that client internally closes connection after 15 second. But this is not happening making test failing. Current change overrides connection keep-alive to 10 second. 
This test verify metrics and not keep-alive functionality. 

## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
