### PR TITLE
fix(client-v2): report LZ4 byte counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,8 @@
 
 ### Bug Fixes 
 
+- **[client-v2]** Fixed truncated LZ4 stream errors reporting literal `{0}` and `{1}` placeholders instead of the
+  number of bytes read and expected. (https://github.com/ClickHouse/clickhouse-java/issues/3108)
 - **[jdbc-v2]** Fixed `DatabaseMetaData#getTables` reporting `TABLE_TYPE = TABLE` for a table with the `BigQuery`
   engine (present in `system.table_engines` since ClickHouse `26.8`). The engine was missing from the
   engine-to-table-type mapping, so it fell back to the default `TABLE`, and `getTables(..., types = {"REMOTE TABLE"})`

--- a/client-v2/src/main/java/com/clickhouse/client/api/internal/ClickHouseLZ4InputStream.java
+++ b/client-v2/src/main/java/com/clickhouse/client/api/internal/ClickHouseLZ4InputStream.java
@@ -83,7 +83,7 @@ public class ClickHouseLZ4InputStream extends InputStream {
                 if (n == 0) {
                     return false;
                 }
-                throw new IOException(ClickHouseUtils.format("Incomplete read: {0} of {1}", n, len));
+                throw new IOException(ClickHouseUtils.format("Incomplete read: %s of %s", n, len));
             }
             n += count;
         }

--- a/client-v2/src/test/java/com/clickhouse/client/api/internal/ClickHouseLZ4InputStreamTest.java
+++ b/client-v2/src/test/java/com/clickhouse/client/api/internal/ClickHouseLZ4InputStreamTest.java
@@ -1,0 +1,25 @@
+package com.clickhouse.client.api.internal;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import net.jpountz.lz4.LZ4Factory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class ClickHouseLZ4InputStreamTest {
+
+    @Test
+    public void reportsActualByteCountsForTruncatedHeader() {
+        byte[] truncatedHeader = new byte[10];
+        ClickHouseLZ4InputStream input = new ClickHouseLZ4InputStream(
+                new ByteArrayInputStream(truncatedHeader),
+                LZ4Factory.fastestJavaInstance().fastDecompressor(),
+                8192);
+
+        IOException exception = Assert.expectThrows(IOException.class,
+                () -> input.read(new byte[1], 0, 1));
+
+        Assert.assertEquals(exception.getMessage(), "Incomplete read: 10 of 25");
+    }
+}


### PR DESCRIPTION
## Summary

`ClickHouseLZ4InputStream` passed MessageFormat-style placeholders to `ClickHouseUtils.format`, which delegates to `String.format`. Truncated compressed streams therefore reported the literal message `Incomplete read: {0} of {1}`.

This change uses the supported `%s` placeholders and adds a focused truncated-header test that verifies the actual and expected byte counts. The changelog records the user-visible diagnostic improvement. No public API or control flow changes.

Closes #3108

## Testing

- `mvn -Dmaven.repo.local=/tmp/m2-clickhouse-3108 -P=-build11,-compile-java11,-compile-java17 -pl client-v2 -am -DskipITs -Dtest=ClickHouseLZ4InputStreamTest -Dsurefire.failIfNoSpecifiedTests=false test`
- Targeted test: 1 passed, 0 failed.
- Spotless check restricted to the two changed Java files passed.

## Checklist

- [x] Closes #3108
- [x] Unit test covering the truncated-stream error path was added
- [x] A human-readable description was added to `CHANGELOG.md`
