### PR TITLE
Fix JDBC parser parameter counting for empty comments and SELECT * EXCEPT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,9 @@
   inserted data or failing with a server-side `SYNTAX_ERROR`. Escape sequences are now recognized only outside of quoted
   text, and a `{fn ...}` escape is unwrapped at its matching closing brace, so nested braces (e.g. a `{name:Type}` query
   parameter or a nested escape) stay balanced. (https://github.com/ClickHouse/clickhouse-java/issues/2995)
+- **[jdbc-v2]** Fixed prepared statements losing parameter markers after an empty `--` comment line or after
+  `SELECT * EXCEPT (...)`, which caused parameter binding to fail with `ArrayIndexOutOfBoundsException` for the
+  affected SQL parser backends. (https://github.com/ClickHouse/clickhouse-java/issues/3052)
 - **[client-v2]** Fixed LZ4 input streams not closing their underlying HTTP response stream. Closing an LZ4 stream
   returned by `QueryResponse.getInputStream()` now releases the wrapped transport stream, including after a partial
   read. (https://github.com/ClickHouse/clickhouse-java/issues/2985)

--- a/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseUtils.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/ClickHouseUtils.java
@@ -1150,7 +1150,7 @@ public final class ClickHouseUtils {
      */
     public static int skipSingleLineComment(String args, int startIndex, int len) {
         int index = args.indexOf('\n', startIndex);
-        return index > startIndex ? index + 1 : len;
+        return index >= startIndex ? index + 1 : len;
     }
 
     /**

--- a/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseUtilsTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/ClickHouseUtilsTest.java
@@ -239,6 +239,9 @@ public class ClickHouseUtilsTest {
                 args.indexOf('\n') + 1);
         Assert.assertEquals(ClickHouseUtils.skipSingleLineComment(args, args.indexOf("--", 11), args.length()),
                 args.length());
+
+        args = "--\nselect 1";
+        Assert.assertEquals(ClickHouseUtils.skipSingleLineComment(args, 2, args.length()), 3);
     }
 
     @Test(groups = { "unit" })

--- a/jdbc-v2/src/main/antlr4/com/clickhouse/jdbc/internal/parser/antlr4/ClickHouseParser.g4
+++ b/jdbc-v2/src/main/antlr4/com/clickhouse/jdbc/internal/parser/antlr4/ClickHouseParser.g4
@@ -1051,10 +1051,15 @@ columnExprList
     ;
 
 columnsExpr
-    : (tableIdentifier DOT)? ASTERISK # ColumnsExprAsterisk
+    : (tableIdentifier DOT)? ASTERISK columnExceptExpr? # ColumnsExprAsterisk
     | LPAREN selectUnionStmt RPAREN   # ColumnsExprSubquery
     // NOTE: asterisk and subquery goes before |columnExpr| so that we can mark them as multi-column expressions.
     | columnExpr # ColumnsExprColumn
+    ;
+
+columnExceptExpr
+    : EXCEPT (STRING_LITERAL | (LPAREN STRING_LITERAL RPAREN))                         # ColumnExceptExprRegexp
+    | EXCEPT (identifier | (LPAREN identifier (COMMA identifier)* RPAREN))             # ColumnExceptExprIdentifiers
     ;
 
 columnExpr

--- a/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/BaseSqlParserFacadeTest.java
+++ b/jdbc-v2/src/test/java/com/clickhouse/jdbc/internal/BaseSqlParserFacadeTest.java
@@ -408,6 +408,9 @@ public abstract class BaseSqlParserFacadeTest {
                 {"CREATE TABLE check_query_log (N UInt32,S String) Engine = MergeTree", 0},
                 {"CREATE TABLE check_query_log (N UInt32,S String) Engine = ReplacingMergeTree", 0},
                 {"select abs(log(e()) - 1) < 1e-8", 0},
+                {"--\nselect count(*) from numbers(10) where number = ?", 1},
+                {"select count(*) from (\n--\nselect 1 as a) x where x.a = ?", 1},
+                {"select count(*) from ( select * EXCEPT (b), b as c from ( select 1 as a, 2 as b ) ) x where x.a = ?", 1},
                 {"SELECT SearchEngineID, ClientIP, count() AS c, sum(Refresh), avg(ResolutionWidth) " +
                         " FROM test.hits_s3 WHERE SearchPhrase != '' GROUP BY SearchEngineID, ClientIP " +
                         "   ORDER BY c DESC LIMIT 10", 0},


### PR DESCRIPTION
## Summary

- fix single-line comment scanning when a bare `--` is followed immediately by a newline, so later JDBC parameter markers are still discovered
- extend the bundled ANTLR4 grammar to accept `SELECT * EXCEPT (...)`, including identifier-list and regular-expression forms
- add regression coverage for top-level and nested empty comments and `SELECT * EXCEPT (...)` across all three SQL parser backends
- document the user-visible fix in `CHANGELOG.md`

Closes #3052

## Root cause

`ClickHouseUtils.skipSingleLineComment` treated a newline located exactly at its start index as if no newline existed, causing the parameter scanner to skip the rest of the SQL. Separately, the bundled ANTLR4 grammar accepted `*` in a select list but did not model ClickHouse's `EXCEPT` modifier, so the parse-tree-based backend never reached a later `?` marker.

## User impact and compatibility

Prepared statements containing either construct now report the correct parameter count and can bind normally instead of failing with `ArrayIndexOutOfBoundsException`. This does not change public APIs, configuration, wire protocols, or binary compatibility.

## Validation

- `mvn -pl jdbc-v2 -am -DskipTests install` — passed under JDK 17
- `mvn -pl jdbc-v2 test` — 1,331 tests passed
- `mvn -pl clickhouse-data test` — 1,554 tests passed, 113 conditionally skipped, 0 failures/errors

## Checklist

- [x] Closes #3052
- [x] Unit tests cover the affected parser scenarios
- [x] A human-readable changelog entry was added
