### PR TITLE
fixed v1 test setting wrong range

### DIFF
--- a/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
+++ b/clickhouse-client/src/test/java/com/clickhouse/client/ClientIntegrationTest.java
@@ -382,7 +382,7 @@ public abstract class ClientIntegrationTest extends BaseIntegrationTest {
                         "1970-01-01 00:00:01" },
                 { ClickHouseDataType.DateTime32.name(), "1970-01-01 00:00:00", "1970-01-01 00:00:00",
                         "1970-01-01 00:00:01" },
-                { ClickHouseDataType.DateTime64.name() + "(3)", "1970-01-01 00:00:00", "1969-12-31 23:59:59.999",
+                { ClickHouseDataType.DateTime64.name() + "(3)", "1970-01-01 00:00:00", "1970-01-01 00:00:00",
                         "1970-01-01 00:00:00.001" },
                 { ClickHouseDataType.Decimal.name() + "(10,9)", "0E-9", "-1.000000000", "1.000000000" },
                 { ClickHouseDataType.Decimal32.name() + "(1)", "0.0", "-1.0", "1.0" },

--- a/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
+++ b/clickhouse-jdbc/src/test/java/com/clickhouse/jdbc/ClickHousePreparedStatementTest.java
@@ -697,7 +697,7 @@ public class ClickHousePreparedStatementTest extends JdbcIntegrationTest {
             Instant i = Instant.ofEpochMilli(value / 1000L);
             LocalDateTime dt = LocalDateTime.ofInstant(i, conn.getServerTimeZone().toZoneId());
             try (PreparedStatement ps = conn.prepareStatement("insert into test_issue_612 values(trim(?),?)")) {
-                ps.setLong(2, value);
+                ps.setObject(2, dt);
                 ps.setObject(1, id);
                 ps.execute();
                 ps.setObject(1, UUID.randomUUID());


### PR DESCRIPTION
## Summary

Fixes datetime64 wrong value in tests of V1 

## Checklist
Delete items not relevant to your PR:
- [ ] Closes #<issue ref>
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided to include in CHANGELOG
- [ ] For significant changes, documentation in https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
