### PR TITLE
fix(client-v2): classify insert write failures as transfer errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Bug Fixes 
 
+- **[client-v2]** Fixed POJO insert error classification so transport write failures such as java.net.SocketException:
+  Broken pipe (Write failed) are now surfaced as transfer/network errors instead of being wrapped as
+  DataSerializationException. This only changes the exception type reported for request-body transport failures during
+  Client.insert(...); actual POJO reflection/serialization failures are still reported as DataSerializationException.
+  (https://github.com/ClickHouse/clickhouse-java/issues/2729)
 - **[client-v2]** Fixed binary varint decoding for length and count fields so overflowing or overlong values fail with an `IOException` instead of being decoded into corrupted or negative `int` values. (https://github.com/ClickHouse/clickhouse-java/issues/2902)
 
 - **[client-v2]** Fixed container query parameters being sent unquoted, so `Client.query(sql, params, settings)` binding

--- a/client-v2/src/main/java/com/clickhouse/client/api/Client.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/Client.java
@@ -1392,7 +1392,7 @@ public class Client implements AutoCloseable {
                                         for (POJOFieldSerializer serializer : serializersForTable) {
                                             try {
                                                 serializer.serialize(obj, out);
-                                            } catch (InvocationTargetException | IllegalAccessException | IOException e) {
+                                            } catch (InvocationTargetException | IllegalAccessException e) {
                                                 throw new DataSerializationException(obj, serializer, e);
                                             }
                                         }

--- a/client-v2/src/test/java/com/clickhouse/client/InsertExceptionClassificationTest.java
+++ b/client-v2/src/test/java/com/clickhouse/client/InsertExceptionClassificationTest.java
@@ -1,0 +1,154 @@
+package com.clickhouse.client;
+
+import com.clickhouse.client.api.Client;
+import com.clickhouse.client.api.DataTransferException;
+import com.clickhouse.client.api.internal.HttpAPIClientHelper;
+import com.clickhouse.client.api.metadata.TableSchema;
+import com.clickhouse.client.api.serde.DataSerializationException;
+import com.clickhouse.client.api.transport.Endpoint;
+import com.clickhouse.data.ClickHouseColumn;
+import net.jpountz.lz4.LZ4Factory;
+import org.apache.hc.core5.http.ClassicHttpResponse;
+import org.apache.hc.core5.io.IOCallback;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+import java.net.SocketException;
+import java.util.Collections;
+
+public class InsertExceptionClassificationTest {
+
+    @Test
+    public void insertPojoWriteFailureIsReportedAsDataTransferException() throws Exception {
+        Client client = newClient(new CallbackHttpClientHelper(new ThresholdFailingOutputStream(64,
+                new SocketException("Broken pipe (Write failed)"))));
+        try {
+            client.register(WritePojo.class, new TableSchema("test_table", null, "",
+                    Collections.singletonList(ClickHouseColumn.of("value", "String"))));
+
+            DataTransferException ex = Assert.expectThrows(DataTransferException.class,
+                    () -> client.insert("test_table", Collections.singletonList(new WritePojo(repeat('x', 4096)))));
+
+            Assert.assertTrue(ex.getCause() instanceof SocketException, "Unexpected cause: " + ex.getCause());
+            Assert.assertFalse(hasCause(ex, DataSerializationException.class),
+                    "Network write failure must not be wrapped as DataSerializationException");
+        } finally {
+            client.close();
+        }
+    }
+
+    @Test
+    public void insertPojoGetterFailureRemainsDataSerializationException() throws Exception {
+        Client client = newClient(new CallbackHttpClientHelper(new ByteArrayOutputStream()));
+        try {
+            client.register(BrokenGetterPojo.class, new TableSchema("test_table", null, "",
+                    Collections.singletonList(ClickHouseColumn.of("value", "String"))));
+
+            DataSerializationException ex = Assert.expectThrows(DataSerializationException.class,
+                    () -> client.insert("test_table", Collections.singletonList(new BrokenGetterPojo())));
+
+            Assert.assertNotNull(ex.getCause(), "Expected original reflection failure in cause chain");
+            Assert.assertTrue(ex.getMessage().contains("Failed to serialize data"),
+                    "Unexpected message: " + ex.getMessage());
+        } finally {
+            client.close();
+        }
+    }
+
+    private static Client newClient(HttpAPIClientHelper helper) throws Exception {
+        Client client = new Client.Builder()
+                .addEndpoint("http://localhost:8123")
+                .setUsername("default")
+                .setPassword("")
+                .build();
+
+        Field httpClientHelperField = Client.class.getDeclaredField("httpClientHelper");
+        httpClientHelperField.setAccessible(true);
+        HttpAPIClientHelper original = (HttpAPIClientHelper) httpClientHelperField.get(client);
+        if (original != null) {
+            original.close();
+        }
+        httpClientHelperField.set(client, helper);
+        return client;
+    }
+
+    private static boolean hasCause(Throwable throwable, Class<? extends Throwable> expectedType) {
+        Throwable current = throwable;
+        while (current != null) {
+            if (expectedType.isInstance(current)) {
+                return true;
+            }
+            current = current.getCause();
+        }
+        return false;
+    }
+
+    private static String repeat(char ch, int count) {
+        char[] chars = new char[count];
+        java.util.Arrays.fill(chars, ch);
+        return new String(chars);
+    }
+
+    private static final class CallbackHttpClientHelper extends HttpAPIClientHelper {
+        private final OutputStream outputStream;
+
+        private CallbackHttpClientHelper(OutputStream outputStream) {
+            super(Collections.emptyMap(), null, false, LZ4Factory.fastestJavaInstance());
+            this.outputStream = outputStream;
+        }
+
+        @Override
+        public ClassicHttpResponse executeRequest(Endpoint server, java.util.Map<String, Object> requestConfig,
+                                                  IOCallback<OutputStream> writeCallback) throws Exception {
+            writeCallback.execute(outputStream);
+            return Mockito.mock(ClassicHttpResponse.class);
+        }
+
+        @Override
+        public void close() {
+            // No-op for tests.
+        }
+    }
+
+    private static final class ThresholdFailingOutputStream extends OutputStream {
+        private final int failAfterBytes;
+        private final IOException failure;
+        private int bytesWritten;
+
+        private ThresholdFailingOutputStream(int failAfterBytes, IOException failure) {
+            this.failAfterBytes = failAfterBytes;
+            this.failure = failure;
+        }
+
+        @Override
+        public void write(int b) throws IOException {
+            if (bytesWritten >= failAfterBytes) {
+                throw failure;
+            }
+            bytesWritten++;
+        }
+    }
+
+    public static final class WritePojo {
+        private final String value;
+
+        public WritePojo(String value) {
+            this.value = value;
+        }
+
+        public String getValue() {
+            return value;
+        }
+    }
+
+    public static final class BrokenGetterPojo {
+        public String getValue() {
+            throw new IllegalStateException("boom");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #2729

This PR fixes exception classification for POJO inserts in `client-v2`.

Previously, `Client.insert(...)` could wrap request-body write failures such as
`java.net.SocketException: Broken pipe (Write failed)` into
`DataSerializationException` while serializing POJOs. That made transport failures
look like serialization bugs.

This change stops catching `IOException` inside the POJO field serialization loop,
so write-time network failures continue through the transport error path and are
reported as `DataTransferException` instead.

Actual POJO reflection/serialization failures are unchanged and still surface as
`DataSerializationException`.

Compatibility impact:
This is a bug fix with no public API signature change. The only user-visible behavior
change is the exception type reported for request-body transport failures during
`Client.insert(...)`.

Tests:
- Added a regression test for a broken-pipe style write failure during POJO insert
- Added a regression test to preserve `DataSerializationException` for real getter failures

Local verification:
- `mvn -pl client-v2 -am -DskipITs=true -Dtest=InsertExceptionClassificationTest -Dsurefire.failIfNoSpecifiedTests=false test`

## Checklist
- [x] Closes #2729
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials