### PR TITLE
Fix clickhouse-data: make NonBlockingPipedOutputStream.close() idempotent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -240,6 +240,11 @@
   performs the handshake and runs the post-close action; a concurrent or repeated `close()` returns immediately. A
   `close()` which fails while flushing the remaining data also marks the stream closed and runs the post-close
   action, so the stream cannot stay half-closed. (https://github.com/ClickHouse/clickhouse-java/issues/3055)
+- **[data]** Fixed `NonBlockingPipedOutputStream.close()` not being idempotent under concurrency. Two threads could
+  both flush and mutate the same pending buffer before the reader consumed it, silently replacing the payload with
+  an empty buffer and running the post-close action twice. Exactly one caller now flushes the pending data, enqueues
+  the end-of-stream marker, and runs the post-close action; concurrent or repeated `close()` calls return immediately.
+  (https://github.com/ClickHouse/clickhouse-java/issues/3057)
 - **[jdbc-v2]** Fixed JDBC escape processing rewriting text inside string literals and quoted identifiers. Because
   `PreparedStatement` inlines bound parameters into the statement text, a bound value containing `{fn ` (or `{d '...'}`
   / `{ts '...'}`) was re-read as SQL syntax: the `{fn ` was removed together with the next `}` found anywhere in the

--- a/clickhouse-data/src/main/java/com/clickhouse/data/stream/NonBlockingPipedOutputStream.java
+++ b/clickhouse-data/src/main/java/com/clickhouse/data/stream/NonBlockingPipedOutputStream.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.clickhouse.data.ClickHouseByteBuffer;
 import com.clickhouse.data.ClickHouseChecker;
@@ -34,6 +35,7 @@ public class NonBlockingPipedOutputStream extends ClickHousePipedOutputStream {
     protected final int bufferSize;
     protected final CompletableFuture<Void> future;
     protected final long timeout;
+    private final AtomicBoolean closing = new AtomicBoolean(false);
 
     protected ByteBuffer buffer;
 
@@ -104,7 +106,7 @@ public class NonBlockingPipedOutputStream extends ClickHousePipedOutputStream {
 
     @Override
     public void close() throws IOException {
-        if (closed) {
+        if (closed || !closing.compareAndSet(false, true)) {
             return;
         }
 

--- a/clickhouse-data/src/test/java/com/clickhouse/data/stream/NonBlockingPipedOutputStreamTest.java
+++ b/clickhouse-data/src/test/java/com/clickhouse/data/stream/NonBlockingPipedOutputStreamTest.java
@@ -9,7 +9,10 @@ import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import com.clickhouse.data.ClickHouseByteBuffer;
@@ -205,6 +208,61 @@ public class NonBlockingPipedOutputStreamTest {
             Assert.fail("Write should fail");
         } catch (IOException e) {
             Assert.assertTrue(e.getMessage().indexOf("closed") > 0);
+        }
+    }
+
+    @Test(groups = { "unit" })
+    public void testConcurrentClose() throws Exception {
+        final long timeout = 5000L;
+        final AtomicBoolean acceptBuffer = new AtomicBoolean(false);
+        final CountDownLatch firstBufferOffer = new CountDownLatch(1);
+        final AtomicInteger closeCount = new AtomicInteger(0);
+        final CapacityPolicy policy = current -> {
+            firstBufferOffer.countDown();
+            return acceptBuffer.get();
+        };
+        final NonBlockingPipedOutputStream stream = new NonBlockingPipedOutputStream(4, 2, timeout * 4L,
+                policy, (Runnable) closeCount::incrementAndGet);
+        final byte[] expected = new byte[] { (byte) 1, (byte) 2, (byte) 3 };
+        stream.write(expected);
+
+        final ExecutorService executor = Executors.newFixedThreadPool(2);
+        try {
+            Future<?> firstClose = executor.submit(() -> {
+                stream.close();
+                return null;
+            });
+            Assert.assertTrue(firstBufferOffer.await(timeout, TimeUnit.MILLISECONDS),
+                    "First close did not try to flush the pending buffer");
+
+            Future<?> concurrentClose = executor.submit(() -> {
+                stream.close();
+                return null;
+            });
+            boolean concurrentCloseReturned = true;
+            try {
+                concurrentClose.get(timeout, TimeUnit.MILLISECONDS);
+            } catch (TimeoutException e) {
+                concurrentCloseReturned = false;
+            }
+
+            acceptBuffer.set(true);
+            firstClose.get(timeout, TimeUnit.MILLISECONDS);
+            concurrentClose.get(timeout, TimeUnit.MILLISECONDS);
+
+            Assert.assertTrue(concurrentCloseReturned, "Concurrent close should return without waiting");
+            Assert.assertEquals(closeCount.get(), 1, "Post close action should have been executed exactly once");
+            try (InputStream in = stream.getInputStream()) {
+                byte[] actual = new byte[expected.length];
+                Assert.assertEquals(in.read(actual), expected.length);
+                Assert.assertEquals(actual, expected);
+                Assert.assertEquals(in.read(), -1);
+            }
+        } finally {
+            acceptBuffer.set(true);
+            executor.shutdownNow();
+            Assert.assertTrue(executor.awaitTermination(timeout, TimeUnit.MILLISECONDS),
+                    "Concurrent close executor did not terminate");
         }
     }
 


### PR DESCRIPTION
## Summary

Make `NonBlockingPipedOutputStream.close()` atomically claim the close path before flushing its pending buffer. Previously, two concurrent callers could both pass the `volatile closed` check, mutate and enqueue the same `ByteBuffer`, enqueue the end-of-stream marker twice, and run the post-close action twice. If the second caller changed the already-queued buffer's limit to zero, the reader observed a clean EOF and silently lost the pending payload.

Exactly one caller now flushes pending data, enqueues the end-of-stream marker, and runs the post-close action. Concurrent or repeated `close()` calls return immediately. The implementation follows the `AtomicBoolean` pattern already used by `BlockingPipedOutputStream`, without holding the instance monitor across the close path or a potentially blocking post-close action.

Closes https://github.com/ClickHouse/clickhouse-java/issues/3057

## Compatibility

There is no public API, configuration, default, output-format, serialization, or exception-type change. A single `close()` keeps its existing behavior. Only a redundant concurrent close changes from racing with the first caller to returning without touching the buffer or queue. `docs/features.md` is not affected because this change is confined to `clickhouse-data`.

## Test

Added `testConcurrentClose`, which holds the first close at the pending-buffer offer, invokes a second close concurrently, and verifies that the second caller returns without waiting, the post-close action runs exactly once, the pending bytes are preserved, and the reader sees EOF afterward.

- Before the production fix, the new test failed with `expected [1] but found [2]` for the post-close action count.
- `mvn -pl clickhouse-data -Dtest=NonBlockingPipedOutputStreamTest test`: 6 tests passed.
- `mvn -pl clickhouse-data test`: 1,668 tests passed; 113 skipped by the existing suite configuration.
- `mvn -Dj8 -pl clickhouse-data -Dtest=NonBlockingPipedOutputStreamTest test`: Java 8 source/target compilation succeeded and 6 tests passed.

## Checklist

- [x] Closes #3057
- [x] A focused unit test covering concurrent close was added
- [x] A human-readable description was added to `CHANGELOG.md`